### PR TITLE
Fix the AdminNotFound exception thrown by the AdminObjectEdit

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -177,7 +177,7 @@ abstract class AdminObjectEdit extends AdminDBEdit
 				throw new AdminNotFoundException(
 					sprintf(
 						'A %s with the id of ‘%s’ does not exist',
-						$class_name,
+						get_class($this->data_object),
 						$this->id
 					)
 				);


### PR DESCRIPTION
$class_name was not definied in the `initObject()` method, so use `get_class()` to build the message. Alternatively we could have used `$this->getResolvedObjectClass()` but I think it's better to return the actual class of the object in case it reveals other issues.

[PT Story](https://www.pivotaltracker.com/n/workspaces/494148)