### PR TITLE
Fix bad variable name.

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -274,7 +274,7 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		if ($primary_content != '') {
 			$message = new SwatMessage($primary_content, $message_type);
 
-			if ($secondary_text != '') {
+			if ($secondary_content != '') {
 				$message->secondary_content = $secondary_content;
 			}
 


### PR DESCRIPTION
Fixes

```
Message:
Undefined variable: secondary_text
Occurred in file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminObjectEdit.php on line 277.

Stack Trace:
7.
In file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminObjectEdit.php line 256.
Method: AdminObjectEdit->getSavedMessage()
6.
In file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminObjectEdit.php line 161.
Method: AdminObjectEdit->addSavedMessage()
5.
In file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminDBEdit.php line 30.
Method: AdminObjectEdit->saveDBData()
4.
In file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminEdit.php line 77.
Method: AdminDBEdit->saveData()
3.
In file /so/sites/emrap-75/pear-live/lib/Admin/pages/AdminPage.php line 198.
Method: AdminEdit->processInternal()
2.
In file /so/sites/emrap-75/pear-live/lib/Site/SiteWebApplication.php line 153.
Method: AdminPage->process()
1.
In file /so/sites/emrap-75/pear-live/lib/Admin/AdminApplication.php line 110.
Method: SiteWebApplication->run()
0.
In file /so/sites/emrap-75/www/admin/index.php line 20.
Method: AdminApplication->run()
```

We never saw this notice in testing because of redirects.
