### PR TITLE
Add an optional getObjectPropertyWidgetMapping() method.

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -171,10 +171,9 @@ abstract class AdminObjectEdit extends AdminDBEdit
 	{
 		$object = $this->getObject();
 
-		$properties = $this->getObjectPropertyWidgetMapping();
-		if (is_array($properties) && count($properties) > 0) {
-			$this->assignUiValues($properties);
-		}
+		$this->assignUiValues(
+			$this->getObjectPropertyWidgetMapping()
+		);
 
 		if ($this->isNew()) {
 			if ($object->hasPublicProperty('createdate') &&
@@ -327,10 +326,9 @@ abstract class AdminObjectEdit extends AdminDBEdit
 
 	protected function loadObject()
 	{
-		$properties = $this->getObjectPropertyWidgetMapping();
-		if (is_array($properties) && count($properties) > 0) {
-			$this->assignValuesToUi($properties);
-		}
+		$this->assignValuesToUi(
+			$this->getObjectPropertyWidgetMapping()
+		);
 	}
 
 	// }}}


### PR DESCRIPTION
Since most edit pages want to load and save teh same set of properties based on the widgets, add a method that can be used to create the array, and if that array is set us it when loading and updating the object. Should cut down on repeated code, and subclassed methods almost all of the time.
