### PR TITLE
Fix issue with admin users going inactive on multi-instance admins

### DIFF
--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -182,7 +182,9 @@ class AdminUser extends SwatDBDataObject
 			}
 
 			// Make sure instance is set so activation check works properly.
-			$this->setInstance($app->getInstance());
+			if ($app->getInstance() instanceof SiteInstance) {
+				$this->setInstance($app->getInstance());
+			}
 		} else {
 			$authenticated = true;
 		}

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -180,6 +180,9 @@ class AdminUser extends SwatDBDataObject
 					$authenticated = true;
 				}
 			}
+
+			// Make sure instance is set so activation check works properly.
+			$this->setInstance($app->getInstance());
 		} else {
 			$authenticated = true;
 		}

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -118,7 +118,7 @@ class AdminUser extends SwatDBDataObject
 	 * Whether or not this user has access to all instances
 	 *
 	 * Only relevent on a multiple instance site. This allows the user to login
-	 * to all instance admins reguradless of AdminUserInstanceBindings. Also
+	 * to all instance admins regardless of AdminUserInstanceBindings. Also
 	 * this user can login into a master admin loading with a null instance.
 	 *
 	 * @var boolean
@@ -419,12 +419,12 @@ class AdminUser extends SwatDBDataObject
 	/**
 	 * Gets user history for this user
 	 *
-	 * If instance is set with the {@link AdminUser::setInstance()} method,
-	 * history will be limited that that instance.
+	 * If account instance is set with the {@link AdminUser::setInstance()}
+	 * method, history will be limited to that instance.
 	 *
 	 * @return AdminUserHistoryWrapper a set of {@link AdminUserHistory}
-	 *                                  objects containing this admin user's
-	 *                                  login history.
+	 *                                 objects containing this admin user's
+	 *                                 login history.
 	 *
 	 * @see AdminUser::setInstance()
 	 */
@@ -450,11 +450,11 @@ class AdminUser extends SwatDBDataObject
 	/**
 	 * Gets most recent login history for this user
 	 *
-	 * If instance is set with the {@link AdminUser::setInstance()} method,
-	 * history will be limited that that instance.
+	 * If account instance is set with the {@link AdminUser::setInstance()}
+	 * method, history will be limited to that instance.
 	 *
 	 * @return AdminUserHistory a {@link AdminUserHistory} containing
-	 *                           this admin user's most recent login history.
+	 *                          this admin user's most recent login history.
 	 *
 	 * @see AdminUser::setInstance()
 	 */

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -432,14 +432,18 @@ class AdminUser extends SwatDBDataObject
 	{
 		$instance_id = null;
 
-		if ($this->instance !== null)
+		if ($this->instance instanceof SiteInstance) {
 			$instance_id = $this->instance->getId();
+		}
 
-		$sql = sprintf('select * from AdminUserHistory
-			where usernum = %s and instance %s %s',
+		$sql = sprintf(
+			'select * from AdminUserHistory
+			where usernum = %s and instance %s %s
+			order by login_date desc',
 			$this->db->quote($this->id, 'integer'),
 			SwatDB::equalityOperator($instance_id),
-			$this->db->quote($instance_id, 'integer'));
+			$this->db->quote($instance_id, 'integer')
+		);
 
 		return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
 	}
@@ -474,6 +478,8 @@ class AdminUser extends SwatDBDataObject
 			SwatDB::equalityOperator($instance_id),
 			$this->db->quote($instance_id, 'integer')
 		);
+
+		$this->db->setLimit(1);
 
 		return SwatDB::query(
 			$this->db,


### PR DESCRIPTION
https://trello.com/c/yyHxiK3H/1525-multi-instance-admin-users-become-deactivated

Testing
-------
To reproduce:

 1. have an admin user with an activation date more than 3 months old
 2. admin user should be for a multi-instance admin (course-host or hippo)
 3. admin user should have recent history in one instance but not in all instances
 4. in master admin user can not sign in to any instance
 5. with PR applied, admin user can sign into the one instance with history