### PR TITLE
show inactive account warning with 2fa

### DIFF
--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -222,6 +222,35 @@ class AdminSessionModule extends SiteSessionModule
 	}
 
 	// }}}
+	// {{{ public function loginWithTwoFactorAuthentication()
+
+	/**
+	 * loginWithTwoFactorAuthentication
+	 *
+	 * @param string $token
+	 *
+	 * @return boolean true if the admin user was logged in is successfully and
+	 *                  false if the admin user could not log in.
+	 */
+	public function loginWithTwoFactorAuthentication($token)
+	{
+		$two_factor_authentication = new AdminTwoFactorAuthentication();
+		$success = $two_factor_authentication->validateToken(
+			$this->user->two_fa_secret,
+			$token,
+			$this->user->two_fa_timeslice
+		);
+
+		if ($success) {
+			$this->user->save();
+			$this->insertUserHistory($user);
+			$this->runLoginCallbacks();
+		}
+
+		return $success;
+	}
+
+	// }}}
 	// {{{ public function registerLoginCallback()
 
 	/**

--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -243,7 +243,7 @@ class AdminSessionModule extends SiteSessionModule
 
 		if ($success) {
 			$this->user->save();
-			$this->insertUserHistory($user);
+			$this->insertUserHistory($this->user);
 			$this->runLoginCallbacks();
 		}
 

--- a/Admin/components/AdminSite/Login.php
+++ b/Admin/components/AdminSite/Login.php
@@ -77,14 +77,7 @@ class AdminAdminSiteLogin extends AdminPage
 			if ($logged_in) {
 				$this->app->relocate($this->app->getUri());
 			} else {
-				if (isset($this->app->session->user) &&
-					$this->app->is2FaEnabled() &&
-					$this->app->session->user->two_fa_enabled &&
-					!$this->app->session->user->is2FaAuthenticated()) {
-					$this->app->replacePage(
-						'AdminSite/TwoFactorAuthentication'
-					);
-				} elseif (isset($this->app->session->user) &&
+				 if (isset($this->app->session->user) &&
 					$this->app->session->user->force_change_password) {
 					$this->app->replacePage('AdminSite/ChangePassword');
 				} elseif (isset($this->app->session->user) &&
@@ -102,6 +95,13 @@ class AdminAdminSiteLogin extends AdminPage
 
 					$message_display->add($message);
 					$this->login_error = true;
+				} elseif (isset($this->app->session->user) &&
+					$this->app->is2FaEnabled() &&
+					$this->app->session->user->two_fa_enabled &&
+					!$this->app->session->user->is2FaAuthenticated()) {
+					$this->app->replacePage(
+						'AdminSite/TwoFactorAuthentication'
+					);
 				} else {
 					$message_display = $this->ui->getWidget('message_display');
 					$message = new SwatMessage(Admin::_('Login failed'),

--- a/Admin/components/AdminSite/TwoFactorAuthentication.php
+++ b/Admin/components/AdminSite/TwoFactorAuthentication.php
@@ -67,17 +67,11 @@ class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 
 	protected function validate2Fa()
 	{
-		$two_factor_authentication = new AdminTwoFactorAuthentication();
-		$success = $two_factor_authentication->validateToken(
-			$this->app->session->user->two_fa_secret,
-			$this->ui->getWidget('two_fa_token')->value,
-			$this->app->session->user->two_fa_timeslice
+		$success = $this->app->session->loginWithTwoFactorAuthentication(
+			$this->ui->getWidget('two_fa_token')->value
 		);
 
-		if ($success) {
-			// save the new timestamp
-			$this->app->session->user->save();
-		} else {
+		if (!$success) {
 			$this->ui->getWidget('two_fa_token')->addMessage(
 				new SwatMessage(
 					Admin::_(


### PR DESCRIPTION
When an account is inactive, we were showing the 2fa screen instead of the warning. This PR makes sure we show that warning first. It also moves 2fa validation into the session module and updates the admin user history during validation.

To Test:
1. Set the `activation_date` on your `adminuser` record to a date more than 90 days in the past
2. Try logging in to the admin, you will get stuck in a loop where you enter your password, then 2fa and then back to username and password
3. Check out this PR
4. Try logging in again and you will now see that your account is inactive
5. Update the `activation_date` and set it to `now()`
6. Try logging in again and you should be able to without any errors