### PR TITLE
Block inactive admin accounts from logging into the admins

### DIFF
--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -112,6 +112,13 @@ class AdminUser extends SwatDBDataObject
 	 */
 	public $all_instances;
 
+	/**
+	 * Date when the user account was created.
+	 *
+	 * @var SwatDate
+	 */
+	public $createdate;
+
 	// }}}
 	// {{{ protected properties
 
@@ -340,6 +347,7 @@ class AdminUser extends SwatDBDataObject
 		$this->id_field = 'integer:id';
 
 		$this->registerDateProperty('password_tag_date');
+		$this->registerDateProperty('createdate');
 	}
 
 	// }}}

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -382,6 +382,41 @@ class AdminUser extends SwatDBDataObject
 	}
 
 	// }}}
+	// {{{ protected function loadMostRecentLogin()
+
+	/**
+	 * Gets most recent login history for this user
+	 *
+	 * If instance is set with the {@link AdminUser::setInstance()} method,
+	 * history will be limited that that instance.
+	 *
+	 * @return AdminUserHistory a {@link AdminUserHistory} containing
+	 *                           this admin user's most recent login history.
+	 *
+	 * @see AdminUser::setInstance()
+	 */
+	protected function loadMostRecentLogin()
+	{
+		$instance_id = null;
+
+		if ($this->instance instanceof SiteInstance) {
+			$instance_id = $this->instance->getId();
+		}
+
+		$sql = sprintf(
+			'select * from AdminUserHistory
+			where usernum = %s and instance %s %s
+			order by createdate desc',
+			$this->db->quote($this->id, 'integer'),
+			SwatDB::equalityOperator($instance_id),
+			$this->db->quote($instance_id, 'integer')
+		);
+
+		$this->db->setLimit(1);
+		return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
+	}
+
+	// }}}
 	// {{{ protected function loadInstances()
 
 	/**

--- a/sql/tables/AdminUser.sql
+++ b/sql/tables/AdminUser.sql
@@ -9,5 +9,6 @@ create table AdminUser (
 	force_change_password boolean not null default true,
 	enabled boolean not null default true,
 	all_instances boolean not null default false,
+	createdate timestamp,
 	primary key(id)
 );


### PR DESCRIPTION
Inactive accounts are defined by accounts that have not logged in within 90 days, or new accounts that haven't logged in within 90 days.