### PR TITLE
Set all smtp credentials

### DIFF
--- a/Admin/components/AdminSite/ForgotPassword.php
+++ b/Admin/components/AdminSite/ForgotPassword.php
@@ -166,7 +166,7 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		$mail_message->smtp_port     = $this->app->config->email->smtp_port;
 		$mail_message->smtp_username = $this->app->config->email->smtp_username;
 		$mail_message->smtp_password = $this->app->config->email->smtp_password;
-		
+
 		$mail_message->from_address =
 			$this->app->config->email->service_address;
 

--- a/Admin/components/AdminSite/ForgotPassword.php
+++ b/Admin/components/AdminSite/ForgotPassword.php
@@ -162,7 +162,11 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		$mail_message = new AdminResetPasswordMailMessage($this->app,
 			$admin_user, $password_link);
 
-		$mail_message->smtp_server = $this->app->config->email->smtp_server;
+		$mail_message->smtp_server   = $this->app->config->email->smtp_server;
+		$mail_message->smtp_port     = $this->app->config->email->smtp_port;
+		$mail_message->smtp_username = $this->app->config->email->smtp_username;
+		$mail_message->smtp_password = $this->app->config->email->smtp_password;
+		
 		$mail_message->from_address =
 			$this->app->config->email->service_address;
 

--- a/Admin/components/AdminSite/ResetPassword.php
+++ b/Admin/components/AdminSite/ResetPassword.php
@@ -136,7 +136,11 @@ class AdminAdminSiteResetPassword extends AdminPage
 		$mail_message = new AdminResetPasswordSuccessMailMessage($this->app,
 			$this->user);
 
-		$mail_message->smtp_server = $this->app->config->email->smtp_server;
+		$mail_message->smtp_server   = $this->app->config->email->smtp_server;
+		$mail_message->smtp_port     = $this->app->config->email->smtp_port;
+		$mail_message->smtp_username = $this->app->config->email->smtp_username;
+		$mail_message->smtp_password = $this->app->config->email->smtp_password;
+
 		$mail_message->from_address =
 			$this->app->config->email->service_address;
 


### PR DESCRIPTION
This is required for the Use Mailchimp Mandrill instead of the silverorange [sc-55469] story.