### PR TITLE
Drop vestigial getDependencies() method.

### DIFF
--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -7,7 +7,7 @@ require_once 'Site/Site.php';
  * Container for package wide static methods
  *
  * @package   Admin
- * @copyright 2005 silverorange
+ * @copyright 2005-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class Admin
@@ -54,19 +54,6 @@ class Admin
 	{
 		bindtextdomain(Admin::GETTEXT_DOMAIN, '@DATA-DIR@/Admin/locale');
 		bind_textdomain_codeset(Admin::GETTEXT_DOMAIN, 'UTF-8');
-	}
-
-	// }}}
-	// {{{ public static function getDependencies()
-
-	/**
-	 * Gets the packages this package depends on
-	 *
-	 * @return array an array of package IDs that this package depends on.
-	 */
-	public static function getDependencies()
-	{
-		return array(Swat::PACKAGE_ID, Site::PACKAGE_ID);
 	}
 
 	// }}}


### PR DESCRIPTION
That system is no longer used. Package-level dependencies for static files are expressed in the dependencies/admin.yaml file.
