### PR TITLE
Fix the variable name used.

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -274,7 +274,7 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		if ($primary_content != '') {
 			$message = new SwatMessage($primary_content, $message_type);
 
-			if ($secondary_text != '') {
+			if ($secondary_content != '') {
 				$message->secondary_content = $secondary_content;
 			}
 


### PR DESCRIPTION
This variable rename was missed in https://github.com/silverorange/admin/pull/16 and was causing a notice.

The package is not widely installed yet, so I propose we don't worry about packaging it up again until next package party.
