### PR TITLE
Don't bother returning the object from updateObject()

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -185,9 +185,6 @@ abstract class AdminObjectEdit extends AdminDBEdit
 			$old_object = clone $object;
 			$this->addObjectToFlushOnSave($old_object);
 		}
-
-		return $object;
-		// Subclass handles the rest.
 	}
 
 	// }}}


### PR DESCRIPTION
getObject() can always be used by subclasses needing it further.

This was left as PR feedback on #11 and just forgotten about.
