### PR TITLE
Reverse the check for a selection vs. actions

### DIFF
--- a/Admin/pages/AdminIndex.php
+++ b/Admin/pages/AdminIndex.php
@@ -12,7 +12,7 @@ require_once 'Swat/SwatActions.php';
  * index page, inherit directly from AdminPage instead.
  *
  * @package   Admin
- * @copyright 2005-2013 silverorange
+ * @copyright 2005-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminIndex extends AdminPage


### PR DESCRIPTION
If there are no checkboxes, but the form still submits (e.g. a replicable widget with a SwatButton), this will throw an error. Instead, check first that the form has actions before looking for the selection.

This came up while developing a new index page and isn't currently testable anywhere but my own branch.
