### PR TITLE
Fix checking of dependency status.

### DIFF
--- a/Admin/AdminListDependency.php
+++ b/Admin/AdminListDependency.php
@@ -63,9 +63,11 @@ class AdminListDependency extends AdminDependency
 	public function getStatusLevelCount($status_level)
 	{
 		$count = 0;
-		foreach ($this->entries as &$entry)
-			if ($entry->status_level === $status_level)
+		foreach ($this->entries as &$entry) {
+			if ($entry->status_level == $status_level) {
 				$count++;
+			}
+		}
 
 		return $count;
 	}

--- a/Admin/AdminSummaryDependency.php
+++ b/Admin/AdminSummaryDependency.php
@@ -50,9 +50,11 @@ class AdminSummaryDependency extends AdminDependency
 	public function getStatusLevelCount($status_level)
 	{
 		$count = 0;
-		foreach ($this->summaries as &$summary)
-			if ($summary->status_level === $status_level)
+		foreach ($this->summaries as &$summary) {
+			if ($summary->status_level == $status_level) {
 				$count += $summary->count;
+			}
+		}
 
 		return $count;
 	}
@@ -111,10 +113,12 @@ class AdminSummaryDependency extends AdminDependency
 	public function displayDependencies($parent, $status_level)
 	{
 		$count = 0;
-		foreach ($this->summaries as $summary)
+		foreach ($this->summaries as $summary) {
 			if ($summary->parent == $parent &&
-				$summary->status_level === $status_level)
+				$summary->status_level == $status_level) {
 				$count += $summary->count;
+			}
+		}
 
 		if ($count > 0) {
 			$span_tag = new SwatHtmlTag('span');


### PR DESCRIPTION
<a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;ZhiOlQRU&#x2F;1406-fix-checking-of-admin-dependency-status"><img src="https:&#x2F;&#x2F;github.trello.services&#x2F;images&#x2F;trello-icon.png" width="12" height="12"> Fix checking of admin dependency status</a>

Don't do strict checking as teh convience methods no longer return
integers for the default dependency types, but a string 0/1.