### PR TITLE
Fix Swat dependancy

### DIFF
--- a/package.php
+++ b/package.php
@@ -55,7 +55,7 @@ $package->addReplacement('Admin/Admin.php', 'pear-config', '@DATA-DIR@', 'data_d
 
 $package->setPhpDep('5.3.0');
 $package->setPearinstallerDep('1.4.0');
-$package->addPackageDepWithChannel('required', 'Swat', 'pear.silverorange.com', '2.0.16');
+$package->addPackageDepWithChannel('required', 'Swat', 'pear.silverorange.com', '2.1.0');
 $package->addPackageDepWithChannel('required', 'Site', 'pear.silverorange.com', '2.1.5');
 $package->addPackageDepWithChannel('required', 'XML_RPCAjax', 'pear.silverorange.com', '1.0.9');
 $package->addPackageDepWithChannel('required', 'Net_Notifier', 'pear.silverorange.com', '0.1.0');


### PR DESCRIPTION
This is needed for various AdminObjectEdit updates (#11, #13 and #18), and the killing of package_id cruft (#14).
