### PR TITLE
Set the shortname directly on the object

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -183,9 +183,9 @@ abstract class AdminObjectEdit extends AdminDBEdit
 			if ($object->hasPublicProperty('shortname') &&
 				$this->ui->hasWidget('shortname') &&
 				$this->ui->hasWidget('title')) {
-				$shortname_widget = $this->ui->getWidget('shortname');
+				$shortname = $this->ui->getWidget('shortname')->value;
 
-				if ($shortname_widget->value == '') {
+				if ($shortname == '') {
 					$object->shortname = $this->generateShortname(
 						$this->ui->getWidget('title')->value
 					);


### PR DESCRIPTION
Setting the value on the widget doesn't really make sense anyway, and it's called after assignUiValues() so never gets applied. Do the same as we do for the createdate and just set the property on the object.
