### PR TITLE
Improvements to automatic deactivation of admin accounts

### DIFF
--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -20,19 +20,6 @@ require_once 'Swat/SwatString.php';
  */
 class AdminSessionModule extends SiteSessionModule
 {
-	// {{{ class constants
-
-	/**
-	 * How many days an admin user account is considered active
-	 *
-	 * If an account has no sign-in activity for this many days, it will be
-	 * prevented from signing into the admin.
-	 *
-	 * @see AdminSessionModule::isActiveUser()
-	 */
-	const ACCOUNT_EXPIRY_DAYS = 90;
-
-	// }}}
 	// {{{ protected properties
 
 	/**
@@ -124,7 +111,7 @@ class AdminSessionModule extends SiteSessionModule
 		$user = new $class_name();
 		$user->setDatabase($this->app->db);
 
-		if ($user->loadFromEmail($email) && $this->isActiveUser($user)) {
+		if ($user->loadFromEmail($email)) {
 			$password_hash = $user->password;
 			$password_salt = $user->password_salt;
 
@@ -338,43 +325,6 @@ class AdminSessionModule extends SiteSessionModule
 			$parameters = $login_callback['parameters'];
 			call_user_func_array($callback, $parameters);
 		}
-	}
-
-	// }}}
-	// {{{ protected function isActiveUser()
-
-	/**
-	 * Checks to see if the AdminUser is an active account.
-	 *
-	 * Users are inactive if they haven't logged in the last 90 days, or 90
-	 * days from the creation of the account if the user has never logged in.
-	 *
-	 * @param AdminUser $user_id the user to record login history for.
-	 *
-	 * @return boolean
-	 *
-	 * @see AdminSessionModule::ACCOUNT_EXPIRY_DAYS
-	 */
-	protected function isActiveUser(AdminUser $user)
-	{
-		$active_user = false;
-
-		$comparison_date = null;
-
-		if ($user->most_recent_history instanceof AdminUserHistory) {
-			$comparison_date = $user->most_recent_history->login_date;
-		} elseif ($user->createdate instanceof SwatDate) {
-			$comparison_date = $user->createdate;
-		}
-
-		$threshold = new SwatDate();
-		$threshold->subtractDays(self::ACCOUNT_EXPIRY_DAYS);
-		if ($comparison_date instanceof SwatDate &&
-			$comparison_date->after($threshold)) {
-			$active_user = true;
-		}
-
-		return $active_user;
 	}
 
 	// }}}

--- a/Admin/components/AdminSite/Login.php
+++ b/Admin/components/AdminSite/Login.php
@@ -88,6 +88,21 @@ class AdminAdminSiteLogin extends AdminPage
 				if (isset($this->app->session->user) &&
 					$this->app->session->user->force_change_password) {
 					$this->app->replacePage('AdminSite/ChangePassword');
+				} elseif (isset($this->app->session->user) &&
+					!$this->app->session->user->isActive()) {
+					$message_display = $this->ui->getWidget('message_display');
+					$message = new SwatMessage(
+						Admin::_('Your account is inactive'),
+						'error'
+					);
+
+					$message->secondary_content = Admin::_(
+						'Please contact another administrator to reactivate '.
+						'your account.'
+					);
+
+					$message_display->add($message);
+					$this->login_error = true;
 				} else {
 					$message_display = $this->ui->getWidget('message_display');
 					$message = new SwatMessage(Admin::_('Login failed'),

--- a/Admin/components/AdminUser/Index.php
+++ b/Admin/components/AdminUser/Index.php
@@ -128,7 +128,7 @@ class AdminAdminUserIndex extends AdminIndex
 
 		$sql = sprintf(
 			'select AdminUser.id, AdminUser.email, AdminUser.name,
-					AdminUser.createdate, AdminUser.enabled,
+					AdminUser.activation_date, AdminUser.enabled,
 					AdminUserLastLoginView.last_login
 				from AdminUser
 				left outer join AdminUserLastLoginView on
@@ -146,8 +146,8 @@ class AdminAdminUserIndex extends AdminIndex
 
 		// Build row objects and separate based on active/inactive status.
 		foreach ($rows as $row) {
-			if ($row->createdate !== null) {
-				$row->createdate = new SwatDate($row->createdate);
+			if ($row->activation_date !== null) {
+				$row->activation_date = new SwatDate($row->activation_date);
 			}
 
 			if ($row->last_login !== null) {

--- a/Admin/components/AdminUser/Index.php
+++ b/Admin/components/AdminUser/Index.php
@@ -97,8 +97,6 @@ class AdminAdminUserIndex extends AdminIndex
 
 		$date_renderer = $date_column->getRendererByPosition();
 		$date_renderer->display_time_zone = $this->app->default_time_zone;
-
-		$this->buildActiveNote();
 	}
 
 	// }}}
@@ -109,6 +107,7 @@ class AdminAdminUserIndex extends AdminIndex
 		$locale = SwatI18NLocale::get();
 
 		$note = $this->ui->getWidget('active_note');
+		$note->visible = true;
 		$note->content = sprintf(
 			Admin::_(
 				'Users become inactive after %s days of inactivity. To '.
@@ -182,6 +181,11 @@ class AdminAdminUserIndex extends AdminIndex
 
 		foreach ($inactive_users as $ds) {
 			$store->add($ds);
+		}
+
+		// If there are inactive users, show a note with help text.
+		if (count($inactive_users) > 0) {
+			$this->buildActiveNote();
 		}
 
 		return $store;

--- a/Admin/components/AdminUser/Reactivate.php
+++ b/Admin/components/AdminUser/Reactivate.php
@@ -38,7 +38,7 @@ class AdminAdminUserReactivate extends AdminDBConfirmation
 		$now->toUTC();
 
 		$sql = sprintf(
-			'update AdminUser set createdate = %s
+			'update AdminUser set activation_date = %s
 			where id in (%s)',
 			$this->app->db->quote($now->getDate(), 'date'),
 			$this->getItemList('integer')

--- a/Admin/components/AdminUser/Reactivate.php
+++ b/Admin/components/AdminUser/Reactivate.php
@@ -1,0 +1,118 @@
+<?php
+
+require_once 'Admin/pages/AdminDBDelete.php';
+require_once 'SwatDB/SwatDB.php';
+require_once 'Admin/AdminListDependency.php';
+
+/**
+ * Reactivate confirmation page for AdminUsers component
+ *
+ * @package   Admin
+ * @copyright 2016 silverorange
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ */
+class AdminAdminUserReactivate extends AdminDBConfirmation
+{
+	// init phase
+	// {{{ protected function initInternal()
+
+	protected function initInternal()
+	{
+		parent::initInternal();
+		$this->navbar->popEntry();
+		$this->navbar->createEntry(Admin::_('Reactivate'));
+	}
+
+	// }}}
+
+	// process phase
+	// {{{ protected function processDBData
+
+	protected function processDBData()
+	{
+		parent::processDBData();
+
+		$locale = SwatI18NLocale::get();
+
+		$now = new SwatDate();
+		$now->toUTC();
+
+		$sql = sprintf(
+			'update AdminUser set createdate = %s
+			where id in (%s)',
+			$this->app->db->quote($now->getDate(), 'date'),
+			$this->getItemList('integer')
+		);
+
+		$num = SwatDB::exec($this->app->db, $sql);
+
+		$this->app->messages->add(
+			new SwatMessage(
+				sprintf(
+					Admin::ngettext(
+						'One admin user has been reactivated.',
+						'%s admin users have been reactivated.',
+						$num
+					),
+					$locale->formatNumber($num)
+				)
+			)
+		);
+
+	}
+
+	// }}}
+
+	// build phase
+	// {{{ protected function buildInternal()
+
+	public function buildInternal()
+	{
+		parent::buildInternal();
+
+		$users = SwatDB::query(
+			$this->app->db,
+			sprintf(
+				'select name from AdminUser
+				where id in (%s)
+				order by name asc',
+				$this->getItemList('integer')
+			),
+			'AdminUserWrapper'
+		);
+
+		ob_start();
+
+		$h3_tag = new SwatHtmlTag('h3');
+		$h3_tag->setContent(
+			Admin::ngettext(
+				'Reactivate the following admin user?',
+				'Reactivate the following admin users?',
+				count($users)
+			)
+		);
+		$h3_tag->display();
+
+		if (count($users) > 0) {
+			echo '<ul>';
+			foreach ($users as $user) {
+				$li_tag = new SwatHtmlTag('li');
+				$li_tag->setContent($user->name);
+				$li_tag->display();
+			}
+			echo '</ul>';
+		}
+
+		$message = $this->ui->getWidget('confirmation_message');
+		$message->content = ob_get_clean();
+		$message->content_type = 'text/xml';
+
+		if (count($users) === 0) {
+			$this->switchToCancelButton();
+		}
+	}
+
+	// }}}
+}
+
+?>

--- a/Admin/components/AdminUser/include/AdminUserTableView.php
+++ b/Admin/components/AdminUser/include/AdminUserTableView.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once 'Swat/SwatTableView.php';
+
+/**
+ * @package   Admin
+ * @copyright 2016 silverorange
+ * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ */
+class AdminUserTableView extends SwatTableView
+{
+	// {{{ protected function getRowClasses()
+
+	protected function getRowClasses($row, $count)
+	{
+		$classes = parent::getRowClasses($row, $count);
+
+		if ($row->is_active) {
+			$classes[] = 'active';
+		} else {
+			$classes[] = 'inactive';
+		}
+
+		return $classes;
+	}
+
+	// }}}
+}
+
+?>

--- a/Admin/components/AdminUser/index.xml
+++ b/Admin/components/AdminUser/index.xml
@@ -11,7 +11,9 @@
 				<property name="stock_id">create</property>
 			</widget>
 		</widget>
-		<widget class="AdminNote" id="active_note" />
+		<widget class="AdminNote" id="active_note">
+			<property name="visible" type="boolean">false</property>
+		</widget>
 		<widget class="SwatForm" id="index_form">
 			<widget class="AdminUserTableView" id="index_view">
 				<object class="SwatTableViewCheckboxColumn" id="checkbox">

--- a/Admin/components/AdminUser/index.xml
+++ b/Admin/components/AdminUser/index.xml
@@ -11,11 +11,18 @@
 				<property name="stock_id">create</property>
 			</widget>
 		</widget>
+		<widget class="AdminNote" id="active_note" />
 		<widget class="SwatForm" id="index_form">
-			<widget class="SwatTableView" id="index_view">
+			<widget class="AdminUserTableView" id="index_view">
 				<object class="SwatTableViewCheckboxColumn" id="checkbox">
 					<object class="SwatCheckboxCellRenderer" id="items">
 						<property name="value" type="data">id</property>
+					</object>
+				</object>
+				<object class="SwatTableViewGroup">
+					<property name="group_by">is_active</property>
+					<object class="SwatTextCellRenderer">
+						<property name="text" type="data">active_title</property>
 					</object>
 				</object>
 				<object class="AdminTableViewOrderableColumn" id="email">
@@ -52,6 +59,9 @@
 				</object>
 			</widget>
 			<widget class="SwatActions" id="index_actions">
+				<widget class="SwatActionItem" id="reactivate">
+					<property name="title" translatable="yes">reactivate…</property>
+				</widget>
 				<widget class="SwatActionItem" id="delete">
 					<property name="title" translatable="yes">delete…</property>
 				</widget>

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -126,11 +126,11 @@ class AdminUser extends SwatDBDataObject
 	public $all_instances;
 
 	/**
-	 * Date when the user account was created.
+	 * Date when the user account was activated.
 	 *
 	 * @var SwatDate
 	 */
-	public $createdate;
+	public $activation_date;
 
 	// }}}
 	// {{{ protected properties
@@ -357,8 +357,8 @@ class AdminUser extends SwatDBDataObject
 	/**
 	 * Checks to see if this user is active
 	 *
-	 * Users are inactive if they haven't logged in the last 90 days, or 90
-	 * days from the creation of the user if the user has never logged in.
+	 * Users are inactive if they haven't logged in or been activated in the
+	 * last 90 days.
 	 *
 	 * @return boolean
 	 *
@@ -369,11 +369,21 @@ class AdminUser extends SwatDBDataObject
 		$is_active = false;
 
 		$comparison_date = null;
+		$comparison_dates = array();
 
 		if ($this->most_recent_history instanceof AdminUserHistory) {
-			$comparison_date = $this->most_recent_history->login_date;
-		} elseif ($this->createdate instanceof SwatDate) {
-			$comparison_date = $this->createdate;
+			$comparison_dates[] = $this->most_recent_history->login_date;
+		} elseif ($this->activation_date instanceof SwatDate) {
+			$comparison_dates[] = $this->activation_date;
+		}
+
+		// Get the most recent activity date (either user history or activation
+		// date)
+		foreach ($comparison_dates as $date) {
+			if (!$comparison_date instanceof SwatDate ||
+				$date->after($comparison_date)) {
+				$comparison_date = $date;
+			}
 		}
 
 		$threshold = new SwatDate();
@@ -395,7 +405,7 @@ class AdminUser extends SwatDBDataObject
 		$this->id_field = 'integer:id';
 
 		$this->registerDateProperty('password_tag_date');
-		$this->registerDateProperty('createdate');
+		$this->registerDateProperty('activation_date');
 	}
 
 	// }}}

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -184,8 +184,11 @@ class AdminUser extends SwatDBDataObject
 			$authenticated = true;
 		}
 
-		$authenticated = ($authenticated && $this->isActive());
-		$authenticated = ($authenticated && !$this->force_change_password);
+		$authenticated = (
+			$authenticated &&
+			$this->isActive() &&
+			!$this->force_change_password
+		);
 
 		return $authenticated;
 	}

--- a/sql/tables/AdminUser.sql
+++ b/sql/tables/AdminUser.sql
@@ -9,6 +9,6 @@ create table AdminUser (
 	force_change_password boolean not null default true,
 	enabled boolean not null default true,
 	all_instances boolean not null default false,
-	createdate timestamp,
+	activation_date timestamp,
 	primary key(id)
 );

--- a/www/styles/admin-user-index-page.css
+++ b/www/styles/admin-user-index-page.css
@@ -1,0 +1,6 @@
+tr.inactive td.email,
+tr.inactive td.name,
+tr.inactive td.enabled,
+tr.inactive td.last-login {
+	opacity: 0.5;
+}


### PR DESCRIPTION
https://trello.com/c/57xnmGP8/632-0-5d-add-error-message-to-failed-logins-that-failed-because-of-90-days-of-inactivity

https://trello.com/c/kJ5GgOP9/633-0-5d-add-reset-method-for-inactive-accounts-to-allow-them-to-be-active-again

 * show a message when you try to sign in with an inactive account
 * show inactive accounts on index page