### PR TITLE
Allow site 14, remove addToSearchQueue

### DIFF
--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -274,7 +274,6 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$this->postSaveObject();
 		$this->deleteOldObject();
 		$this->flushObjectsOnSave();
-		$this->addToSearchQueue();
 		$this->addSavedMessage();
 
 		// parent::saveDBData() expects to return true on success.
@@ -404,13 +403,6 @@ abstract class AdminObjectEdit extends AdminDBEdit
 				$object->flushCacheNamespaces();
 			}
 		}
-	}
-
-	// }}}
-	// {{{ protected function addToSearchQueue()
-
-	protected function addToSearchQueue()
-	{
 	}
 
 	// }}}

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
 	"require": {
 		"php": ">=5.3.0",
 		"ext-mbstring": "*",
-		"silverorange/site": "^13.0.0",
+		"silverorange/site": "^13.0.0 || ^14.0.0",
 		"silverorange/swat": "^5.0.0 || ^6.0.0"
 	},
 	"require-dev": {


### PR DESCRIPTION
This upgrades academy to site version 14, which gets rid of all mentions
of nategosearch. It also deprecates the addToSearchQueue method, so all
references to that method have also been removed.

AdminObjectEdit is the first in its inheritance hierarchy to declare
addToSearchQueue, so this will require a major release, as it creates a
breaking change in the interface of AdminObjectEdit.