### PR TITLE
Bump version of site

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"php": ">=5.3.0",
 		"ext-mbstring": "*",
 		"silverorange/net_notifier": "^1.0.0",
-		"silverorange/site": "^9.0.0 || ^10.1.0",
+		"silverorange/site": "^9.0.0 || ^10.1.0 || ^11.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
site version 11 just deprecates getSentryClient. admin doesn't use it anywhere, so version 11 is also compatible with admin.
