### PR TITLE
Allow for overriding expiry days constant in subclasses.

### DIFF
--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -392,7 +392,7 @@ class AdminUser extends SwatDBDataObject
 		}
 
 		$threshold = new SwatDate();
-		$threshold->subtractDays(self::EXPIRY_DAYS);
+		$threshold->subtractDays(static::EXPIRY_DAYS);
 		if ($comparison_date instanceof SwatDate &&
 			$comparison_date->after($threshold)) {
 			$is_active = true;


### PR DESCRIPTION
Make use of PHP's late static bindings by using static:: instead of
self::