### PR TITLE
Move deleteOldObject() to after postSaveObject()

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -240,8 +240,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 
 		$this->saveObject();
-		$this->deleteOldObject();
 		$this->postSaveObject();
+		$this->deleteOldObject();
 		$this->flushObjectsOnSave();
 		$this->addToSearchQueue();
 		$this->addSavedMessage();


### PR DESCRIPTION
This change allows postSaveObject() some more flexibilty. For example if the postSaveObject() is used to update a binding table value that has an on delete cascade, this allows the reference on that table to be updated to the new object before the old object is deleted, preventing an unwanted cascade.
