### PR TITLE
Add dataobject properties (MERGE #109 FIRST)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,8 +12,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 2
 
-[*.{php,js,css,json,xml,sql}]
-indent_style = tab
+[*.php]
 indent_size = 4
 
 [*.{diff,md}]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+# Description
+
+Add a description of new changes, the reason for new changes, and how the new
+changes work here.
+
+# Testing Instructions (optional)
+
+Add step-by-step instructions for testing the PR, if necessary.
+
+1. Check out this PR
+2. …
+
+# Developer Checklist
+
+Before requesting review for this PR, make sure the following tasks are
+complete:
+
+- [ ] I added a link to the relevant Shortcut story, if applicable
+- [ ] I added testing instructions, if any
+- [ ] I made sure existing CI checks pass
+- [ ] I checked that all requirements of the ticket are fulfilled
+
+# Reviewer Checklist
+
+Before merging this PR, make sure the following tasks are complete:
+
+- [ ] I made sure there are no active labels that block merge
+- [ ] I followed the testing instructions
+- [ ] I made sure the CI checks pass
+- [ ] I reviewed the file changes on GitHub
+- [ ] I checked that all requirements of the ticket (if any) are fulfilled

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,40 @@
+name: Pull Requests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  runner:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP with tools
+        uses: silverorange/actions-setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: gd
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install PHP dependencies
+        run: 'composer install'
+
+      - name: Run tests
+        timeout-minutes: 5
+        run: |
+          composer run phpcs:ci
+          composer run phpstan:ci

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -17,7 +17,7 @@ jobs:
         uses: silverorange/actions-setup-php@v2
         with:
           php-version: '8.2'
-          extensions: gd
+          extensions: gd   # required by silverorange/Site
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 .DS_Store
 .env
 .idea/
+.php-cs-fixer.cache
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
@@ -16,3 +17,6 @@ yarn-error.log*
 # dependency lock file
 composer.lock
 yarn.lock
+
+# overrides for local tooling
+/phpstan.neon

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,0 +1,52 @@
+<?php
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+use PhpCsFixer\Runner\Parallel\ParallelConfigFactory;
+
+$finder = (new Finder())
+    ->in(__DIR__);
+
+return (new Config())
+    ->setParallelConfig(ParallelConfigFactory::detect(null, null, 2**18-1))
+    ->setRules([
+        '@PhpCsFixer'      => true,
+        '@PHP82Migration'  => true,
+        'indentation_type' => true,
+
+        // Overrides for (opinionated) @PhpCsFixer and @Symfony rules:
+
+        // Align "=>" in multi-line array definitions, unless a blank line exists between elements
+        'binary_operator_spaces' => ['operators' => ['=>' => 'align_single_space_minimal']],
+
+        // Subset of statements that should be proceeded with blank line
+        'blank_line_before_statement' => ['statements' => ['case', 'continue', 'declare', 'default', 'return', 'throw', 'try', 'yield', 'yield_from']],
+
+        // Enforce space around concatenation operator
+        'concat_space' => ['spacing' => 'one'],
+
+        // Use {} for empty loop bodies
+        'empty_loop_body' => ['style' => 'braces'],
+
+        // Don't change any increment/decrement styles
+        'increment_style' => false,
+
+        // Forbid multi-line whitespace before the closing semicolon
+        'multiline_whitespace_before_semicolons' => ['strategy' => 'no_multi_line'],
+
+        // Clean up PHPDocs, but leave @inheritDoc entries alone
+        'no_superfluous_phpdoc_tags' => ['allow_mixed' => true, 'remove_inheritdoc' => false],
+
+        // Ensure that traits are listed first in classes
+        // (it would be nice to enforce more, but we'll start simple)
+        'ordered_class_elements' => ['order' => ['use_trait']],
+
+        // Ensure that param and return types are sorted consistently, with null at end
+        'phpdoc_types_order' => ['sort_algorithm' => 'alpha', 'null_adjustment' => 'always_last'],
+
+        // Yoda style is too weird
+        'yoda_style' => false,
+    ])
+    ->setIndent('    ')
+    ->setLineEnding("\n")
+    ->setFinder($finder);

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -9,12 +9,12 @@
  */
 class Admin
 {
-	// {{{ constants
+
 
 	const GETTEXT_DOMAIN = 'admin';
 
-	// }}}
-	// {{{ private properties
+
+
 
 	/**
 	 * Whether or not this package is initialized
@@ -23,24 +23,24 @@ class Admin
 	 */
 	private static $is_initialized = false;
 
-	// }}}
-	// {{{ public static function _()
+
+
 
 	public static function _($message)
 	{
 		return self::gettext($message);
 	}
 
-	// }}}
-	// {{{ public static function gettext()
+
+
 
 	public static function gettext($message)
 	{
 		return dgettext(self::GETTEXT_DOMAIN, $message);
 	}
 
-	// }}}
-	// {{{ public static function ngettext()
+
+
 
 	public static function ngettext(
 		$singular_message,
@@ -51,8 +51,8 @@ class Admin
 			$singular_message, $plural_message, $number);
 	}
 
-	// }}}
-	// {{{ public static function setupGettext()
+
+
 
 	public static function setupGettext()
 	{
@@ -60,8 +60,8 @@ class Admin
 		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
 	}
 
-	// }}}
-	// {{{ public static function getConfigDefinitions()
+
+
 
 	/**
 	 * Gets configuration definitions used by the Admin package
@@ -81,8 +81,8 @@ class Admin
 		];
 	}
 
-	// }}}
-	// {{{ public static function init()
+
+
 
 	public static function init()
 	{
@@ -100,8 +100,8 @@ class Admin
 		self::$is_initialized = true;
 	}
 
-	// }}}
-	// {{{ private function __construct()
+
+
 
 	/**
 	 * Prevent instantiation of this static class
@@ -110,7 +110,7 @@ class Admin
 	{
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/Admin.php
+++ b/Admin/Admin.php
@@ -1,116 +1,87 @@
 <?php
 
 /**
- * Container for package wide static methods
+ * Container for package wide static methods.
  *
- * @package   Admin
  * @copyright 2005-2017 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class Admin
 {
+    public const GETTEXT_DOMAIN = 'admin';
 
+    /**
+     * Whether or not this package is initialized.
+     *
+     * @var bool
+     */
+    private static $is_initialized = false;
 
-	const GETTEXT_DOMAIN = 'admin';
+    public static function _($message)
+    {
+        return self::gettext($message);
+    }
 
+    public static function gettext($message)
+    {
+        return dgettext(self::GETTEXT_DOMAIN, $message);
+    }
 
+    public static function ngettext(
+        $singular_message,
+        $plural_message,
+        $number
+    ) {
+        return dngettext(
+            self::GETTEXT_DOMAIN,
+            $singular_message,
+            $plural_message,
+            $number
+        );
+    }
 
+    public static function setupGettext()
+    {
+        bindtextdomain(self::GETTEXT_DOMAIN, '@DATA-DIR@/Admin/locale');
+        bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
+    }
 
-	/**
-	 * Whether or not this package is initialized
-	 *
-	 * @var boolean
-	 */
-	private static $is_initialized = false;
+    /**
+     * Gets configuration definitions used by the Admin package.
+     *
+     * Applications should add these definitions to their config module before
+     * loading the application configuration.
+     *
+     * @return array the configuration definitions used by the Admin package
+     *
+     * @see SiteConfigModule::addDefinitions()
+     */
+    public static function getConfigDefinitions()
+    {
+        return [
+            'admin.allow_reset_password' => '0',
+            'admin.two_fa_enabled'       => false,
+        ];
+    }
 
+    public static function init()
+    {
+        if (self::$is_initialized) {
+            return;
+        }
 
+        Swat::init();
+        Site::init();
 
+        self::setupGettext();
 
-	public static function _($message)
-	{
-		return self::gettext($message);
-	}
+        SwatUI::mapClassPrefixToPath('Admin', 'Admin');
 
+        self::$is_initialized = true;
+    }
 
-
-
-	public static function gettext($message)
-	{
-		return dgettext(self::GETTEXT_DOMAIN, $message);
-	}
-
-
-
-
-	public static function ngettext(
-		$singular_message,
-		$plural_message,
-		$number
-	) {
-		return dngettext(self::GETTEXT_DOMAIN,
-			$singular_message, $plural_message, $number);
-	}
-
-
-
-
-	public static function setupGettext()
-	{
-		bindtextdomain(self::GETTEXT_DOMAIN, '@DATA-DIR@/Admin/locale');
-		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
-	}
-
-
-
-
-	/**
-	 * Gets configuration definitions used by the Admin package
-	 *
-	 * Applications should add these definitions to their config module before
-	 * loading the application configuration.
-	 *
-	 * @return array the configuration definitions used by the Admin package.
-	 *
-	 * @see SiteConfigModule::addDefinitions()
-	 */
-	public static function getConfigDefinitions()
-	{
-		return [
-			'admin.allow_reset_password' => '0',
-			'admin.two_fa_enabled' => false,
-		];
-	}
-
-
-
-
-	public static function init()
-	{
-		if (self::$is_initialized) {
-			return;
-		}
-
-		Swat::init();
-		Site::init();
-
-		self::setupGettext();
-
-		SwatUI::mapClassPrefixToPath('Admin', 'Admin');
-
-		self::$is_initialized = true;
-	}
-
-
-
-
-	/**
-	 * Prevent instantiation of this static class
-	 */
-	private function __construct()
-	{
-	}
-
-
+    /**
+     * Prevent instantiation of this static class.
+     */
+    private function __construct() {}
 }
-
-?>

--- a/Admin/AdminApplication.php
+++ b/Admin/AdminApplication.php
@@ -68,7 +68,7 @@ class AdminApplication extends SiteWebApplication
      *
      * @var string the menu-view class name
      */
-    protected $menu_view_class = 'AdminMenuView';
+    protected $menu_view_class = AdminMenuView::class;
 
     // @var array
     protected $has_component_cache = [];
@@ -163,8 +163,8 @@ class AdminApplication extends SiteWebApplication
     /**
      * Sets the class to use for this admin application's menu-view.
      *
-     * @param string $class_name the class to use for this admin application's
-     *                           menu-view
+     * @param class-string $class_name the class to use for this admin application's
+     *                                 menu-view
      *
      * @throws AdminException if the menu-view class is not defined or if the
      *                        menu-view class is not an AdminMenuView
@@ -178,8 +178,8 @@ class AdminApplication extends SiteWebApplication
             ));
         }
 
-        if ($class_name !== 'AdminMenuView'
-            && !is_subclass_of($class_name, 'AdminMenuView')) {
+        if ($class_name !== AdminMenuView::class
+            && !is_subclass_of($class_name, AdminMenuView::class)) {
             throw new AdminException(sprintf(
                 "Class '%s' is not an AdminMenuView.",
                 $class_name
@@ -322,12 +322,12 @@ class AdminApplication extends SiteWebApplication
     {
         $enabled = $this->config->admin->two_fa_enabled;
         if ($enabled) {
-            if (!class_exists('RobThree\Auth\TwoFactorAuth')) {
+            if (!class_exists(RobThree\Auth\TwoFactorAuth::class)) {
                 throw new AdminException(
                     'robthree/twofactorauth is required for using 2FA'
                 );
             }
-            if (!class_exists('BaconQrCode\Writer')) {
+            if (!class_exists(BaconQrCode\Writer::class)) {
                 throw new AdminException(
                     'bacon/bacon-qr-code is required for using 2FA'
                 );

--- a/Admin/AdminApplication.php
+++ b/Admin/AdminApplication.php
@@ -5,6 +5,13 @@
  *
  * @copyright 2004-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property SiteCookieModule $cookie
+ * @property SiteDatabaseModule $database
+ * @property AdminSessionModule $session
+ * @property SiteMessagesModule $messages
+ * @property SiteConfigModule $config
+ * @property SiteCryptModule $crypt
  */
 class AdminApplication extends SiteWebApplication
 {

--- a/Admin/AdminApplication.php
+++ b/Admin/AdminApplication.php
@@ -9,7 +9,7 @@
  */
 class AdminApplication extends SiteWebApplication
 {
-	// {{{ public properties
+
 
 	/**
 	 * A visble title for this admin
@@ -37,8 +37,8 @@ class AdminApplication extends SiteWebApplication
 	 */
 	public $default_locale = null;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * The default path to include components from
@@ -81,8 +81,8 @@ class AdminApplication extends SiteWebApplication
 	 */
 	protected $has_component_cache = array();
 
-	// }}}
-	// {{{ public function run()
+
+
 
 	public function run()
 	{
@@ -92,8 +92,8 @@ class AdminApplication extends SiteWebApplication
 		parent::run();
 	}
 
-	// }}}
-	// {{{ public function replacePage()
+
+
 
 	/**
 	 * Replace the page object
@@ -127,8 +127,8 @@ class AdminApplication extends SiteWebApplication
 		return parent::replacePage($source);
 	}
 
-	// }}}
-	// {{{ public function getDefaultSubComponent()
+
+
 
 	/**
 	 * Gets the name of the default sub-component of this application
@@ -141,8 +141,8 @@ class AdminApplication extends SiteWebApplication
 		return 'Index';
 	}
 
-	// }}}
-	// {{{ public function getFrontendBaseHref()
+
+
 
 	/**
 	 * Gets the base href of the frontend application administered by this
@@ -158,8 +158,8 @@ class AdminApplication extends SiteWebApplication
 		return $base_href;
 	}
 
-	// }}}
-	// {{{ public function getFrontSource()
+
+
 
 	/**
 	 * Gets the source of the front page
@@ -172,8 +172,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->front_source;
 	}
 
-	// }}}
-	// {{{ public function setFrontSource()
+
+
 
 	/**
 	 * Sets the source of the front page
@@ -186,8 +186,8 @@ class AdminApplication extends SiteWebApplication
 		$this->front_source = $source;
 	}
 
-	// }}}
-	// {{{ public function setMenuViewClass()
+
+
 
 	/**
 	 * Sets the class to use for this admin application's menu-view
@@ -212,8 +212,8 @@ class AdminApplication extends SiteWebApplication
 		$this->menu_view_class = $class_name;
 	}
 
-	// }}}
-	// {{{ public function getMenuViewClass()
+
+
 
 	/**
 	 * Gets the class used for this admin application's menu-view
@@ -228,8 +228,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->menu_view_class;
 	}
 
-	// }}}
-	// {{{ public function setDefaultComponentIncludePath()
+
+
 
 	/**
 	 * Sets the default a path to include components from
@@ -243,8 +243,8 @@ class AdminApplication extends SiteWebApplication
 		$this->default_component_include_path = $path;
 	}
 
-	// }}}
-	// {{{ public function getDeafultComponentIncludePath()
+
+
 
 	/**
 	 * Gets the default component include path
@@ -256,8 +256,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->default_component_include_path;
 	}
 
-	// }}}
-	// {{{ public function addComponentIncludePath()
+
+
 
 	/**
 	 * Adds a path to the list of component include paths
@@ -277,8 +277,8 @@ class AdminApplication extends SiteWebApplication
 		$this->component_include_paths[$prefix] = $path;
 	}
 
-	// }}}
-	// {{{ public function getComponentIncludePaths()
+
+
 
 	/**
 	 * Gets the array of paths to check for components when finding the
@@ -296,8 +296,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->component_include_paths;
 	}
 
-	// }}}
-	// {{{ public function hasComponent()
+
+
 
 	public function hasComponent($shortname)
 	{
@@ -312,8 +312,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->has_component_cache[$shortname];
 	}
 
-	// }}}
-	// {{{ public function isMultipleInstanceAdmin()
+
+
 
 	/**
 	 * Helper method to check to see if this is the admin for all instances of a
@@ -328,16 +328,16 @@ class AdminApplication extends SiteWebApplication
 			$this->getInstanceId() === null);
 	}
 
-	// }}}
-	// {{{ public function userHasAccess()
+
+
 
 	public function userHasAccess($shortname)
 	{
 		return $this->session->user->hasAccessByShortname($shortname);
 	}
 
-	// }}}
-	// {{{ public function setMemcacheInstanceValues()
+
+
 
 	/**
 	 * Convience method to ensure the memcache module is configured correctly
@@ -370,8 +370,8 @@ class AdminApplication extends SiteWebApplication
 		}
 	}
 
-	// }}}
-	// {{{ public function is2FaEnabled()
+
+
 
 	public function is2FaEnabled()
 	{
@@ -391,8 +391,8 @@ class AdminApplication extends SiteWebApplication
 		return $enabled;
 	}
 
-	// }}}
-	// {{{ protected function normalizeSource()
+
+
 
 	protected function normalizeSource($source)
 	{
@@ -404,8 +404,8 @@ class AdminApplication extends SiteWebApplication
 		return $source;
 	}
 
-	// }}}
-	// {{{ protected function resolvePage()
+
+
 
 	protected function resolvePage($source)
 	{
@@ -428,8 +428,8 @@ class AdminApplication extends SiteWebApplication
 		}
 	}
 
-	// }}}
-	// {{{ protected function resolveAdminPage()
+
+
 
 	protected function resolveAdminPage($source)
 	{
@@ -473,8 +473,8 @@ class AdminApplication extends SiteWebApplication
 		return $page;
 	}
 
-	// }}}
-	// {{{ protected function resolveExceptionPage()
+
+
 
 	/**
 	 * Resolves an exception page for a particular source
@@ -491,8 +491,8 @@ class AdminApplication extends SiteWebApplication
 		return $this->resolvePage('AdminSite/Exception');
 	}
 
-	// }}}
-	// {{{ protected function getDefaultModuleList()
+
+
 
 	/**
 	 * Gets the list of default modules to load for this applicaiton
@@ -515,8 +515,8 @@ class AdminApplication extends SiteWebApplication
 		);
 	}
 
-	// }}}
-	// {{{ protected function initModules()
+
+
 
 	protected function initModules()
 	{
@@ -525,8 +525,8 @@ class AdminApplication extends SiteWebApplication
 		$this->db = $this->database->getConnection();
 	}
 
-	// }}}
-	// {{{ protected function configure()
+
+
 
 	protected function configure(SiteConfigModule $config)
 	{
@@ -535,8 +535,8 @@ class AdminApplication extends SiteWebApplication
 		$this->addComponentIncludePath('Admin/components', 'Admin');
 	}
 
-	// }}}
-	// {{{ protected function addConfigDefinitions()
+
+
 
 	/**
 	 * Adds configuration definitions to the config module of this application
@@ -550,7 +550,7 @@ class AdminApplication extends SiteWebApplication
 		$config->addDefinitions(Admin::getConfigDefinitions());
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminApplication.php
+++ b/Admin/AdminApplication.php
@@ -1,17 +1,20 @@
 <?php
 
+use BaconQrCode\Writer;
+use RobThree\Auth\TwoFactorAuth;
+
 /**
  * Web application class for an administration application.
  *
  * @copyright 2004-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property SiteCookieModule $cookie
+ * @property SiteCookieModule   $cookie
  * @property SiteDatabaseModule $database
  * @property AdminSessionModule $session
  * @property SiteMessagesModule $messages
- * @property SiteConfigModule $config
- * @property SiteCryptModule $crypt
+ * @property SiteConfigModule   $config
+ * @property SiteCryptModule    $crypt
  */
 class AdminApplication extends SiteWebApplication
 {
@@ -329,12 +332,12 @@ class AdminApplication extends SiteWebApplication
     {
         $enabled = $this->config->admin->two_fa_enabled;
         if ($enabled) {
-            if (!class_exists(RobThree\Auth\TwoFactorAuth::class)) {
+            if (!class_exists(TwoFactorAuth::class)) {
                 throw new AdminException(
                     'robthree/twofactorauth is required for using 2FA'
                 );
             }
-            if (!class_exists(BaconQrCode\Writer::class)) {
+            if (!class_exists(Writer::class)) {
                 throw new AdminException(
                     'bacon/bacon-qr-code is required for using 2FA'
                 );

--- a/Admin/AdminApplication.php
+++ b/Admin/AdminApplication.php
@@ -1,556 +1,482 @@
 <?php
 
 /**
- * Web application class for an administration application
+ * Web application class for an administration application.
  *
- * @package   Admin
  * @copyright 2004-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminApplication extends SiteWebApplication
 {
-
-
-	/**
-	 * A visble title for this admin
-	 *
-	 * @var string
-	 */
-	public $title;
-
-	/**
-	 * Convenience reference to MDB2 object within the built-in AdminDatabaseModule
-	 *
-	 * @var MDB2_Connection Database connection object (readonly)
-	 */
-	public $db;
-
-	/**
-	 * Default locale
-	 *
-	 * This locale is used for translations, collation and locale-specific
-	 * formatting. The locale is a five character identifier composed of a
-	 * language code (ISO 639) an underscore and a country code (ISO 3166). For
-	 * example, use 'en_CA' for Canadian English.
-	 *
-	 * @var string
-	 */
-	public $default_locale = null;
-
-
-
-
-	/**
-	 * The default path to include components from
-	 *
-	 * @var string
-	 *
-	 * @see AdminApplication::setDefaultComponentIncludePath()
-	 */
-	protected $default_component_include_path =
-		'../../include/admin/components';
-
-	/**
-	 * An array of paths to check for components when finding the filename of
-	 * a component
-	 *
-	 * The array is of the form: 'ClassPrefix' => 'path'.
-	 *
-	 * @var array
-	 *
-	 * @see AdminApplication::addComponentIncludePath()
-	 */
-	protected $component_include_paths = array();
-
-	/**
-	 * Source of the front page.
-	 *
-	 * @var string the page to load as the front page of the admin.
-	 */
-	protected $front_source = 'AdminSite/Front';
-
-	/**
-	 * Class to use for the menu-view
-	 *
-	 * @var string the menu-view class name.
-	 */
-	protected $menu_view_class = 'AdminMenuView';
-
-	/*
-	 * @var array
-	 */
-	protected $has_component_cache = array();
-
-
-
-
-	public function run()
-	{
-		if ($this->default_locale !== null)
-			setlocale(LC_ALL, $this->default_locale);
-
-		parent::run();
-	}
-
-
-
-
-	/**
-	 * Replace the page object
-	 *
-	 * This method can be used to load another page to replace the current
-	 * page. For example, this is used to load a confirmation page when
-	 * processing an admin index page.
-	 *
-	 * @param string $source the source of the page with which to replace the
-	 *                        current page. The source will be passed to the
-	 *                        {@link SiteWebApplication::resolvePage()} method.
-	 *
-	 * @param integer $reset_vars bitwise argument of whether or not to reset
-	 *                           GET or POST vars when replacing the page. By
-	 *                           default, both are reset.
-	 */
-	public function replacePage($source, $reset_vars = null)
-	{
-		if ($reset_vars === null) {
-			$reset_vars = self::VAR_GET | self::VAR_POST;
-		}
-
-		if ($reset_vars & self::VAR_GET) {
-			$_GET = array();
-		}
-
-		if ($reset_vars & self::VAR_POST) {
-			$_POST = array();
-		}
-
-		return parent::replacePage($source);
-	}
-
-
-
-
-	/**
-	 * Gets the name of the default sub-component of this application
-	 *
-	 * @return string the name of the default sub-component to use if no
-	 *                 sub-component is specified in the page request source.
-	 */
-	public function getDefaultSubComponent()
-	{
-		return 'Index';
-	}
-
-
-
-
-	/**
-	 * Gets the base href of the frontend application administered by this
-	 * admin application
-	 *
-	 * @return string the base href of the frontend application administered
-	 *                 by this admin application.
-	 */
-	public function getFrontendBaseHref()
-	{
-		$base_href = $this->getBaseHref();
-		$base_href = dirname($base_href).'/'; // strip off admin sub-directory
-		return $base_href;
-	}
-
-
-
-
-	/**
-	 * Gets the source of the front page
-	 *
-	 * @return string the subcomponent page to load as the front page of this
-	 *                 admin application.
-	 */
-	public function getFrontSource()
-	{
-		return $this->front_source;
-	}
-
-
-
-
-	/**
-	 * Sets the source of the front page
-	 *
-	 * @param string $source the subcomponent page to load as the front page
-	 *                        of this admin application.
-	 */
-	public function setFrontSource($source)
-	{
-		$this->front_source = $source;
-	}
-
-
-
-
-	/**
-	 * Sets the class to use for this admin application's menu-view
-	 *
-	 * @param string $class_name the class to use for this admin application's
-	 *                            menu-view.
-	 *
-	 * @throws AdminException if the menu-view class is not defined or if the
-	 *                         menu-view class is not an AdminMenuView.
-	 */
-	public function setMenuViewClass($class_name)
-	{
-		if (!class_exists($class_name))
-			throw new AdminException(sprintf(
-				"AdminMenuView class '%s' is undefined.", $class_name));
-
-		if ($class_name !== 'AdminMenuView' &&
-			!is_subclass_of($class_name, 'AdminMenuView'))
-			throw new AdminException(sprintf(
-				"Class '%s' is not an AdminMenuView.", $class_name));
-
-		$this->menu_view_class = $class_name;
-	}
-
-
-
-
-	/**
-	 * Gets the class used for this admin application's menu-view
-	 *
-	 * @return string the class to use for this admin application's menu-view.
-	 *                 By default, this is 'AdminMenuView'.
-	 *
-	 * @see AdminApplication::setMenuViewClass()
-	 */
-	public function getMenuViewClass()
-	{
-		return $this->menu_view_class;
-	}
-
-
-
-
-	/**
-	 * Sets the default a path to include components from
-	 *
-	 * Paths are relative to the www dir of the site.
-	 *
-	 * @param string $path the include path.
-	 */
-	public function setDefaultComponentIncludePath($path)
-	{
-		$this->default_component_include_path = $path;
-	}
-
-
-
-
-	/**
-	 * Gets the default component include path
-	 *
-	 * @return string the component include path.
-	 */
-	public function getDefaultComponentIncludePath()
-	{
-		return $this->default_component_include_path;
-	}
-
-
-
-
-	/**
-	 * Adds a path to the list of component include paths
-	 *
-	 * Paths do not contain leading or trailing slashes and are relative to
-	 * the PHP include path. The component include paths are searched in order
-	 * so if a file exists in two places, the first filename will be returned.
-	 *
-	 * @param string $path the include path to add.
-	 * @param string $prefix the prefix to prefix classes defined in the
-	 *                        include path with.
-	 *
-	 * @see AdminApplication::getComponentIncludePaths()
-	 */
-	public function addComponentIncludePath($path, $prefix)
-	{
-		$this->component_include_paths[$prefix] = $path;
-	}
-
-
-
-
-	/**
-	 * Gets the array of paths to check for components when finding the
-	 * filename of a component
-	 *
-	 * The array is indexed by a class prefix. This class prefix is prepended
-	 * to the names of classes defined in files found in the component include
-	 * path.
-	 *
-	 * @return array an array containing the paths to check for components when
-	 *                finding the filename of a component.
-	 */
-	public function &getComponentIncludePaths()
-	{
-		return $this->component_include_paths;
-	}
-
-
-
-
-	public function hasComponent($shortname)
-	{
-		if (!isset($this->has_component_cache[$shortname])) {
-			$component = new AdminComponent();
-			$component->setDatabase($this->db);
-
-			$this->has_component_cache[$shortname] =
-				$component->loadFromShortname($shortname);
-		}
-
-		return $this->has_component_cache[$shortname];
-	}
-
-
-
-
-	/**
-	 * Helper method to check to see if this is the admin for all instances of a
-	 * multi-instance site.
-	 *
-	 * @returns boolean true if it is the admin for multiple instances, false if
-	 *                   it is not.
-	 */
-	public function isMultipleInstanceAdmin()
-	{
-		return ($this->hasModule('SiteMultipleInstanceModule') &&
-			$this->getInstanceId() === null);
-	}
-
-
-
-
-	public function userHasAccess($shortname)
-	{
-		return $this->session->user->hasAccessByShortname($shortname);
-	}
-
-
-
-
-	/**
-	 * Convience method to ensure the memcache module is configured correctly
-	 * for the given instance, which is necessary for caching calls in a
-	 * multiple instance admin.
-	 *
-	 * @param SiteInstance $instance
-	 */
-	public function setMemcacheInstanceValues(SiteInstance $instance = null)
-	{
-		if ($this->hasModule('SiteMemcacheModule')) {
-			$cache = $this->getModule('SiteMemcacheModule');
-
-			// server and app_ns can be instance specific by using the
-			// InstanceConfigSetting table, so reset them with the instance's
-			// config setting for those values.
-			$cache->server = $this->getConfigSetting(
-				'memcache.server',
-				$instance
-			);
-
-			$cache->app_ns = $this->getConfigSetting(
-				'memcache.app_ns',
-				$instance
-			);
-
-			if ($instance instanceof SiteInstance) {
-				$cache->setInstance($instance);
-			}
-		}
-	}
-
-
-
-
-	public function is2FaEnabled()
-	{
-		$enabled = $this->config->admin->two_fa_enabled;
-		if ($enabled) {
-			if (!class_exists('RobThree\Auth\TwoFactorAuth')) {
-				throw new AdminException(
-					'robthree/twofactorauth is required for using 2FA'
-				);
-			} elseif (!class_exists('BaconQrCode\Writer')) {
-				throw new AdminException(
-					'bacon/bacon-qr-code is required for using 2FA'
-				);
-			}
-		}
-
-		return $enabled;
-	}
-
-
-
-
-	protected function normalizeSource($source)
-	{
-		$source = parent::normalizeSource($source);
-
-		if ($source === 'index.html' || $source === '')
-			$source = $this->front_source;
-
-		return $source;
-	}
-
-
-
-
-	protected function resolvePage($source)
-	{
-		$path = explode('/', $source);
-		switch ($path[0]) {
-		case 'smil':
-			array_shift($path);
-			$layout = new SiteLayout($this, SiteSMILTemplate::class);
-			$page = new SiteAmazonCdnMediaManifestPage($this, $layout);
-			$page->setMediaKey(mb_substr(array_shift($path), 0, -5));
-			return $page;
-		case 'vtt':
-			array_shift($path);
-			$layout = new SiteLayout($this, SiteVTTTemplate::class);
-			$page = new SiteVideoTextTracksPage($this, $layout);
-			$page->setMediaKey(mb_substr(array_shift($path), 0, -4));
-			return $page;
-		default :
-			return $this->resolveAdminPage($source);
-		}
-	}
-
-
-
-
-	protected function resolveAdminPage($source)
-	{
-		$request = new AdminPageRequest($this, $source);
-
-		$classname = $request->getClassName();
-		if (!class_exists($classname)) {
-			throw new AdminNotFoundException(
-				sprintf(
-					Admin::_("Class '%s' does not exist."),
-					$classname
-				)
-			);
-		}
-
-		$layout = $this->resolveLayout($source);
-		$page = new $classname($this, $layout);
-		$page->title = $request->getTitle();
-
-		if ($page instanceof AdminPage) {
-			$page->source = $request->getSource();
-			$page->component = $request->getComponent();
-			$page->subcomponent = $request->getSubComponent();
-		}
-
-		if ($page->layout instanceof AdminDefaultLayout) {
-			$entry = new AdminImportantNavBarEntry($this->title, '.');
-			$page->layout->navbar->addEntry($entry);
-
-			// Don't link the default sub-component navbar entry
-			if ($request->getSubComponent() == $this->getDefaultSubComponent()) {
-				$entry = new SwatNavBarEntry($request->getTitle(), null);
-			} else {
-				$entry = new SwatNavBarEntry($request->getTitle(),
-					$request->getComponent());
-			}
-
-			$page->layout->navbar->addEntry($entry);
-		}
-
-		return $page;
-	}
-
-
-
-
-	/**
-	 * Resolves an exception page for a particular source
-	 *
-	 * Sub-classes are encouraged to override this method to create different
-	 * exception page instances for different sources.
-	 *
-	 * @param string $source the source to use to resolve the exception page.
-	 *
-	 * @return SitePage the exception page corresponding the given source.
-	 */
-	protected function resolveExceptionPage($source)
-	{
-		return $this->resolvePage('AdminSite/Exception');
-	}
-
-
-
-
-	/**
-	 * Gets the list of default modules to load for this applicaiton
-	 *
-	 * @return array
-	 * @see    SiteApplication::getDefaultModuleList()
-	 */
-	protected function getDefaultModuleList()
-	{
-		return array_merge(
-			parent::getDefaultModuleList(),
-			[
-				'cookie' => SiteCookieModule::class,
-				'database' => SiteDatabaseModule::class,
-				'session' => AdminSessionModule::class,
-				'messages' => SiteMessagesModule::class,
-				'config' => SiteConfigModule::class,
-				'crypt' => SiteCryptModule::class,
-			]
-		);
-	}
-
-
-
-
-	protected function initModules()
-	{
-		parent::initModules();
-		// set up convenience references
-		$this->db = $this->database->getConnection();
-	}
-
-
-
-
-	protected function configure(SiteConfigModule $config)
-	{
-		parent::configure($config);
-
-		$this->addComponentIncludePath('Admin/components', 'Admin');
-	}
-
-
-
-
-	/**
-	 * Adds configuration definitions to the config module of this application
-	 *
-	 * @param SiteConfigModule $config the config module of this application to
-	 *                                  which to add the config definitions.
-	 */
-	protected function addConfigDefinitions(SiteConfigModule $config)
-	{
-		parent::addConfigDefinitions($config);
-		$config->addDefinitions(Admin::getConfigDefinitions());
-	}
-
-
+    /**
+     * A visble title for this admin.
+     *
+     * @var string
+     */
+    public $title;
+
+    /**
+     * Convenience reference to MDB2 object within the built-in AdminDatabaseModule.
+     *
+     * @var MDB2_Connection Database connection object (readonly)
+     */
+    public $db;
+
+    /**
+     * Default locale.
+     *
+     * This locale is used for translations, collation and locale-specific
+     * formatting. The locale is a five character identifier composed of a
+     * language code (ISO 639) an underscore and a country code (ISO 3166). For
+     * example, use 'en_CA' for Canadian English.
+     *
+     * @var string
+     */
+    public $default_locale;
+
+    /**
+     * The default path to include components from.
+     *
+     * @var string
+     *
+     * @see AdminApplication::setDefaultComponentIncludePath()
+     */
+    protected $default_component_include_path =
+        '../../include/admin/components';
+
+    /**
+     * An array of paths to check for components when finding the filename of
+     * a component.
+     *
+     * The array is of the form: 'ClassPrefix' => 'path'.
+     *
+     * @var array
+     *
+     * @see AdminApplication::addComponentIncludePath()
+     */
+    protected $component_include_paths = [];
+
+    /**
+     * Source of the front page.
+     *
+     * @var string the page to load as the front page of the admin
+     */
+    protected $front_source = 'AdminSite/Front';
+
+    /**
+     * Class to use for the menu-view.
+     *
+     * @var string the menu-view class name
+     */
+    protected $menu_view_class = 'AdminMenuView';
+
+    // @var array
+    protected $has_component_cache = [];
+
+    public function run()
+    {
+        if ($this->default_locale !== null) {
+            setlocale(LC_ALL, $this->default_locale);
+        }
+
+        parent::run();
+    }
+
+    /**
+     * Replace the page object.
+     *
+     * This method can be used to load another page to replace the current
+     * page. For example, this is used to load a confirmation page when
+     * processing an admin index page.
+     *
+     * @param string $source     the source of the page with which to replace the
+     *                           current page. The source will be passed to the
+     *                           {@link SiteWebApplication::resolvePage()} method.
+     * @param int    $reset_vars bitwise argument of whether or not to reset
+     *                           GET or POST vars when replacing the page. By
+     *                           default, both are reset.
+     */
+    public function replacePage($source, $reset_vars = null)
+    {
+        if ($reset_vars === null) {
+            $reset_vars = self::VAR_GET | self::VAR_POST;
+        }
+
+        if ($reset_vars & self::VAR_GET) {
+            $_GET = [];
+        }
+
+        if ($reset_vars & self::VAR_POST) {
+            $_POST = [];
+        }
+
+        return parent::replacePage($source);
+    }
+
+    /**
+     * Gets the name of the default sub-component of this application.
+     *
+     * @return string the name of the default sub-component to use if no
+     *                sub-component is specified in the page request source
+     */
+    public function getDefaultSubComponent()
+    {
+        return 'Index';
+    }
+
+    /**
+     * Gets the base href of the frontend application administered by this
+     * admin application.
+     *
+     * @return string the base href of the frontend application administered
+     *                by this admin application
+     */
+    public function getFrontendBaseHref()
+    {
+        $base_href = $this->getBaseHref();
+
+        return dirname($base_href) . '/'; // strip off admin sub-directory
+    }
+
+    /**
+     * Gets the source of the front page.
+     *
+     * @return string the subcomponent page to load as the front page of this
+     *                admin application
+     */
+    public function getFrontSource()
+    {
+        return $this->front_source;
+    }
+
+    /**
+     * Sets the source of the front page.
+     *
+     * @param string $source the subcomponent page to load as the front page
+     *                       of this admin application
+     */
+    public function setFrontSource($source)
+    {
+        $this->front_source = $source;
+    }
+
+    /**
+     * Sets the class to use for this admin application's menu-view.
+     *
+     * @param string $class_name the class to use for this admin application's
+     *                           menu-view
+     *
+     * @throws AdminException if the menu-view class is not defined or if the
+     *                        menu-view class is not an AdminMenuView
+     */
+    public function setMenuViewClass($class_name)
+    {
+        if (!class_exists($class_name)) {
+            throw new AdminException(sprintf(
+                "AdminMenuView class '%s' is undefined.",
+                $class_name
+            ));
+        }
+
+        if ($class_name !== 'AdminMenuView'
+            && !is_subclass_of($class_name, 'AdminMenuView')) {
+            throw new AdminException(sprintf(
+                "Class '%s' is not an AdminMenuView.",
+                $class_name
+            ));
+        }
+
+        $this->menu_view_class = $class_name;
+    }
+
+    /**
+     * Gets the class used for this admin application's menu-view.
+     *
+     * @return string the class to use for this admin application's menu-view.
+     *                By default, this is 'AdminMenuView'.
+     *
+     * @see AdminApplication::setMenuViewClass()
+     */
+    public function getMenuViewClass()
+    {
+        return $this->menu_view_class;
+    }
+
+    /**
+     * Sets the default a path to include components from.
+     *
+     * Paths are relative to the www dir of the site.
+     *
+     * @param string $path the include path
+     */
+    public function setDefaultComponentIncludePath($path)
+    {
+        $this->default_component_include_path = $path;
+    }
+
+    /**
+     * Gets the default component include path.
+     *
+     * @return string the component include path
+     */
+    public function getDefaultComponentIncludePath()
+    {
+        return $this->default_component_include_path;
+    }
+
+    /**
+     * Adds a path to the list of component include paths.
+     *
+     * Paths do not contain leading or trailing slashes and are relative to
+     * the PHP include path. The component include paths are searched in order
+     * so if a file exists in two places, the first filename will be returned.
+     *
+     * @param string $path   the include path to add
+     * @param string $prefix the prefix to prefix classes defined in the
+     *                       include path with
+     *
+     * @see AdminApplication::getComponentIncludePaths()
+     */
+    public function addComponentIncludePath($path, $prefix)
+    {
+        $this->component_include_paths[$prefix] = $path;
+    }
+
+    /**
+     * Gets the array of paths to check for components when finding the
+     * filename of a component.
+     *
+     * The array is indexed by a class prefix. This class prefix is prepended
+     * to the names of classes defined in files found in the component include
+     * path.
+     *
+     * @return array an array containing the paths to check for components when
+     *               finding the filename of a component
+     */
+    public function &getComponentIncludePaths()
+    {
+        return $this->component_include_paths;
+    }
+
+    public function hasComponent($shortname)
+    {
+        if (!isset($this->has_component_cache[$shortname])) {
+            $component = new AdminComponent();
+            $component->setDatabase($this->db);
+
+            $this->has_component_cache[$shortname] =
+                $component->loadFromShortname($shortname);
+        }
+
+        return $this->has_component_cache[$shortname];
+    }
+
+    /**
+     * Helper method to check to see if this is the admin for all instances of a
+     * multi-instance site.
+     *
+     * @returns boolean true if it is the admin for multiple instances, false if
+     *                   it is not.
+     */
+    public function isMultipleInstanceAdmin()
+    {
+        return $this->hasModule('SiteMultipleInstanceModule')
+            && $this->getInstanceId() === null;
+    }
+
+    public function userHasAccess($shortname)
+    {
+        return $this->session->user->hasAccessByShortname($shortname);
+    }
+
+    /**
+     * Convience method to ensure the memcache module is configured correctly
+     * for the given instance, which is necessary for caching calls in a
+     * multiple instance admin.
+     */
+    public function setMemcacheInstanceValues(?SiteInstance $instance = null)
+    {
+        if ($this->hasModule('SiteMemcacheModule')) {
+            $cache = $this->getModule('SiteMemcacheModule');
+
+            // server and app_ns can be instance specific by using the
+            // InstanceConfigSetting table, so reset them with the instance's
+            // config setting for those values.
+            $cache->server = $this->getConfigSetting(
+                'memcache.server',
+                $instance
+            );
+
+            $cache->app_ns = $this->getConfigSetting(
+                'memcache.app_ns',
+                $instance
+            );
+
+            if ($instance instanceof SiteInstance) {
+                $cache->setInstance($instance);
+            }
+        }
+    }
+
+    public function is2FaEnabled()
+    {
+        $enabled = $this->config->admin->two_fa_enabled;
+        if ($enabled) {
+            if (!class_exists('RobThree\Auth\TwoFactorAuth')) {
+                throw new AdminException(
+                    'robthree/twofactorauth is required for using 2FA'
+                );
+            }
+            if (!class_exists('BaconQrCode\Writer')) {
+                throw new AdminException(
+                    'bacon/bacon-qr-code is required for using 2FA'
+                );
+            }
+        }
+
+        return $enabled;
+    }
+
+    protected function normalizeSource($source)
+    {
+        $source = parent::normalizeSource($source);
+
+        if ($source === 'index.html' || $source === '') {
+            $source = $this->front_source;
+        }
+
+        return $source;
+    }
+
+    protected function resolvePage($source)
+    {
+        $path = explode('/', $source);
+        switch ($path[0]) {
+            case 'smil':
+                array_shift($path);
+                $layout = new SiteLayout($this, SiteSMILTemplate::class);
+                $page = new SiteAmazonCdnMediaManifestPage($this, $layout);
+                $page->setMediaKey(mb_substr(array_shift($path), 0, -5));
+
+                return $page;
+
+            case 'vtt':
+                array_shift($path);
+                $layout = new SiteLayout($this, SiteVTTTemplate::class);
+                $page = new SiteVideoTextTracksPage($this, $layout);
+                $page->setMediaKey(mb_substr(array_shift($path), 0, -4));
+
+                return $page;
+
+            default:
+                return $this->resolveAdminPage($source);
+        }
+    }
+
+    protected function resolveAdminPage($source)
+    {
+        $request = new AdminPageRequest($this, $source);
+
+        $classname = $request->getClassName();
+        if (!class_exists($classname)) {
+            throw new AdminNotFoundException(
+                sprintf(
+                    Admin::_("Class '%s' does not exist."),
+                    $classname
+                )
+            );
+        }
+
+        $layout = $this->resolveLayout($source);
+        $page = new $classname($this, $layout);
+        $page->title = $request->getTitle();
+
+        if ($page instanceof AdminPage) {
+            $page->source = $request->getSource();
+            $page->component = $request->getComponent();
+            $page->subcomponent = $request->getSubComponent();
+        }
+
+        if ($page->layout instanceof AdminDefaultLayout) {
+            $entry = new AdminImportantNavBarEntry($this->title, '.');
+            $page->layout->navbar->addEntry($entry);
+
+            // Don't link the default sub-component navbar entry
+            if ($request->getSubComponent() == $this->getDefaultSubComponent()) {
+                $entry = new SwatNavBarEntry($request->getTitle(), null);
+            } else {
+                $entry = new SwatNavBarEntry(
+                    $request->getTitle(),
+                    $request->getComponent()
+                );
+            }
+
+            $page->layout->navbar->addEntry($entry);
+        }
+
+        return $page;
+    }
+
+    /**
+     * Resolves an exception page for a particular source.
+     *
+     * Sub-classes are encouraged to override this method to create different
+     * exception page instances for different sources.
+     *
+     * @param string $source the source to use to resolve the exception page
+     *
+     * @return SitePage the exception page corresponding the given source
+     */
+    protected function resolveExceptionPage($source)
+    {
+        return $this->resolvePage('AdminSite/Exception');
+    }
+
+    /**
+     * Gets the list of default modules to load for this applicaiton.
+     *
+     * @return array
+     *
+     * @see    SiteApplication::getDefaultModuleList()
+     */
+    protected function getDefaultModuleList()
+    {
+        return array_merge(
+            parent::getDefaultModuleList(),
+            [
+                'cookie'   => SiteCookieModule::class,
+                'database' => SiteDatabaseModule::class,
+                'session'  => AdminSessionModule::class,
+                'messages' => SiteMessagesModule::class,
+                'config'   => SiteConfigModule::class,
+                'crypt'    => SiteCryptModule::class,
+            ]
+        );
+    }
+
+    protected function initModules()
+    {
+        parent::initModules();
+        // set up convenience references
+        $this->db = $this->database->getConnection();
+    }
+
+    protected function configure(SiteConfigModule $config)
+    {
+        parent::configure($config);
+
+        $this->addComponentIncludePath('Admin/components', 'Admin');
+    }
+
+    /**
+     * Adds configuration definitions to the config module of this application.
+     *
+     * @param SiteConfigModule $config the config module of this application to
+     *                                 which to add the config definitions
+     */
+    protected function addConfigDefinitions(SiteConfigModule $config)
+    {
+        parent::addConfigDefinitions($config);
+        $config->addDefinitions(Admin::getConfigDefinitions());
+    }
 }
-
-?>

--- a/Admin/AdminControlCellRenderer.php
+++ b/Admin/AdminControlCellRenderer.php
@@ -14,7 +14,7 @@
  */
 class AdminControlCellRenderer extends SwatImageLinkCellRenderer
 {
-	// {{{ public properties
+
 
 	/**
 	 * The stock id of this AdminControlCellRenderer
@@ -28,8 +28,8 @@ class AdminControlCellRenderer extends SwatImageLinkCellRenderer
 	 */
 	public $stock_id = null;
 
-	// }}}
-	// {{{ public function render()
+
+
 
 	public function render()
 	{
@@ -44,8 +44,8 @@ class AdminControlCellRenderer extends SwatImageLinkCellRenderer
 		parent::render();
 	}
 
-	// }}}
-	// {{{ public function setFromStock()
+
+
 
 	/**
 	 * Sets the values of this control cell renderer to a stock type
@@ -102,7 +102,7 @@ class AdminControlCellRenderer extends SwatImageLinkCellRenderer
 			$this->height = $height;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminControlCellRenderer.php
+++ b/Admin/AdminControlCellRenderer.php
@@ -1,108 +1,104 @@
 <?php
 
 /**
- * Details Control
+ * Details Control.
  *
  * Convenience class for a Details button
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @deprecated Use {@link AdminTitleLinkCellRenderer} or one of its subclasses
- *              instead.
+ * @deprecated use {@link AdminTitleLinkCellRenderer} or one of its subclasses
+ *              instead
  */
 class AdminControlCellRenderer extends SwatImageLinkCellRenderer
 {
+    /**
+     * The stock id of this AdminControlCellRenderer.
+     *
+     * Specifying a stock id initializes this control cell renderer with
+     * a set of stock values.
+     *
+     * @var string
+     *
+     * @see AdminControlCellRenderer::setFromStock()
+     */
+    public $stock_id;
 
+    public function render()
+    {
+        if (!$this->visible) {
+            return;
+        }
 
-	/**
-	 * The stock id of this AdminControlCellRenderer
-	 *
-	 * Specifying a stock id initializes this control cell renderer with
-	 * a set of stock values.
-	 *
-	 * @var string
-	 *
-	 * @see AdminControlCellRenderer::setFromStock()
-	 */
-	public $stock_id = null;
+        if ($this->stock_id === null) {
+            $this->setFromStock('details', false);
+        } else {
+            $this->setFromStock($this->stock_id, false);
+        }
 
+        parent::render();
+    }
 
+    /**
+     * Sets the values of this control cell renderer to a stock type.
+     *
+     * Valid stock type ids are:
+     *
+     * - details (default)
+     * - edit
+     *
+     * @param string $stock_id             the identifier of the stock type to use
+     * @param bool   $overwrite_properties whether to overwrite properties if
+     *                                     they are already set
+     *
+     * @throws SwatUndefinedStockTypeException
+     */
+    public function setFromStock($stock_id, $overwrite_properties = true)
+    {
+        switch ($stock_id) {
+            case 'details':
+                $title = Admin::_('View Details');
+                $alt = Admin::_('Details');
+                $image = 'packages/admin/images/admin-generic-document.png';
+                $width = '22';
+                $height = '22';
+                break;
 
+            case 'edit':
+                $title = Admin::_('Edit');
+                $alt = Admin::_('Edit');
+                $image = 'packages/admin/images/admin-edit.png';
+                $width = '22';
+                $height = '22';
+                break;
 
-	public function render()
-	{
-		if (!$this->visible)
-			return;
+            default:
+                throw new SwatUndefinedStockTypeException(
+                    "Stock type with id of '{$stock_id}' not found.",
+                    0,
+                    $stock_id
+                );
+        }
 
-		if ($this->stock_id === null)
-			$this->setFromStock('details', false);
-		else
-			$this->setFromStock($this->stock_id, false);
+        if ($overwrite_properties || ($this->title === null)) {
+            $this->title = $title;
+        }
 
-		parent::render();
-	}
+        if ($overwrite_properties || ($this->alt === null)) {
+            $this->alt = $alt;
+        }
 
+        if ($overwrite_properties || ($this->image === null)) {
+            $this->image = $image;
+        }
 
+        if ($overwrite_properties || ($this->width === null)) {
+            $this->width = $width;
+        }
 
-
-	/**
-	 * Sets the values of this control cell renderer to a stock type
-	 *
-	 * Valid stock type ids are:
-	 *
-	 * - details (default)
-	 * - edit
-	 *
-	 * @param string $stock_id the identifier of the stock type to use.
-	 * @param boolean $overwrite_properties whether to overwrite properties if
-	 *                                       they are already set.
-	 *
-	 * @throws SwatUndefinedStockTypeException
-	 */
-	public function setFromStock($stock_id, $overwrite_properties = true)
-	{
-		switch ($stock_id) {
-		case 'details':
-			$title = Admin::_('View Details');
-			$alt = Admin::_('Details');
-			$image = 'packages/admin/images/admin-generic-document.png';
-			$width = '22';
-			$height = '22';
-			break;
-
-		case 'edit':
-			$title = Admin::_('Edit');
-			$alt = Admin::_('Edit');
-			$image = 'packages/admin/images/admin-edit.png';
-			$width = '22';
-			$height = '22';
-			break;
-
-		default:
-			throw new SwatUndefinedStockTypeException(
-				"Stock type with id of '{$stock_id}' not found.",
-				0, $stock_id);
-		}
-
-		if ($overwrite_properties || ($this->title === null))
-			$this->title = $title;
-
-		if ($overwrite_properties || ($this->alt === null))
-			$this->alt = $alt;
-
-		if ($overwrite_properties || ($this->image === null))
-			$this->image = $image;
-
-		if ($overwrite_properties || ($this->width === null))
-			$this->width = $width;
-
-		if ($overwrite_properties || ($this->height === null))
-			$this->height = $height;
-	}
-
-
+        if ($overwrite_properties || ($this->height === null)) {
+            $this->height = $height;
+        }
+    }
 }
-
-?>

--- a/Admin/AdminDateLinkCellRenderer.php
+++ b/Admin/AdminDateLinkCellRenderer.php
@@ -1,81 +1,69 @@
 <?php
 
 /**
- * Hybrid swat date/admin title link cell renderer for dates
+ * Hybrid swat date/admin title link cell renderer for dates.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDateLinkCellRenderer extends AdminTitleLinkCellRenderer
 {
+    /**
+     * Date to render.
+     *
+     * This may either be a SwatDate object, or may be an ISO-formatted date
+     * string that can be passed into the SwatDate constructor.
+     *
+     * @var string|SwatDate
+     */
+    public $date;
 
+    /**
+     * Format.
+     *
+     * Either a {@link SwatDate} format mask, or class constant. Class
+     * constants are preferable for sites that require translation.
+     *
+     * @var mixed
+     */
+    public $format = SwatDate::DF_DATE_TIME;
 
-	/**
-	 * Date to render
-	 *
-	 * This may either be a SwatDate object, or may be an ISO-formatted date
-	 * string that can be passed into the SwatDate constructor.
-	 *
-	 * @var string|SwatDate
-	 */
-	public $date = null;
+    /**
+     * Time Zone Format.
+     *
+     * A time zone format class constant from SwatDate.
+     *
+     * @var int
+     */
+    public $time_zone_format;
 
-	/**
-	 * Format
-	 *
-	 * Either a {@link SwatDate} format mask, or class constant. Class
-	 * constants are preferable for sites that require translation.
-	 *
-	 * @var mixed
-	 */
-	public $format = SwatDate::DF_DATE_TIME;
+    /**
+     * The time zone to render the date in.
+     *
+     * The time zone may be specified either as a time zone identifier valid
+     * for DateTimeZone or as a DateTimeZone object. If the render
+     * time zone is null, no time zone conversion is performed.
+     *
+     * @var DateTimeZone|string
+     */
+    public $display_time_zone;
 
-	/**
-	 * Time Zone Format
-	 *
-	 * A time zone format class constant from SwatDate.
-	 *
-	 * @var integer
-	 */
-	public $time_zone_format = null;
+    protected function getText()
+    {
+        $date_renderer = new SwatDateCellRenderer();
+        $date_renderer->date = $this->date;
+        $date_renderer->format = $this->format;
+        $date_renderer->time_zone_format = $this->time_zone_format;
+        $date_renderer->display_time_zone = $this->display_time_zone;
 
-	/**
-	 * The time zone to render the date in
-	 *
-	 * The time zone may be specified either as a time zone identifier valid
-	 * for DateTimeZone or as a DateTimeZone object. If the render
-	 * time zone is null, no time zone conversion is performed.
-	 *
-	 * @var string|DateTimeZone
-	 */
-	public $display_time_zone = null;
+        ob_start();
+        $date_renderer->render();
 
+        return ob_get_clean();
+    }
 
-
-
-	protected function getText()
-	{
-		$date_renderer = new SwatDateCellRenderer();
-		$date_renderer->date = $this->date;
-		$date_renderer->format = $this->format;
-		$date_renderer->time_zone_format = $this->time_zone_format;
-		$date_renderer->display_time_zone = $this->display_time_zone;
-
-		ob_start();
-		$date_renderer->render();
-		return ob_get_clean();
-	}
-
-
-
-
-	protected function getTitle()
-	{
-		return parent::getText();
-	}
-
-
+    protected function getTitle()
+    {
+        return parent::getText();
+    }
 }
-
-?>

--- a/Admin/AdminDateLinkCellRenderer.php
+++ b/Admin/AdminDateLinkCellRenderer.php
@@ -9,7 +9,7 @@
  */
 class AdminDateLinkCellRenderer extends AdminTitleLinkCellRenderer
 {
-	// {{{ public properties
+
 
 	/**
 	 * Date to render
@@ -51,8 +51,8 @@ class AdminDateLinkCellRenderer extends AdminTitleLinkCellRenderer
 	 */
 	public $display_time_zone = null;
 
-	// }}}
-	// {{{ protected function getText()
+
+
 
 	protected function getText()
 	{
@@ -67,15 +67,15 @@ class AdminDateLinkCellRenderer extends AdminTitleLinkCellRenderer
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ protected function getTitle()
+
+
 
 	protected function getTitle()
 	{
 		return parent::getText();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependency.php
+++ b/Admin/AdminDependency.php
@@ -270,7 +270,7 @@ abstract class AdminDependency
         $count = $this->getStatusLevelCount($status_level);
         $first = true;
 
-        /** @phpstan-ignore property.notFound */
+        // @phpstan-ignore property.notFound
         foreach ($this->entries as $entry) {
             if ($entry->status_level == $status_level) {
                 if ($first) {

--- a/Admin/AdminDependency.php
+++ b/Admin/AdminDependency.php
@@ -17,7 +17,7 @@
  */
 abstract class AdminDependency
 {
-	// {{{ constants
+
 
 	/**
 	 * Dependency items at this status level may be deleted
@@ -29,8 +29,8 @@ abstract class AdminDependency
 	 */
 	const NODELETE = 1;
 
-	// }}}
-	// {{{ public properties
+
+
 
 	/**
 	 * An array of possible status levels. Status levels are the categories
@@ -54,8 +54,8 @@ abstract class AdminDependency
 	 */
 	public $status_levels = null;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * A visible title for the type of items this dependency object deals with
@@ -77,8 +77,8 @@ abstract class AdminDependency
 	 */
 	public $plural_title = null;
 
-	// }}}
-	// {{{ private properties
+
+
 
 	/**
 	 * An array of sub-dependencies of this dependency
@@ -90,8 +90,8 @@ abstract class AdminDependency
 	 */
 	protected $dependencies = array();
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new dependency object
@@ -101,8 +101,8 @@ abstract class AdminDependency
 		$this->status_levels = array(self::DELETE, self::NODELETE);
 	}
 
-	// }}}
-	// {{{ public function setTitle()
+
+
 
 	/**
 	 * Sets the user-visible title of the type of items this dependency object
@@ -122,8 +122,8 @@ abstract class AdminDependency
 		$this->plural_title = $plural;
 	}
 
-	// }}}
-	// {{{ public function getMessage()
+
+
 
 	/**
 	 * Gets the dependency message
@@ -146,8 +146,8 @@ abstract class AdminDependency
 		return ob_get_clean();
 	}
 
-	// }}}
-	// {{{ public function display()
+
+
 
 	/**
 	 * Displays this dependency and all its sub-dependencies
@@ -158,8 +158,8 @@ abstract class AdminDependency
 			$this->displayStatusLevel($status_level);
 	}
 
-	// }}}
-	// {{{ public abstract function getStatusLevelCount()
+
+
 
 	/**
 	 * Gets the number of items in this dependency at a given status level
@@ -171,8 +171,8 @@ abstract class AdminDependency
 	 */
 	public abstract function getStatusLevelCount($status_level);
 
-	// }}}
-	// {{{ public abstract function getItemCount()
+
+
 
 	/**
 	 * Gets the number of items in this dependency
@@ -181,8 +181,8 @@ abstract class AdminDependency
 	 */
 	public abstract function getItemCount();
 
-	// }}}
-	// {{{ public abstract function displayDependencies()
+
+
 
 	/**
 	 * Displays the dependency items of this dependency for a given parent
@@ -195,8 +195,8 @@ abstract class AdminDependency
 	 */
 	public abstract function displayDependencies($parent, $status_level);
 
-	// }}}
-	// {{{ public abstract function processItemStatuses()
+
+
 
 	/**
 	 * Figures out the status level of all dependency items of this dependency
@@ -214,8 +214,8 @@ abstract class AdminDependency
 	 */
 	public abstract function processItemStatuses($parent = null);
 
-	// }}}
-	// {{{ protected function getStatusLevelText()
+
+
 
 	/**
 	 * Gets the text representing a status level of this dependency
@@ -260,8 +260,8 @@ abstract class AdminDependency
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getTitle()
+
+
 
 	/**
 	 * Helper method to get an appropriate title for the type of item this
@@ -289,8 +289,8 @@ abstract class AdminDependency
 		}
 	}
 
-	// }}}
-	// {{{ protected function displayStatusLevel()
+
+
 
 	/**
 	 * Displays all the dependency entries at a single status level for this
@@ -331,8 +331,8 @@ abstract class AdminDependency
 			echo '</ul>';
 	}
 
-	// }}}
-	// {{{ protected function displayStatusLevelHeader()
+
+
 
 	protected function displayStatusLevelHeader($status_level, $count)
 	{
@@ -343,7 +343,7 @@ abstract class AdminDependency
 		$header_tag->display();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependency.php
+++ b/Admin/AdminDependency.php
@@ -270,6 +270,7 @@ abstract class AdminDependency
         $count = $this->getStatusLevelCount($status_level);
         $first = true;
 
+        /** @phpstan-ignore property.notFound */
         foreach ($this->entries as $entry) {
             if ($entry->status_level == $status_level) {
                 if ($first) {

--- a/Admin/AdminDependency.php
+++ b/Admin/AdminDependency.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Dependency message class
+ * Dependency message class.
  *
  * This class provides a standard way to display hierachal dependencies.
  * The typical use for this class is for displaying items to be deleted on a
@@ -10,340 +10,301 @@
  * The items can be categorized into status levels (eg, DELETE and NODELETE)
  * based upon the existence of dependencies.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminDBDelete, AdminListDependency, AdminSummaryDependency
  */
 abstract class AdminDependency
 {
-
-
-	/**
-	 * Dependency items at this status level may be deleted
-	 */
-	const DELETE = 0;
-
-	/**
-	 * Dependency items at this status level can not be deleted
-	 */
-	const NODELETE = 1;
-
-
-
-
-	/**
-	 * An array of possible status levels. Status levels are the categories
-	 * that dependency items are sorted into when this dependency is displayed.
-	 * The two most common levels -- also the default levels -- are
-	 * "DELETE" and "NODELETE".
-	 *
-	 * Status levels are integers where a higher value indicates a higher
-	 * priority as compared to other status levels.
-	 *
-	 * By default two status levels are available:
-	 *
-	 * <code>
-	 * array(
-	 *     self::DELETE,
-	 *     self::NODELETE
-	 * );
-	 * </code>
-	 *
-	 * @var array
-	 */
-	public $status_levels = null;
-
-
-
-
-	/**
-	 * A visible title for the type of items this dependency object deals with
-	 * (singular form)
-	 *
-	 * @var string
-	 *
-	 * @see AdminDependency::setTitle()
-	 */
-	public $singular_title = null;
-
-	/**
-	 * A visible title for the type of items this dependency object deals with
-	 * (plural form)
-	 *
-	 * @var string
-	 *
-	 * @see AdminDependency::setTitle()
-	 */
-	public $plural_title = null;
-
-
-
-
-	/**
-	 * An array of sub-dependencies of this dependency
-	 *
-	 * This is an array of {@link AdminDependency} objects that allows a tree
-	 * of {@link AdminDependencyItem} objects to be created.
-	 *
-	 * @var array
-	 */
-	protected $dependencies = array();
-
-
-
-
-	/**
-	 * Creates a new dependency object
-	 */
-	public function __construct()
-	{
-		$this->status_levels = array(self::DELETE, self::NODELETE);
-	}
-
-
-
-
-	/**
-	 * Sets the user-visible title of the type of items this dependency object
-	 * deals with
-	 *
-	 * Both the singular and plural forms are required when setting the title.
-	 * Titles should be all lowercase, not title-case.
-	 *
-	 * @param string $singular a visible title for the type of items this
-	 *                          dependency object deals with (singular form).
-	 * @param string $plural a visible title for the type of items this
-	 *                          dependency object deals with (plural form).
-	 */
-	public function setTitle($singular, $plural)
-	{
-		$this->singular_title = $singular;
-		$this->plural_title = $plural;
-	}
-
-
-
-
-	/**
-	 * Gets the dependency message
-	 *
-	 * Retrieves the dependency message ready for display. When using a tree of
-	 * {@link AdminDependency} objects, this should be called on the
-	 * root object.
-	 *
-	 * @return string the XHTML structured dependency message.
-	 */
-	public function getMessage()
-	{
-		if ($this->getItemCount() == 0)
-			return '';
-
-		$this->processItemStatuses();
-
-		ob_start();
-		$this->display();
-		return ob_get_clean();
-	}
-
-
-
-
-	/**
-	 * Displays this dependency and all its sub-dependencies
-	 */
-	public function display()
-	{
-		foreach ($this->status_levels as $status_level)
-			$this->displayStatusLevel($status_level);
-	}
-
-
-
-
-	/**
-	 * Gets the number of items in this dependency at a given status level
-	 *
-	 * @param integer $status_level the status level to count items in.
-	 *
-	 * @return integer the number of items at the given status level in this
-	 *                  dependency.
-	 */
-	public abstract function getStatusLevelCount($status_level);
-
-
-
-
-	/**
-	 * Gets the number of items in this dependency
-	 *
-	 * @return integer the number of items in this dependency.
-	 */
-	public abstract function getItemCount();
-
-
-
-
-	/**
-	 * Displays the dependency items of this dependency for a given parent
-	 * at a given status level
-	 *
-	 * @param integer $parent the id of the parent to display the dependency
-	 *                         items for.
-	 * @param integer $status_level the status level to display the dependency
-	 *                               items for.
-	 */
-	public abstract function displayDependencies($parent, $status_level);
-
-
-
-
-	/**
-	 * Figures out the status level of all dependency items of this dependency
-	 *
-	 * If any child elements have a higher priority status than their parents,
-	 * the status level of the parent is set to the status level of the
-	 * child with the highest priority.
-	 *
-	 * @param mixed $parent the id of the parent of the items to process. If
-	 *                       the parent id is not specified, all items are
-	 *                       processed.
-	 *
-	 * @return integer the highest priority status level of the processed
-	 *                  items.
-	 */
-	public abstract function processItemStatuses($parent = null);
-
-
-
-
-	/**
-	 * Gets the text representing a status level of this dependency
-	 *
-	 * Sub-classes may override this method to have more descriptive or
-	 * meaningful text. If the text for a non-existant status level in this
-	 * dependency is requested an exception is thrown.
-	 *
-	 * @param integer $status_level the status level to get the textual
-	 *                               representation of.
-	 * @param integer $count the number of items at the given status level.
-	 *
-	 * @return string the textual representation of the given status level.
-	 *
-	 * @thows SwatException
-	 */
-	protected function getStatusLevelText($status_level, $count)
-	{
-		switch ($status_level) {
-		case self::DELETE:
-			$title = $this->getTitle($count);
-			$message = Admin::ngettext(
-				'Delete the following %s?',
-				'Delete the following %s?', $count);
-
-			$message = sprintf($message, $title);
-			break;
-
-		case self::NODELETE:
-			$title = $this->getTitle($count);
-			$message = Admin::ngettext(
-				'The following %s can not be deleted:',
-				'The following %s can not be deleted:', $count);
-
-			$message = sprintf($message, $title);
-			break;
-
-		default:
-			throw new SwatException('Unknown status level text requested in '.
-				'AdminDependency.');
-		}
-		return $message;
-	}
-
-
-
-
-	/**
-	 * Helper method to get an appropriate title for the type of item this
-	 * dependency object deal with
-	 *
-	 * This is set with {@link AdminDependency::setTitle()}. If the title is
-	 * not set on this object, a generic text of 'item' or 'items' is returned.
-	 *
-	 * @param integer $count the number of items to get the title for. This
-	 *                        determines whether the singular or plural form is
-	 *                        returned.
-	 *
-	 * @return string an appropriate title for the type of item this dependency
-	 *                 object deals with.
-	 */
-	protected function getTitle($count)
-	{
-		// Note: ngettext() is intentionally used here instead of
-		// Admin::ngettext(). Developers are responsible for translating the
-		// values passed to setTitle().
-		if ($this->singular_title === null || $this->plural_title === null) {
-			return ngettext('item', 'items', $count);
-		} else {
-			return ngettext($this->singular_title, $this->plural_title, $count);
-		}
-	}
-
-
-
-
-	/**
-	 * Displays all the dependency entries at a single status level for this
-	 * dependency
-	 *
-	 * @param integer $status_level the status level to display dependency
-	 *                               entries for.
-	 *
-	 * TODO: this is in the wrong place.
-	 */
-	protected function displayStatusLevel($status_level)
-	{
-		$count = $this->getStatusLevelCount($status_level);
-		$first = true;
-
-		foreach ($this->entries as $entry) {
-			if ($entry->status_level == $status_level) {
-				if ($first) {
-					$this->displayStatusLevelHeader($status_level, $count);
-					echo '<ul>';
-					$first = false;
-				}
-
-				echo '<li>';
-
-				if ($entry->content_type == 'text/xml')
-					echo $entry->title;
-				else
-					echo SwatString::minimizeEntities($entry->title);
-
-				foreach ($this->dependencies as $dep)
-					$dep->displayDependencies($entry->id, $status_level);
-
-				echo '</li>';
-			}
-		}
-		if ($count > 0)
-			echo '</ul>';
-	}
-
-
-
-
-	protected function displayStatusLevelHeader($status_level, $count)
-	{
-		$header_tag = new SwatHtmlTag('h3');
-		$header_tag->setContent(
-			$this->getStatusLevelText($status_level, $count));
-
-		$header_tag->display();
-	}
-
-
+    /**
+     * Dependency items at this status level may be deleted.
+     */
+    public const DELETE = 0;
+
+    /**
+     * Dependency items at this status level can not be deleted.
+     */
+    public const NODELETE = 1;
+
+    /**
+     * An array of possible status levels. Status levels are the categories
+     * that dependency items are sorted into when this dependency is displayed.
+     * The two most common levels -- also the default levels -- are
+     * "DELETE" and "NODELETE".
+     *
+     * Status levels are integers where a higher value indicates a higher
+     * priority as compared to other status levels.
+     *
+     * By default two status levels are available:
+     *
+     * <code>
+     * array(
+     *     self::DELETE,
+     *     self::NODELETE
+     * );
+     * </code>
+     *
+     * @var array
+     */
+    public $status_levels;
+
+    /**
+     * A visible title for the type of items this dependency object deals with
+     * (singular form).
+     *
+     * @var string
+     *
+     * @see AdminDependency::setTitle()
+     */
+    public $singular_title;
+
+    /**
+     * A visible title for the type of items this dependency object deals with
+     * (plural form).
+     *
+     * @var string
+     *
+     * @see AdminDependency::setTitle()
+     */
+    public $plural_title;
+
+    /**
+     * An array of sub-dependencies of this dependency.
+     *
+     * This is an array of {@link AdminDependency} objects that allows a tree
+     * of {@link AdminDependencyItem} objects to be created.
+     *
+     * @var array
+     */
+    protected $dependencies = [];
+
+    /**
+     * Creates a new dependency object.
+     */
+    public function __construct()
+    {
+        $this->status_levels = [self::DELETE, self::NODELETE];
+    }
+
+    /**
+     * Sets the user-visible title of the type of items this dependency object
+     * deals with.
+     *
+     * Both the singular and plural forms are required when setting the title.
+     * Titles should be all lowercase, not title-case.
+     *
+     * @param string $singular a visible title for the type of items this
+     *                         dependency object deals with (singular form)
+     * @param string $plural   a visible title for the type of items this
+     *                         dependency object deals with (plural form)
+     */
+    public function setTitle($singular, $plural)
+    {
+        $this->singular_title = $singular;
+        $this->plural_title = $plural;
+    }
+
+    /**
+     * Gets the dependency message.
+     *
+     * Retrieves the dependency message ready for display. When using a tree of
+     * {@link AdminDependency} objects, this should be called on the
+     * root object.
+     *
+     * @return string the XHTML structured dependency message
+     */
+    public function getMessage()
+    {
+        if ($this->getItemCount() == 0) {
+            return '';
+        }
+
+        $this->processItemStatuses();
+
+        ob_start();
+        $this->display();
+
+        return ob_get_clean();
+    }
+
+    /**
+     * Displays this dependency and all its sub-dependencies.
+     */
+    public function display()
+    {
+        foreach ($this->status_levels as $status_level) {
+            $this->displayStatusLevel($status_level);
+        }
+    }
+
+    /**
+     * Gets the number of items in this dependency at a given status level.
+     *
+     * @param int $status_level the status level to count items in
+     *
+     * @return int the number of items at the given status level in this
+     *             dependency
+     */
+    abstract public function getStatusLevelCount($status_level);
+
+    /**
+     * Gets the number of items in this dependency.
+     *
+     * @return int the number of items in this dependency
+     */
+    abstract public function getItemCount();
+
+    /**
+     * Displays the dependency items of this dependency for a given parent
+     * at a given status level.
+     *
+     * @param int $parent       the id of the parent to display the dependency
+     *                          items for
+     * @param int $status_level the status level to display the dependency
+     *                          items for
+     */
+    abstract public function displayDependencies($parent, $status_level);
+
+    /**
+     * Figures out the status level of all dependency items of this dependency.
+     *
+     * If any child elements have a higher priority status than their parents,
+     * the status level of the parent is set to the status level of the
+     * child with the highest priority.
+     *
+     * @param mixed $parent the id of the parent of the items to process. If
+     *                      the parent id is not specified, all items are
+     *                      processed.
+     *
+     * @return int the highest priority status level of the processed
+     *             items
+     */
+    abstract public function processItemStatuses($parent = null);
+
+    /**
+     * Gets the text representing a status level of this dependency.
+     *
+     * Sub-classes may override this method to have more descriptive or
+     * meaningful text. If the text for a non-existant status level in this
+     * dependency is requested an exception is thrown.
+     *
+     * @param int $status_level the status level to get the textual
+     *                          representation of
+     * @param int $count        the number of items at the given status level
+     *
+     * @return string the textual representation of the given status level
+     *
+     * @thows SwatException
+     */
+    protected function getStatusLevelText($status_level, $count)
+    {
+        switch ($status_level) {
+            case self::DELETE:
+                $title = $this->getTitle($count);
+                $message = Admin::ngettext(
+                    'Delete the following %s?',
+                    'Delete the following %s?',
+                    $count
+                );
+
+                $message = sprintf($message, $title);
+                break;
+
+            case self::NODELETE:
+                $title = $this->getTitle($count);
+                $message = Admin::ngettext(
+                    'The following %s can not be deleted:',
+                    'The following %s can not be deleted:',
+                    $count
+                );
+
+                $message = sprintf($message, $title);
+                break;
+
+            default:
+                throw new SwatException('Unknown status level text requested in ' .
+                    'AdminDependency.');
+        }
+
+        return $message;
+    }
+
+    /**
+     * Helper method to get an appropriate title for the type of item this
+     * dependency object deal with.
+     *
+     * This is set with {@link AdminDependency::setTitle()}. If the title is
+     * not set on this object, a generic text of 'item' or 'items' is returned.
+     *
+     * @param int $count the number of items to get the title for. This
+     *                   determines whether the singular or plural form is
+     *                   returned.
+     *
+     * @return string an appropriate title for the type of item this dependency
+     *                object deals with
+     */
+    protected function getTitle($count)
+    {
+        // Note: ngettext() is intentionally used here instead of
+        // Admin::ngettext(). Developers are responsible for translating the
+        // values passed to setTitle().
+        if ($this->singular_title === null || $this->plural_title === null) {
+            return ngettext('item', 'items', $count);
+        }
+
+        return ngettext($this->singular_title, $this->plural_title, $count);
+    }
+
+    /**
+     * Displays all the dependency entries at a single status level for this
+     * dependency.
+     *
+     * @param int $status_level the status level to display dependency
+     *                          entries for.
+     *
+     * TODO: this is in the wrong place.
+     */
+    protected function displayStatusLevel($status_level)
+    {
+        $count = $this->getStatusLevelCount($status_level);
+        $first = true;
+
+        foreach ($this->entries as $entry) {
+            if ($entry->status_level == $status_level) {
+                if ($first) {
+                    $this->displayStatusLevelHeader($status_level, $count);
+                    echo '<ul>';
+                    $first = false;
+                }
+
+                echo '<li>';
+
+                if ($entry->content_type == 'text/xml') {
+                    echo $entry->title;
+                } else {
+                    echo SwatString::minimizeEntities($entry->title);
+                }
+
+                foreach ($this->dependencies as $dep) {
+                    $dep->displayDependencies($entry->id, $status_level);
+                }
+
+                echo '</li>';
+            }
+        }
+        if ($count > 0) {
+            echo '</ul>';
+        }
+    }
+
+    protected function displayStatusLevelHeader($status_level, $count)
+    {
+        $header_tag = new SwatHtmlTag('h3');
+        $header_tag->setContent(
+            $this->getStatusLevelText($status_level, $count)
+        );
+
+        $header_tag->display();
+    }
 }
-
-?>

--- a/Admin/AdminDependencyEntry.php
+++ b/Admin/AdminDependencyEntry.php
@@ -9,7 +9,7 @@
  */
 class AdminDependencyEntry extends AdminDependencyItem
 {
-	// {{{ public properties
+
 
 	/**
 	 * Identifier for this entry
@@ -37,8 +37,8 @@ class AdminDependencyEntry extends AdminDependencyItem
 	 */
 	public $content_type = 'text/plain';
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new AdminDependencyEntry
@@ -59,7 +59,7 @@ class AdminDependencyEntry extends AdminDependencyItem
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependencyEntry.php
+++ b/Admin/AdminDependencyEntry.php
@@ -1,65 +1,55 @@
 <?php
 
 /**
- * An entry in an admin dependency
+ * An entry in an admin dependency.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDependencyEntry extends AdminDependencyItem
 {
+    /**
+     * Identifier for this entry.
+     *
+     * This is usually a database primary key value or a single field value in
+     * a binding table.
+     *
+     * @var mixed
+     */
+    public $id;
 
+    /**
+     * Title for display.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * Identifier for this entry
-	 *
-	 * This is usually a database primary key value or a single field value in
-	 * a binding table.
-	 *
-	 * @var mixed
-	 */
-	public $id;
+    /**
+     * Content type of the title.
+     *
+     * Defaults to 'text/plain'. Use 'text/xml' for XHTML fragments.
+     *
+     * @var string
+     */
+    public $content_type = 'text/plain';
 
-	/**
-	 * Title for display
-	 *
-	 * @var string
-	 */
-	public $title;
-
-	/**
-	 * Content type of the title
-	 *
-	 * Defaults to 'text/plain'. Use 'text/xml' for XHTML fragments.
-	 *
-	 * @var string
-	 */
-	public $content_type = 'text/plain';
-
-
-
-
-	/**
-	 * Creates a new AdminDependencyEntry
-	 *
-	 * This constructor enables the entry to be used in a MDB2 data wrapper
-	 * to automatically create objects from a result set.
-	 *
-	 * @param mixed $data the MDB2 row containing the data for this entry
-	 *                     object.
-	 */
-	public function __construct($data = null)
-	{
-		if ($data !== null) {
-			$this->id = $data->id;
-			$this->title = $data->title;
-			$this->parent = $data->parent;
-			$this->status_level = $data->status_level;
-		}
-	}
-
-
+    /**
+     * Creates a new AdminDependencyEntry.
+     *
+     * This constructor enables the entry to be used in a MDB2 data wrapper
+     * to automatically create objects from a result set.
+     *
+     * @param mixed $data the MDB2 row containing the data for this entry
+     *                    object
+     */
+    public function __construct($data = null)
+    {
+        if ($data !== null) {
+            $this->id = $data->id;
+            $this->title = $data->title;
+            $this->parent = $data->parent;
+            $this->status_level = $data->status_level;
+        }
+    }
 }
-
-?>

--- a/Admin/AdminDependencyEntryWrapper.php
+++ b/Admin/AdminDependencyEntryWrapper.php
@@ -1,22 +1,14 @@
 <?php
 
 /**
- *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDependencyEntryWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminDependencyEntry';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminDependencyEntry';
+    }
 }
-
-?>

--- a/Admin/AdminDependencyEntryWrapper.php
+++ b/Admin/AdminDependencyEntryWrapper.php
@@ -9,6 +9,6 @@ class AdminDependencyEntryWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminDependencyEntry';
+        $this->row_wrapper_class = AdminDependencyEntry::class;
     }
 }

--- a/Admin/AdminDependencyEntryWrapper.php
+++ b/Admin/AdminDependencyEntryWrapper.php
@@ -8,7 +8,7 @@
  */
 class AdminDependencyEntryWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -16,7 +16,7 @@ class AdminDependencyEntryWrapper extends SwatDBRecordsetWrapper
 		$this->row_wrapper_class = 'AdminDependencyEntry';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependencyItem.php
+++ b/Admin/AdminDependencyItem.php
@@ -10,7 +10,7 @@
  */
 abstract class AdminDependencyItem
 {
-	// {{{ public properties
+
 
 	/**
 	 * Initial status level of this entry (eg, DELETE, NODELETE).
@@ -31,7 +31,7 @@ abstract class AdminDependencyItem
 	 */
 	public $parent = null;
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependencyItem.php
+++ b/Admin/AdminDependencyItem.php
@@ -1,37 +1,31 @@
 <?php
 
 /**
- * An item in an admin dependency
+ * An item in an admin dependency.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminDependencyEntry, AdminDependencySummary
  */
 abstract class AdminDependencyItem
 {
+    /**
+     * Initial status level of this entry (eg, DELETE, NODELETE).
+     *
+     * @var int
+     *
+     * @see AdminDependency
+     */
+    public $status_level = AdminDependency::NODELETE;
 
-
-	/**
-	 * Initial status level of this entry (eg, DELETE, NODELETE).
-	 *
-	 * @var integer
-	 *
-	 * @see AdminDependency
-	 */
-	public $status_level = AdminDependency::NODELETE;
-
-	/**
-	 * Id of the parent item
-	 *
-	 * An identifier that references a parent item in a parent
-	 * {@link AdminDependency} object.
-	 *
-	 * @var mixed
-	 */
-	public $parent = null;
-
-
+    /**
+     * Id of the parent item.
+     *
+     * An identifier that references a parent item in a parent
+     * {@link AdminDependency} object.
+     *
+     * @var mixed
+     */
+    public $parent;
 }
-
-?>

--- a/Admin/AdminDependencySummary.php
+++ b/Admin/AdminDependencySummary.php
@@ -1,46 +1,35 @@
 <?php
 
 /**
- * A dependency summary that contains a count of items
+ * A dependency summary that contains a count of items.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDependencySummary extends AdminDependencyItem
 {
+    /**
+     * The number of items in this summary.
+     *
+     * @var int
+     */
+    public $count;
 
-
-	/**
-	 * The number of items in this summary
-	 *
-	 * @var integer
-	 */
-	public $count;
-
-
-
-
-	/**
-	 * Creates a new AdminDependencySummary
-	 *
-	 * This constructor enables the entry to be used in a MDB2 data wrapper
-	 * to automatically create objects from a result set.
-	 *
-	 * @param mixed $data the MDB2 row containing the data for this summary
-	 *                     object.
-	 */
-	public function __construct($data = null)
-	{
-		if ($data !== null) {
-			$this->count = $data->count;
-			$this->parent = $data->parent;
-			$this->status_level = $data->status_level;
-		}
-	}
-
-
-
+    /**
+     * Creates a new AdminDependencySummary.
+     *
+     * This constructor enables the entry to be used in a MDB2 data wrapper
+     * to automatically create objects from a result set.
+     *
+     * @param mixed $data the MDB2 row containing the data for this summary
+     *                    object
+     */
+    public function __construct($data = null)
+    {
+        if ($data !== null) {
+            $this->count = $data->count;
+            $this->parent = $data->parent;
+            $this->status_level = $data->status_level;
+        }
+    }
 }
-
-?>

--- a/Admin/AdminDependencySummary.php
+++ b/Admin/AdminDependencySummary.php
@@ -9,7 +9,7 @@
  */
 class AdminDependencySummary extends AdminDependencyItem
 {
-	// {{{ public properties
+
 
 	/**
 	 * The number of items in this summary
@@ -18,8 +18,8 @@ class AdminDependencySummary extends AdminDependencyItem
 	 */
 	public $count;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new AdminDependencySummary
@@ -39,7 +39,7 @@ class AdminDependencySummary extends AdminDependencyItem
 		}
 	}
 
-	// }}}
+
 
 }
 

--- a/Admin/AdminDependencySummaryWrapper.php
+++ b/Admin/AdminDependencySummaryWrapper.php
@@ -8,7 +8,7 @@
  */
 class AdminDependencySummaryWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -16,7 +16,7 @@ class AdminDependencySummaryWrapper extends SwatDBRecordsetWrapper
 		$this->row_wrapper_class = 'AdminDependencySummary';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminDependencySummaryWrapper.php
+++ b/Admin/AdminDependencySummaryWrapper.php
@@ -9,6 +9,6 @@ class AdminDependencySummaryWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminDependencySummary';
+        $this->row_wrapper_class = AdminDependencySummary::class;
     }
 }

--- a/Admin/AdminDependencySummaryWrapper.php
+++ b/Admin/AdminDependencySummaryWrapper.php
@@ -1,22 +1,14 @@
 <?php
 
 /**
- *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDependencySummaryWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminDependencySummary';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminDependencySummary';
+    }
 }
-
-?>

--- a/Admin/AdminGroupLinkCellRenderer.php
+++ b/Admin/AdminGroupLinkCellRenderer.php
@@ -9,7 +9,7 @@
  */
 class AdminGroupLinkCellRenderer extends SwatLinkCellRenderer
 {
-	// {{{ public function __construct()
+
 
 	public function __construct()
 	{
@@ -20,8 +20,8 @@ class AdminGroupLinkCellRenderer extends SwatLinkCellRenderer
 		);
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
+
+
 
 	/**
 	 * Gets the array of CSS classes that are applied to this user-interface
@@ -42,7 +42,7 @@ class AdminGroupLinkCellRenderer extends SwatLinkCellRenderer
 		return array_merge($classes, $this->classes);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminGroupLinkCellRenderer.php
+++ b/Admin/AdminGroupLinkCellRenderer.php
@@ -1,48 +1,38 @@
 <?php
 
 /**
- * A link cell renderer to display in group headers
+ * A link cell renderer to display in group headers.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminGroupLinkCellRenderer extends SwatLinkCellRenderer
 {
+    public function __construct()
+    {
+        parent::__construct();
 
+        $this->addStyleSheet(
+            'packages/admin/styles/admin-group-link-cell-renderer.css'
+        );
+    }
 
-	public function __construct()
-	{
-		parent::__construct();
+    /**
+     * Gets the array of CSS classes that are applied to this user-interface
+     * object.
+     *
+     * User-interface objects aggregate the list of user-specified classes and
+     * may add static CSS classes of their own in this method.
+     *
+     * @return array the array of CSS classes that are applied to this
+     *               user-interface object
+     *
+     * @see SwatUIObject::getCSSClassString()
+     */
+    protected function getCSSClassNames()
+    {
+        $classes = ['admin-group-link-cell-renderer'];
 
-		$this->addStyleSheet(
-			'packages/admin/styles/admin-group-link-cell-renderer.css'
-		);
-	}
-
-
-
-
-	/**
-	 * Gets the array of CSS classes that are applied to this user-interface
-	 * object
-	 *
-	 * User-interface objects aggregate the list of user-specified classes and
-	 * may add static CSS classes of their own in this method.
-	 *
-	 * @return array the array of CSS classes that are applied to this
-	 *                user-interface object.
-	 *
-	 * @see SwatUIObject::getCSSClassString()
-	 */
-	protected function getCSSClassNames()
-	{
-		$classes = array('admin-group-link-cell-renderer');
-
-		return array_merge($classes, $this->classes);
-	}
-
-
+        return array_merge($classes, $this->classes);
+    }
 }
-
-?>

--- a/Admin/AdminImportantNavBarEntry.php
+++ b/Admin/AdminImportantNavBarEntry.php
@@ -1,16 +1,11 @@
 <?php
 
 /**
- * An important entry for the admin navigation tool
+ * An important entry for the admin navigation tool.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
  * @see SwatNavBarEntry
  */
-class AdminImportantNavBarEntry extends SwatNavBarEntry
-{
-}
-
-?>
+class AdminImportantNavBarEntry extends SwatNavBarEntry {}

--- a/Admin/AdminListDependency.php
+++ b/Admin/AdminListDependency.php
@@ -9,7 +9,7 @@
  */
 class AdminListDependency extends AdminDependency
 {
-	// {{{ public properties
+
 
 	/**
 	 * Array of {@link AdminDependencyEntry} objects to be displayed
@@ -26,8 +26,8 @@ class AdminListDependency extends AdminDependency
 	 */
 	public $entries = array();
 
-	// }}}
-	// {{{ public function addDependency()
+
+
 
 	/**
 	 * Adds a sub-dependency
@@ -43,8 +43,8 @@ class AdminListDependency extends AdminDependency
 		$this->dependencies[] = $dep;
 	}
 
-	// }}}
-	// {{{ public function getStatusLevelCount()
+
+
 
 	/**
 	 * Gets the number of entries in this dependency at a given status level
@@ -64,8 +64,8 @@ class AdminListDependency extends AdminDependency
 		return $count;
 	}
 
-	// }}}
-	// {{{ public function getItemCount()
+
+
 
 	/**
 	 * Gets the number of entries in this dependency
@@ -77,8 +77,8 @@ class AdminListDependency extends AdminDependency
 		return count($this->entries);
 	}
 
-	// }}}
-	// {{{ public function processItemStatuses()
+
+
 
 	/**
 	 * Processes the status level of entries in this dependency
@@ -104,8 +104,8 @@ class AdminListDependency extends AdminDependency
 		return $return;
 	}
 
-	// }}}
-	// {{{ public function displayDependencies()
+
+
 
 	/**
 	 * Displays a list of the dependency entries of this dependency for a given
@@ -155,8 +155,8 @@ class AdminListDependency extends AdminDependency
 			echo '</ul>';
 	}
 
-	// }}}
-	// {{{ public static function queryEntries()
+
+
 
 	/**
 	 * Queries for dependency entries
@@ -252,8 +252,8 @@ class AdminListDependency extends AdminDependency
 		return $entry_array;
 	}
 
-	// }}}
-	// {{{ public static function buildEntriesArray()
+
+
 
 	/**
 	 * Builds an array of dependency entries
@@ -303,8 +303,8 @@ class AdminListDependency extends AdminDependency
 		return $entries;
 	}
 
-	// }}}
-	// {{{ protected function getDependencyText()
+
+
 
 	/**
 	 * Gets the text for a dependency list for this dependency
@@ -327,7 +327,7 @@ class AdminListDependency extends AdminDependency
 		return $message;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminListDependency.php
+++ b/Admin/AdminListDependency.php
@@ -1,333 +1,315 @@
 <?php
 
 /**
- * A dependency that displays a list of entries
+ * A dependency that displays a list of entries.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminListDependency extends AdminDependency
 {
+    /**
+     * Array of {@link AdminDependencyEntry} objects to be displayed.
+     *
+     * While this is a flat array, the objects in the array contain tree
+     * structure information in their properties.
+     *
+     * Such an array may be automatically constructed from database data by
+     * calling the static convenience method
+     * {@link AdminListDependency::queryEntries()}.
+     *
+     * @var array
+     *
+     * @see AdminDependencyEntry, AdminDependencyEntryWrapper
+     */
+    public $entries = [];
 
+    /**
+     * Adds a sub-dependency.
+     *
+     * Adds another AdminDependency object as a sub-dependency of this one.
+     * The parent fields within the items of the sub-dependency object should
+     * correspond to the id fields of the entries of this dependency.
+     *
+     * @param AdminDependency $dep the sub-dependency to add
+     */
+    public function addDependency(AdminDependency $dep)
+    {
+        $this->dependencies[] = $dep;
+    }
 
-	/**
-	 * Array of {@link AdminDependencyEntry} objects to be displayed
-	 *
-	 * While this is a flat array, the objects in the array contain tree
-	 * structure information in their properties.
-	 *
-	 * Such an array may be automatically constructed from database data by
-	 * calling the static convenience method
-	 * {@link AdminListDependency::queryEntries()}.
-	 *
-	 * @var array
-	 * @see AdminDependencyEntry, AdminDependencyEntryWrapper
-	 */
-	public $entries = array();
+    /**
+     * Gets the number of entries in this dependency at a given status level.
+     *
+     * @param int $status_level the status level to count entries in
+     *
+     * @return int the number of entries at the given status level in this
+     *             dependency
+     */
+    public function getStatusLevelCount($status_level)
+    {
+        $count = 0;
+        foreach ($this->entries as &$entry) {
+            if ($entry->status_level === $status_level) {
+                $count++;
+            }
+        }
 
+        return $count;
+    }
 
+    /**
+     * Gets the number of entries in this dependency.
+     *
+     * @return int the number of entries in this dependency
+     */
+    public function getItemCount()
+    {
+        return count($this->entries);
+    }
 
+    /**
+     * Processes the status level of entries in this dependency.
+     *
+     * @param $parent mixed the parent identifier of entries to process
+     *
+     * @see AdminDependency::processItemStatuses()
+     */
+    public function processItemStatuses($parent = null)
+    {
+        $return = self::DELETE;
 
-	/**
-	 * Adds a sub-dependency
-	 *
-	 * Adds another AdminDependency object as a sub-dependency of this one.
-	 * The parent fields within the items of the sub-dependency object should
-	 * correspond to the id fields of the entries of this dependency.
-	 *
-	 * @param AdminDependency $dep the sub-dependency to add.
-	 */
-	public function addDependency(AdminDependency $dep)
-	{
-		$this->dependencies[] = $dep;
-	}
+        foreach ($this->entries as $entry) {
+            if ($parent === null || $entry->parent === $parent) {
+                foreach ($this->dependencies as $dep) {
+                    $entry->status_level = max(
+                        $entry->status_level,
+                        $dep->processItemStatuses($entry->id)
+                    );
+                }
+                $return = max($return, $entry->status_level);
+            }
+        }
 
+        return $return;
+    }
 
+    /**
+     * Displays a list of the dependency entries of this dependency for a given
+     * parent at a given status level.
+     *
+     * @param int $parent       the id of the parent to display the list for
+     * @param int $status_level the status level to display the list for
+     */
+    public function displayDependencies($parent, $status_level)
+    {
+        $count = 0;
+        foreach ($this->entries as $entry) {
+            if ($entry->parent == $parent
+                && $entry->status_level == $status_level) {
+                $count++;
+            }
+        }
 
+        $first = true;
 
-	/**
-	 * Gets the number of entries in this dependency at a given status level
-	 *
-	 * @param integer $status_level the status level to count entries in.
-	 *
-	 * @return integer the number of entries at the given status level in this
-	 *                  dependency.
-	 */
-	public function getStatusLevelCount($status_level)
-	{
-		$count = 0;
-		foreach ($this->entries as &$entry)
-			if ($entry->status_level === $status_level)
-				$count++;
+        foreach ($this->entries as $entry) {
+            if ($entry->parent == $parent
+                && $entry->status_level == $status_level) {
+                if ($first) {
+                    echo '<br />';
+                    echo SwatString::minimizeEntities(
+                        $this->getDependencyText($count)
+                    );
 
-		return $count;
-	}
+                    echo '<ul>';
+                    $first = false;
+                }
 
+                echo '<li>';
 
+                if ($entry->content_type == 'text/xml') {
+                    echo $entry->title;
+                } else {
+                    echo SwatString::minimizeEntities($entry->title);
+                }
 
+                foreach ($this->dependencies as $dep) {
+                    $dep->displayDependencies($entry->id, $status_level);
+                }
 
-	/**
-	 * Gets the number of entries in this dependency
-	 *
-	 * @return integer the number of entries in this dependency.
-	 */
-	public function getItemCount()
-	{
-		return count($this->entries);
-	}
+                echo '</li>';
+            }
+        }
 
+        if ($count > 0) {
+            echo '</ul>';
+        }
+    }
 
+    /**
+     * Queries for dependency entries.
+     *
+     * Convenience method to query for an array of {@link AdminDependencyEntry}
+     * objects. The returned entry array may be directly assigned to the
+     * {@link AdminListDependency::$entries} property.
+     *
+     * For example:
+     * <code>
+     * $dep = new AdminListDependency();
+     * $dep->entries = AdminListDependency::queryEntries($this->app->db,
+     *     'orders', 'integer:id', 'integer:paymentmethod',
+     *     'paymentmethod in (123, 456, 789)', AdminDependency::DELETE);
+     * </code>
+     *
+     * @param MDB2_Driver_Common $db              the database connection
+     * @param string             $table           the database table to query
+     * @param string             $id_field        The name of the database field to query for
+     *                                            the id. Can be given in the form type:name where type is a
+     *                                            standard MDB2 datatype. If type is ommitted, then integer is
+     *                                            assummed for this field.
+     * @param string             $parent_field    The name of the database field to query to
+     *                                            link the child dependencies to the parent, or null. The values
+     *                                            in this field should correspond to entry ids in a parent
+     *                                            AdminListDependency object. This field may be given in the form
+     *                                            type:name where type is a standard MDB2 datatype. If type is
+     *                                            ommitted, then integer is assummed for this field.
+     * @param string             $title_field     The name of the database field to query for
+     *                                            the title. Can be given in the form type:name where type is a
+     *                                            standard MDB2 datatype. If type is ommitted, then text is
+     *                                            assummed for this field.
+     * @param string             $order_by_clause Optional comma deliminated list of
+     *                                            database field names to use in the <i>order by</i> clause.
+     *                                            Do not include "order by" in the string; only include the list
+     *                                            of field names. Use the value <b>null</b> to ignore this
+     *                                            paramater.
+     * @param string             $where_clause    Optional <i>where</i> clause to limit the
+     *                                            returned results. Do not include "where" in the string; only
+     *                                            include the conditional statement.
+     * @param int                $status_level    Optional status level to assign to the
+     *                                            queried entries. If no status level is specified, the status
+     *                                            level {@link AdminDependency::NODELETE} is used.
+     *
+     * @return array an array of {@link AdminDependencyEntry} objects
+     */
+    public static function queryEntries(
+        $db,
+        $table,
+        $id_field,
+        $parent_field,
+        $title_field,
+        $order_by_clause = null,
+        $where_clause = null,
+        $status_level = AdminDependency::NODELETE
+    ) {
+        $id_field = new SwatDBField($id_field, 'integer');
+        $title_field = new SwatDBField($title_field, 'text');
 
+        if ($parent_field === null) {
+            $parent_value = 'null';
+            $types = [$id_field->type, 'integer',
+                $title_field->type, 'integer'];
+        } else {
+            $parent_field = new SwatDBField($parent_field, 'integer');
+            $parent_value = $parent_field->name;
+            $types = [$id_field->type, $parent_field->type,
+                $title_field->type, 'integer'];
+        }
 
-	/**
-	 * Processes the status level of entries in this dependency
-	 *
-	 * @param $parent mixed the parent identifier of entries to process.
-	 *
-	 * @see AdminDependency::processItemStatuses()
-	 */
-	public function processItemStatuses($parent = null)
-	{
-		$return = self::DELETE;
-
-		foreach ($this->entries as $entry) {
-			if ($parent === null || $entry->parent === $parent) {
-				foreach ($this->dependencies as $dep) {
-					$entry->status_level = max($entry->status_level,
-						$dep->processItemStatuses($entry->id));
-				}
-				$return = max($return, $entry->status_level);
-			}
-		}
-
-		return $return;
-	}
-
-
-
-
-	/**
-	 * Displays a list of the dependency entries of this dependency for a given
-	 * parent at a given status level
-	 *
-	 * @param integer $parent the id of the parent to display the list for.
-	 * @param integer $status_level the status level to display the list for.
-	 */
-	public function displayDependencies($parent, $status_level)
-	{
-		$count = 0;
-		foreach ($this->entries as $entry)
-			if ($entry->parent == $parent &&
-				$entry->status_level == $status_level)
-				$count++;
-
-		$first = true;
-
-		foreach ($this->entries as $entry) {
-			if ($entry->parent == $parent &&
-				$entry->status_level == $status_level) {
-
-				if ($first) {
-					echo '<br />';
-					echo SwatString::minimizeEntities(
-						$this->getDependencyText($count));
-
-					echo '<ul>';
-					$first = false;
-				}
-
-				echo '<li>';
-
-				if ($entry->content_type == 'text/xml')
-					echo $entry->title;
-				else
-					echo SwatString::minimizeEntities($entry->title);
-
-				foreach ($this->dependencies as $dep)
-					$dep->displayDependencies($entry->id, $status_level);
-
-				echo '</li>';
-			}
-		}
-
-		if ($count > 0)
-			echo '</ul>';
-	}
-
-
-
-
-	/**
-	 * Queries for dependency entries
-	 *
-	 * Convenience method to query for an array of {@link AdminDependencyEntry}
-	 * objects. The returned entry array may be directly assigned to the
-	 * {@link AdminListDependency::$entries} property.
-	 *
-	 * For example:
-	 * <code>
-	 * $dep = new AdminListDependency();
-	 * $dep->entries = AdminListDependency::queryEntries($this->app->db,
-	 *     'orders', 'integer:id', 'integer:paymentmethod',
-	 *     'paymentmethod in (123, 456, 789)', AdminDependency::DELETE);
-	 * </code>
-	 *
-	 * @param MDB2_Driver_Common $db The database connection.
-	 *
-	 * @param string $table The database table to query.
-	 *
-	 * @param string $id_field The name of the database field to query for
-	 *        the id. Can be given in the form type:name where type is a
-	 *        standard MDB2 datatype. If type is ommitted, then integer is
-	 *        assummed for this field.
-	 *
-	 * @param string $parent_field The name of the database field to query to
-	 *        link the child dependencies to the parent, or null. The values
-	 *        in this field should correspond to entry ids in a parent
-	 *        AdminListDependency object. This field may be given in the form
-	 *        type:name where type is a standard MDB2 datatype. If type is
-	 *        ommitted, then integer is assummed for this field.
-	 *
-	 * @param string $title_field The name of the database field to query for
-	 *        the title. Can be given in the form type:name where type is a
-	 *        standard MDB2 datatype. If type is ommitted, then text is
-	 *        assummed for this field.
-	 *
-	 * @param string $order_by_clause Optional comma deliminated list of
-	 *        database field names to use in the <i>order by</i> clause.
-	 *        Do not include "order by" in the string; only include the list
-	 *        of field names. Use the value <b>null</b> to ignore this
-	 *        paramater.
-	 *
-	 * @param string $where_clause Optional <i>where</i> clause to limit the
-	 *        returned results. Do not include "where" in the string; only
-	 *        include the conditional statement.
-	 *
-	 * @param integer $status_level Optional status level to assign to the
-	 *        queried entries. If no status level is specified, the status
-	 *        level {@link AdminDependency::NODELETE} is used.
-	 *
-	 * @return array An array of {@link AdminDependencyEntry} objects.
-	 */
-	public static function queryEntries(
-		$db,
-		$table,
-		$id_field,
-		$parent_field,
-		$title_field,
-		$order_by_clause = null,
-		$where_clause = null,
-		$status_level = AdminDependency::NODELETE
-	) {
-		$id_field = new SwatDBField($id_field, 'integer');
-		$title_field = new SwatDBField($title_field, 'text');
-
-		if ($parent_field === null) {
-			$parent_value = 'null';
-			$types = array($id_field->type, 'integer',
-				$title_field->type, 'integer');
-		} else {
-			$parent_field = new SwatDBField($parent_field, 'integer');
-			$parent_value = $parent_field->name;
-			$types = array($id_field->type, $parent_field->type,
-				$title_field->type, 'integer');
-		}
-
-		$sql = sprintf('select %s as id, %s as parent, %s as title,
+        $sql = sprintf(
+            'select %s as id, %s as parent, %s as title,
 				%s as status_level from %s',
-			$id_field->name, $parent_value, $title_field->name,
-			$db->quote($status_level, 'integer'), $table);
+            $id_field->name,
+            $parent_value,
+            $title_field->name,
+            $db->quote($status_level, 'integer'),
+            $table
+        );
 
-		if ($where_clause !== null)
-			$sql.= ' where '.$where_clause;
+        if ($where_clause !== null) {
+            $sql .= ' where ' . $where_clause;
+        }
 
-		if ($order_by_clause !== null)
-			$sql.= ' order by '.$order_by_clause;
+        if ($order_by_clause !== null) {
+            $sql .= ' order by ' . $order_by_clause;
+        }
 
-		$entries = SwatDB::query($db, $sql, 'AdminDependencyEntryWrapper',
-			$types);
+        $entries = SwatDB::query(
+            $db,
+            $sql,
+            'AdminDependencyEntryWrapper',
+            $types
+        );
 
-		$entry_array = $entries->getArray();
-		return $entry_array;
-	}
+        return $entries->getArray();
+    }
 
+    /**
+     * Builds an array of dependency entries.
+     *
+     * Convenience method to create a flat array of {@link AdminDependencyEntry}
+     * objects. The returned array of dependency entries may be directly
+     * assigned to the {@link AdminListDependency::$entries} property of an
+     * {@link AdminListDependency} object.
+     *
+     * @param array $items        an associative array of dependent items in the form
+     *                            of id => title. This array is usually constructed
+     *                            from the result of a database query.
+     * @param array $parents      Optional associative array containing tree
+     *                            information for the items array in the form of
+     *                            id => parent. This array is usually constructed
+     *                            from the result of a database query. If not
+     *                            specified, all created entries will have a
+     *                            parent of null.
+     * @param int   $status_level Optional status level to assign to the
+     *                            queried entries. If no status level is
+     *                            specified, the status level
+     *                            {@link AdminDependency::NODELETE} is used.
+     *
+     * @return array a flat array of {@link AdminDependencyEntry} objects that
+     *               contains dependency tree information
+     */
+    public static function buildEntriesArray(
+        $items,
+        $parents = null,
+        $status_level = AdminDependency::NODELETE
+    ) {
+        $entries = [];
 
+        foreach ($items as $id => $title) {
+            if ($parents === null || array_key_exists($id, $parents)) {
+                $entry = new AdminDependencyEntry();
+                $entry->id = $id;
+                $entry->title = $title;
+                $entry->parent = ($parents === null) ? null : $parents[$id];
+                $entry->status_level = $status_level;
 
+                $entries[] = $entry;
+            }
+        }
 
-	/**
-	 * Builds an array of dependency entries
-	 *
-	 * Convenience method to create a flat array of {@link AdminDependencyEntry}
-	 * objects. The returned array of dependency entries may be directly
-	 * assigned to the {@link AdminListDependency::$entries} property of an
-	 * {@link AdminListDependency} object.
-	 *
-	 * @param array $items an associative array of dependent items in the form
-	 *                      of id => title. This array is usually constructed
-	 *                      from the result of a database query.
-	 * @param array $parents Optional associative array containing tree
-	 *                        information for the items array in the form of
-	 *                        id => parent. This array is usually constructed
-	 *                        from the result of a database query. If not
-	 *                        specified, all created entries will have a
-	 *                        parent of null.
-	 * @param integer $status_level Optional status level to assign to the
-	 *                               queried entries. If no status level is
-	 *                               specified, the status level
-	 *                               {@link AdminDependency::NODELETE} is used.
-	 *
-	 * @return array a flat array of {@link AdminDependencyEntry} objects that
-	 *                contains dependency tree information.
-	 */
-	public static function buildEntriesArray(
-		$items,
-		$parents = null,
-		$status_level = AdminDependency::NODELETE
-	) {
-		$entries = array();
+        return $entries;
+    }
 
-		foreach ($items as $id => $title) {
-			if ($parents === null || array_key_exists($id, $parents)) {
+    /**
+     * Gets the text for a dependency list for this dependency.
+     *
+     * Sub-classes may override this method to have more descriptive or
+     * meaningful text.
+     *
+     * @param int $count the number of dependencies in the list
+     *
+     * @return string the text for a dependency list for this dependency
+     */
+    protected function getDependencyText($count)
+    {
+        $title = $this->getTitle($count);
+        $message = Admin::ngettext(
+            'Dependent %s:',
+            'Dependent %s:',
+            $count
+        );
 
-				$entry = new AdminDependencyEntry();
-				$entry->id = $id;
-				$entry->title = $title;
-				$entry->parent = ($parents === null) ? null : $parents[$id];
-				$entry->status_level = $status_level;
-
-				$entries[] = $entry;
-			}
-		}
-
-		return $entries;
-	}
-
-
-
-
-	/**
-	 * Gets the text for a dependency list for this dependency
-	 *
-	 * Sub-classes may override this method to have more descriptive or
-	 * meaningful text.
-	 *
-	 * @param integer $count the number of dependencies in the list.
-	 *
-	 * @return string the text for a dependency list for this dependency.
-	 */
-	protected function getDependencyText($count)
-	{
-		$title = $this->getTitle($count);
-		$message = Admin::ngettext(
-			'Dependent %s:',
-			'Dependent %s:', $count);
-
-		$message = sprintf($message, $title);
-		return $message;
-	}
-
-
+        return sprintf($message, $title);
+    }
 }
-
-?>

--- a/Admin/AdminListDependency.php
+++ b/Admin/AdminListDependency.php
@@ -237,7 +237,7 @@ class AdminListDependency extends AdminDependency
         $entries = SwatDB::query(
             $db,
             $sql,
-            'AdminDependencyEntryWrapper',
+            AdminDependencyEntryWrapper::class,
             $types
         );
 

--- a/Admin/AdminMenuComponent.php
+++ b/Admin/AdminMenuComponent.php
@@ -11,7 +11,7 @@
  */
 class AdminMenuComponent
 {
-	// {{{ public properties
+
 
 	public $id;
 	public $shortname;
@@ -19,8 +19,8 @@ class AdminMenuComponent
 	public $title;
 	public $subcomponents;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	public function __construct($id, $shortname, $title, $description = null)
 	{
@@ -31,7 +31,7 @@ class AdminMenuComponent
 		$this->subcomponents = array();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminMenuComponent.php
+++ b/Admin/AdminMenuComponent.php
@@ -1,37 +1,27 @@
 <?php
 
 /**
- * Admin menu component
+ * Admin menu component.
  *
  * Internal data class used internally within {@link AdminMenuStore}.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuComponent
 {
+    public $id;
+    public $shortname;
+    public $description;
+    public $title;
+    public $subcomponents;
 
-
-	public $id;
-	public $shortname;
-	public $description;
-	public $title;
-	public $subcomponents;
-
-
-
-
-	public function __construct($id, $shortname, $title, $description = null)
-	{
-		$this->id = $id;
-		$this->shortname = $shortname;
-		$this->title = $title;
-		$this->description = $description;
-		$this->subcomponents = array();
-	}
-
-
+    public function __construct($id, $shortname, $title, $description = null)
+    {
+        $this->id = $id;
+        $this->shortname = $shortname;
+        $this->title = $title;
+        $this->description = $description;
+        $this->subcomponents = [];
+    }
 }
-
-?>

--- a/Admin/AdminMenuSection.php
+++ b/Admin/AdminMenuSection.php
@@ -11,15 +11,15 @@
  */
 class AdminMenuSection
 {
-	// {{{ public properties
+
 
 	public $id;
 	public $title;
 	public $components;
 	public $show;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	public function __construct($id, $title)
 	{
@@ -29,7 +29,7 @@ class AdminMenuSection
 		$this->show = true;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminMenuSection.php
+++ b/Admin/AdminMenuSection.php
@@ -1,35 +1,25 @@
 <?php
 
 /**
- * Admin menu section
+ * Admin menu section.
  *
  * Internal data class used internally within {@link AdminMenuStore}.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuSection
 {
+    public $id;
+    public $title;
+    public $components;
+    public $show;
 
-
-	public $id;
-	public $title;
-	public $components;
-	public $show;
-
-
-
-
-	public function __construct($id, $title)
-	{
-		$this->id = $id;
-		$this->title = $title;
-		$this->components = array();
-		$this->show = true;
-	}
-
-
+    public function __construct($id, $title)
+    {
+        $this->id = $id;
+        $this->title = $title;
+        $this->components = [];
+        $this->show = true;
+    }
 }
-
-?>

--- a/Admin/AdminMenuStore.php
+++ b/Admin/AdminMenuStore.php
@@ -1,85 +1,84 @@
 <?php
 
 /**
- * Data store for primary navigation menu
+ * Data store for primary navigation menu.
  *
  * Designed to be used as a MDB2 result wrapper class.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuStore
 {
+    /**
+     * Sections in this menu.
+     *
+     * @var AdminMenuSection
+     */
+    public $sections;
 
+    /**
+     * @param MDB2_Result $rs A recordset containing the menu.
+     *                        Requires the fields: section (integer), section_title (text),
+     *                        component_id (integer), shortname (text), title (text)
+     *                        subcomponent_shortname (text), subcomponent_title (text)
+     */
+    public function __construct($rs)
+    {
+        if (MDB2::isError($rs)) {
+            throw new Exception($rs->getMessage());
+        }
 
-	/**
-	 * Sections in this menu
-	 *
-	 * @var AdminMenuSection
-	 */
-	public $sections;
+        $this->sections = [];
+        $section = null;
+        $component = null;
 
+        do {
+            while ($row = $rs->fetchRow(MDB2_FETCHMODE_OBJECT)) {
+                if ($section === null || $row->section != $section->id) {
+                    $section = new AdminMenuSection(
+                        $row->section,
+                        $row->section_title
+                    );
 
+                    $this->sections[$row->section] = $section;
+                }
 
+                if ($component === null
+                    || $row->component_id != $component->id) {
+                    $component = new AdminMenuComponent(
+                        $row->component_id,
+                        $row->shortname,
+                        $row->title,
+                        $row->description
+                    );
 
-	/**
-	 * @param MDB2_Result $rs A recordset containing the menu.
-	 *        Requires the fields: section (integer), section_title (text),
-	 *        component_id (integer), shortname (text), title (text)
-	 *        subcomponent_shortname (text), subcomponent_title (text)
-	 */
-	public function __construct($rs)
-	{
-		if (MDB2::isError($rs))
-			throw new Exception($rs->getMessage());
+                    $section->components[$row->shortname] = $component;
+                }
 
-		$this->sections = array();
-		$section = null;
-		$component = null;
+                if ($row->subcomponent_shortname != '') {
+                    $subcomponent = new AdminMenuSubcomponent(
+                        $row->subcomponent_shortname,
+                        $row->subcomponent_title
+                    );
 
-		do {
-			while ($row = $rs->fetchRow(MDB2_FETCHMODE_OBJECT)) {
-				if ($section === null || $row->section != $section->id) {
-					$section = new AdminMenuSection($row->section,
-						$row->section_title);
+                    $component->subcomponents[$row->subcomponent_shortname] =
+                        $subcomponent;
+                }
+            }
+        } while ($rs->nextResult());
+    }
 
-					$this->sections[$row->section] = $section;
-				}
+    public function getComponentByName($name)
+    {
+        foreach ($this->sections as $section) {
+            foreach ($section->components as $component) {
+                if ($component->shortname === $name) {
+                    return $component;
+                }
+            }
+        }
 
-				if ($component === null ||
-					$row->component_id != $component->id) {
-					$component = new AdminMenuComponent($row->component_id,
-						$row->shortname, $row->title, $row->description);
-
-					$section->components[$row->shortname] = $component;
-				}
-
-				if ($row->subcomponent_shortname != '') {
-					$subcomponent = new AdminMenuSubcomponent(
-						$row->subcomponent_shortname, $row->subcomponent_title);
-
-					$component->subcomponents[$row->subcomponent_shortname] =
-						$subcomponent;
-				}
-			}
-		} while ($rs->nextResult());
-	}
-
-
-
-
-	public function getComponentByName($name)
-	{
-		foreach ($this->sections as $section)
-			foreach ($section->components as $component)
-				if ($component->shortname === $name)
-					return $component;
-
-		return null;
-	}
-
-
+        return null;
+    }
 }
-
-?>

--- a/Admin/AdminMenuStore.php
+++ b/Admin/AdminMenuStore.php
@@ -11,7 +11,7 @@
  */
 class AdminMenuStore
 {
-	// {{{ public properties
+
 
 	/**
 	 * Sections in this menu
@@ -20,8 +20,8 @@ class AdminMenuStore
 	 */
 	public $sections;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * @param MDB2_Result $rs A recordset containing the menu.
@@ -66,8 +66,8 @@ class AdminMenuStore
 		} while ($rs->nextResult());
 	}
 
-	// }}}
-	// {{{ public function getComponentByName()
+
+
 
 	public function getComponentByName($name)
 	{
@@ -79,7 +79,7 @@ class AdminMenuStore
 		return null;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminMenuSubcomponent.php
+++ b/Admin/AdminMenuSubcomponent.php
@@ -1,31 +1,21 @@
 <?php
 
 /**
- * Admin menu sub component
+ * Admin menu sub component.
  *
  * Internal data class used internally within {@link AdminMenuStore}.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuSubcomponent
 {
+    public $shortname;
+    public $title;
 
-
-	public $shortname;
-	public $title;
-
-
-
-
-	public function __construct($shortname, $title)
-	{
-		$this->shortname = $shortname;
-		$this->title = $title;
-	}
-
-
+    public function __construct($shortname, $title)
+    {
+        $this->shortname = $shortname;
+        $this->title = $title;
+    }
 }
-
-?>

--- a/Admin/AdminMenuSubcomponent.php
+++ b/Admin/AdminMenuSubcomponent.php
@@ -11,13 +11,13 @@
  */
 class AdminMenuSubcomponent
 {
-	// {{{ public properties
+
 
 	public $shortname;
 	public $title;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	public function __construct($shortname, $title)
 	{
@@ -25,7 +25,7 @@ class AdminMenuSubcomponent
 		$this->title = $title;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminMenuView.php
+++ b/Admin/AdminMenuView.php
@@ -1,238 +1,209 @@
 <?php
 
 /**
- * Displays the primary navigation menu
+ * Displays the primary navigation menu.
  *
  * This is the default view. This class may be extended to provide completely
  * different menu styles.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuView extends SwatControl
 {
-
-
-	/**
-	 * The unique identifier of this menu-view
-	 *
-	 * If not set explicitly, an id will be auto-generated after this menu-view
-	 * is initialized.
-	 *
-	 * @var string
-	 */
-	public $id;
-
-
-
-
-	/**
-	 * The menu-store this menu-view is viewing
-	 *
-	 * @var AdminMenuStore
-	 */
-	protected $store;
-
-
-
-
-	/**
-	 * Creates a new menu-view control
-	 *
-	 * @param string $id optional identifier for this menu-view.
-	 */
-	public function __construct($id = null)
-	{
-		parent::__construct($id);
-
-		$this->requires_id = true;
-
-		$yui = new SwatYUI(array('dom', 'event', 'animation'));
-		$this->html_head_entry_set->addEntrySet($yui->getHtmlHeadEntrySet());
-
-		$this->addStyleSheet('packages/admin/styles/admin-menu.css');
-		$this->addJavaScript('packages/admin/javascript/admin-menu.js');
-	}
-
-
-
-
-	/**
-	 * @param AdminMenuStore $store the menu-store this view will view.
-	 */
-	public function setModel(AdminMenuStore $store)
-	{
-		$this->store = $store;
-	}
-
-
-
-
-	/**
-	 * Displays this menu
-	 *
-	 * Outputs the HTML of this menu.
-	 */
-	public function display()
-	{
-		if (!$this->visible) {
-			return;
-		}
-
-		parent::display();
-
-		$menu_div = new SwatHtmlTag('div');
-		$menu_div->id = $this->id;
-		$menu_div->class = 'admin-menu';
-		$menu_div->open();
-
-		$this->displayMenuContent();
-
-		$menu_div->close();
-
-		Swat::displayInlineJavaScript($this->getInlineJavaScript());
-	}
-
-
-
-
-	/**
-	 * Displays a single menu section
-	 *
-	 * @param AdminMenuSection $section the section to display.
-	 */
-	public function displaySection($section)
-	{
-		$section_title_tag = new SwatHtmlTag('span');
-		$section_title_tag->class = 'menu-section-title';
-
-		$section_title_span_tag = new SwatHtmlTag('span');
-		$section_title_span_tag->setContent($section->title);
-
-		$section_li_tag = new SwatHtmlTag('li');
-		if (!$section->show)
-			$section_li_tag->class = 'hide-menu-section';
-
-		$section_li_tag->open();
-
-		$section_title_tag->open();
-		$section_title_span_tag->display();
-		$section_title_tag->close();
-
-		$section_content = new SwatHtmlTag('ul');
-		$section_content->id = sprintf('%s_section_%s', $this->id,
-			$section->id);
-
-		$section_content->open();
-
-		foreach ($section->components as $component)
-			$this->displayComponent($component);
-
-		$section_content->close();
-
-		$section_li_tag->close();
-	}
-
-
-
-
-	/**
-	 * Displays a single menu component
-	 *
-	 * @param AdminMenuComponent $component the component to display.
-	 */
-	public function displayComponent($component)
-	{
-		echo '<li class="admin-menu-component">';
-
-		$anchor_tag = new SwatHtmlTag('a');
-		$anchor_tag->href = $component->shortname;
-		$anchor_tag->setContent($component->title);
-		$anchor_tag->display();
-
-		if ($component->description != '') {
-			echo '<span class="admin-menu-help">';
-			echo '<span class="admin-menu-help-arrow"></span>';
-
-			$span_tag = new SwatHtmlTag('span');
-			$span_tag->class = 'admin-menu-help-content';
-			$span_tag->setContent(
-				SiteCommentFilter::toXhtml($component->description),
-				'text/xml'
-			);
-			$span_tag->display();
-
-			echo '</span>';
-		}
-
-		$span_tag = new SwatHtmlTag('span');
-		$span_tag->class = 'admin-menu-help';
-
-		if (count($component->subcomponents)) {
-			echo '<ul>';
-
-			foreach ($component->subcomponents as $subcomponent) {
-				$this->displaySubcomponent($subcomponent, $component->shortname);
-			}
-
-			echo '</ul>';
-		}
-
-		echo '</li>';
-	}
-
-
-
-
-	/**
-	 * Displays a single menu subcomponent
-	 *
-	 * @param AdminmenuSubcomponent $subcomponent the subcomponent to display.
-	 * @param string $component_shortname the short name of the component this
-	 *                                     subcomponent belongs to.
-	 */
-	public function displaySubcomponent($subcomponent, $component_shortname)
-	{
-		$anchor_tag = new SwatHtmlTag('a');
-		$anchor_tag->href = $component_shortname.'/'.$subcomponent->shortname;
-		$anchor_tag->setContent($subcomponent->title);
-
-		echo '<li>';
-		$anchor_tag->display();
-		echo '</li>';
-	}
-
-
-
-
-	/**
-	 * Displays the content of this menu-view
-	 */
-	protected function displayMenuContent()
-	{
-		echo '<ul>';
-
-		foreach ($this->store->sections as $section) {
-			$this->displaySection($section);
-		}
-
-		echo '</ul>';
-	}
-
-
-
-
-	protected function getInlineJavaScript()
-	{
-		return sprintf(
-			"%s_obj = new AdminMenu(%s);\n",
-			$this->id,
-			SwatString::quoteJavaScriptString($this->id)
-		);
-	}
-
-
+    /**
+     * The unique identifier of this menu-view.
+     *
+     * If not set explicitly, an id will be auto-generated after this menu-view
+     * is initialized.
+     *
+     * @var string
+     */
+    public $id;
+
+    /**
+     * The menu-store this menu-view is viewing.
+     *
+     * @var AdminMenuStore
+     */
+    protected $store;
+
+    /**
+     * Creates a new menu-view control.
+     *
+     * @param string $id optional identifier for this menu-view
+     */
+    public function __construct($id = null)
+    {
+        parent::__construct($id);
+
+        $this->requires_id = true;
+
+        $yui = new SwatYUI(['dom', 'event', 'animation']);
+        $this->html_head_entry_set->addEntrySet($yui->getHtmlHeadEntrySet());
+
+        $this->addStyleSheet('packages/admin/styles/admin-menu.css');
+        $this->addJavaScript('packages/admin/javascript/admin-menu.js');
+    }
+
+    /**
+     * @param AdminMenuStore $store the menu-store this view will view
+     */
+    public function setModel(AdminMenuStore $store)
+    {
+        $this->store = $store;
+    }
+
+    /**
+     * Displays this menu.
+     *
+     * Outputs the HTML of this menu.
+     */
+    public function display()
+    {
+        if (!$this->visible) {
+            return;
+        }
+
+        parent::display();
+
+        $menu_div = new SwatHtmlTag('div');
+        $menu_div->id = $this->id;
+        $menu_div->class = 'admin-menu';
+        $menu_div->open();
+
+        $this->displayMenuContent();
+
+        $menu_div->close();
+
+        Swat::displayInlineJavaScript($this->getInlineJavaScript());
+    }
+
+    /**
+     * Displays a single menu section.
+     *
+     * @param AdminMenuSection $section the section to display
+     */
+    public function displaySection($section)
+    {
+        $section_title_tag = new SwatHtmlTag('span');
+        $section_title_tag->class = 'menu-section-title';
+
+        $section_title_span_tag = new SwatHtmlTag('span');
+        $section_title_span_tag->setContent($section->title);
+
+        $section_li_tag = new SwatHtmlTag('li');
+        if (!$section->show) {
+            $section_li_tag->class = 'hide-menu-section';
+        }
+
+        $section_li_tag->open();
+
+        $section_title_tag->open();
+        $section_title_span_tag->display();
+        $section_title_tag->close();
+
+        $section_content = new SwatHtmlTag('ul');
+        $section_content->id = sprintf(
+            '%s_section_%s',
+            $this->id,
+            $section->id
+        );
+
+        $section_content->open();
+
+        foreach ($section->components as $component) {
+            $this->displayComponent($component);
+        }
+
+        $section_content->close();
+
+        $section_li_tag->close();
+    }
+
+    /**
+     * Displays a single menu component.
+     *
+     * @param AdminMenuComponent $component the component to display
+     */
+    public function displayComponent($component)
+    {
+        echo '<li class="admin-menu-component">';
+
+        $anchor_tag = new SwatHtmlTag('a');
+        $anchor_tag->href = $component->shortname;
+        $anchor_tag->setContent($component->title);
+        $anchor_tag->display();
+
+        if ($component->description != '') {
+            echo '<span class="admin-menu-help">';
+            echo '<span class="admin-menu-help-arrow"></span>';
+
+            $span_tag = new SwatHtmlTag('span');
+            $span_tag->class = 'admin-menu-help-content';
+            $span_tag->setContent(
+                SiteCommentFilter::toXhtml($component->description),
+                'text/xml'
+            );
+            $span_tag->display();
+
+            echo '</span>';
+        }
+
+        $span_tag = new SwatHtmlTag('span');
+        $span_tag->class = 'admin-menu-help';
+
+        if (count($component->subcomponents)) {
+            echo '<ul>';
+
+            foreach ($component->subcomponents as $subcomponent) {
+                $this->displaySubcomponent($subcomponent, $component->shortname);
+            }
+
+            echo '</ul>';
+        }
+
+        echo '</li>';
+    }
+
+    /**
+     * Displays a single menu subcomponent.
+     *
+     * @param AdminmenuSubcomponent $subcomponent        the subcomponent to display
+     * @param string                $component_shortname the short name of the component this
+     *                                                   subcomponent belongs to
+     */
+    public function displaySubcomponent($subcomponent, $component_shortname)
+    {
+        $anchor_tag = new SwatHtmlTag('a');
+        $anchor_tag->href = $component_shortname . '/' . $subcomponent->shortname;
+        $anchor_tag->setContent($subcomponent->title);
+
+        echo '<li>';
+        $anchor_tag->display();
+        echo '</li>';
+    }
+
+    /**
+     * Displays the content of this menu-view.
+     */
+    protected function displayMenuContent()
+    {
+        echo '<ul>';
+
+        foreach ($this->store->sections as $section) {
+            $this->displaySection($section);
+        }
+
+        echo '</ul>';
+    }
+
+    protected function getInlineJavaScript()
+    {
+        return sprintf(
+            "%s_obj = new AdminMenu(%s);\n",
+            $this->id,
+            SwatString::quoteJavaScriptString($this->id)
+        );
+    }
 }
-
-?>

--- a/Admin/AdminMenuView.php
+++ b/Admin/AdminMenuView.php
@@ -12,7 +12,7 @@
  */
 class AdminMenuView extends SwatControl
 {
-	// {{{ public properties
+
 
 	/**
 	 * The unique identifier of this menu-view
@@ -24,8 +24,8 @@ class AdminMenuView extends SwatControl
 	 */
 	public $id;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * The menu-store this menu-view is viewing
@@ -34,8 +34,8 @@ class AdminMenuView extends SwatControl
 	 */
 	protected $store;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new menu-view control
@@ -55,8 +55,8 @@ class AdminMenuView extends SwatControl
 		$this->addJavaScript('packages/admin/javascript/admin-menu.js');
 	}
 
-	// }}}
-	// {{{ public function setModel()
+
+
 
 	/**
 	 * @param AdminMenuStore $store the menu-store this view will view.
@@ -66,8 +66,8 @@ class AdminMenuView extends SwatControl
 		$this->store = $store;
 	}
 
-	// }}}
-	// {{{ public function display()
+
+
 
 	/**
 	 * Displays this menu
@@ -94,8 +94,8 @@ class AdminMenuView extends SwatControl
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ public function displaySection()
+
+
 
 	/**
 	 * Displays a single menu section
@@ -134,8 +134,8 @@ class AdminMenuView extends SwatControl
 		$section_li_tag->close();
 	}
 
-	// }}}
-	// {{{ public function displayComponent()
+
+
 
 	/**
 	 * Displays a single menu component
@@ -182,8 +182,8 @@ class AdminMenuView extends SwatControl
 		echo '</li>';
 	}
 
-	// }}}
-	// {{{ public function displaySubcomponent()
+
+
 
 	/**
 	 * Displays a single menu subcomponent
@@ -203,8 +203,8 @@ class AdminMenuView extends SwatControl
 		echo '</li>';
 	}
 
-	// }}}
-	// {{{ protected function displayMenuContent()
+
+
 
 	/**
 	 * Displays the content of this menu-view
@@ -220,8 +220,8 @@ class AdminMenuView extends SwatControl
 		echo '</ul>';
 	}
 
-	// }}}
-	// {{{ protected function getInlineJavaScript()
+
+
 
 	protected function getInlineJavaScript()
 	{
@@ -232,7 +232,7 @@ class AdminMenuView extends SwatControl
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminNavBar.php
+++ b/Admin/AdminNavBar.php
@@ -11,7 +11,7 @@
  */
 class AdminNavBar extends SwatNavBar
 {
-	// {{{ protected function displayEntry()
+
 
 	/**
 	 * Displays an entry in this navigational bar
@@ -47,7 +47,7 @@ class AdminNavBar extends SwatNavBar
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminNavBar.php
+++ b/Admin/AdminNavBar.php
@@ -1,9 +1,8 @@
 <?php
 
 /**
- * A navagational bar for the admin
+ * A navagational bar for the admin.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
@@ -11,43 +10,36 @@
  */
 class AdminNavBar extends SwatNavBar
 {
+    /**
+     * Displays an entry in this navigational bar.
+     *
+     * @param SwatNavBarEntry $entry the entry to display
+     * @param bool            $link  whether or not to hyperlink the given entry if the
+     *                               entry has a link set
+     * @param bool            $first whether or not this entry should be displayed as
+     *                               the first entry
+     *
+     * @see SwatNavBar::displayEntry()
+     */
+    protected function displayEntry(
+        SwatNavBarEntry $entry,
+        $link = true,
+        $first = false
+    ) {
+        if ($entry instanceof AdminImportantNavBarEntry
+            && $entry->link !== null && $link) {
+            echo '<h1>';
+            $a_tag = new SwatHtmlTag('a');
+            if ($first) {
+                $a_tag->class = 'swat-navbar-first';
+            }
 
-
-	/**
-	 * Displays an entry in this navigational bar
-	 *
-	 * @param SwatNavBarEntry $entry the entry to display.
-	 * @param boolean $link whether or not to hyperlink the given entry if the
-	 *                       entry has a link set.
-	 * @param boolean $first whether or not this entry should be displayed as
-	 *                        the first entry.
-	 *
-	 * @see SwatNavBar::displayEntry()
-	 */
-	protected function displayEntry(
-		SwatNavBarEntry $entry,
-		$link = true,
-		$first = false
-	) {
-		if ($entry instanceof AdminImportantNavBarEntry &&
-			$entry->link !== null && $link) {
-
-			echo '<h1>';
-			$a_tag = new SwatHtmlTag('a');
-			if ($first)
-				$a_tag->class = 'swat-navbar-first';
-
-			$a_tag->href = $entry->link;
-			$a_tag->setContent($entry->title);
-			$a_tag->display();
-			echo '</h1>';
-
-		} else {
-			parent::displayEntry($entry, $link, $first);
-		}
-	}
-
-
+            $a_tag->href = $entry->link;
+            $a_tag->setContent($entry->title);
+            $a_tag->display();
+            echo '</h1>';
+        } else {
+            parent::displayEntry($entry, $link, $first);
+        }
+    }
 }
-
-?>

--- a/Admin/AdminNote.php
+++ b/Admin/AdminNote.php
@@ -9,7 +9,7 @@
  */
 class AdminNote extends SwatContentBlock
 {
-	// {{{ public properties
+
 
 	/**
 	 * User visible title of this widget
@@ -18,8 +18,8 @@ class AdminNote extends SwatContentBlock
 	 */
 	public $title = '';
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new note
@@ -34,8 +34,8 @@ class AdminNote extends SwatContentBlock
 		$this->addStyleSheet('packages/admin/styles/admin-note.css');
 	}
 
-	// }}}
-	// {{{ public function display()
+
+
 
 	/**
 	 * Displays this content
@@ -71,8 +71,8 @@ class AdminNote extends SwatContentBlock
 		$div->close();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
+
+
 
 	/**
 	 * Gets the array of CSS classes that are applied to this note
@@ -86,7 +86,7 @@ class AdminNote extends SwatContentBlock
 		return $classes;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminNote.php
+++ b/Admin/AdminNote.php
@@ -1,92 +1,77 @@
 <?php
 
 /**
- * A widget to display a formatted note in the widget tree
+ * A widget to display a formatted note in the widget tree.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminNote extends SwatContentBlock
 {
+    /**
+     * User visible title of this widget.
+     *
+     * @var string
+     */
+    public $title = '';
 
+    /**
+     * Creates a new note.
+     *
+     * @param string $id a non-visible unique id for this widget
+     *
+     * @see SwatWidget::__construct()
+     */
+    public function __construct($id = null)
+    {
+        parent::__construct($id);
+        $this->addStyleSheet('packages/admin/styles/admin-note.css');
+    }
 
-	/**
-	 * User visible title of this widget
-	 *
-	 * @var string
-	 */
-	public $title = '';
+    /**
+     * Displays this content.
+     *
+     * Merely performs an echo of the content.
+     */
+    public function display()
+    {
+        if (!$this->visible) {
+            return;
+        }
 
+        SwatWidget::display();
 
+        $div = new SwatHtmlTag('div');
+        $div->id = $this->id;
+        $div->class = $this->getCSSClassString();
+        $div->open();
 
+        if ($this->title != '') {
+            $header_tag = new SwatHtmlTag('h3');
+            $header_tag->class = 'admin-note-title';
+            $header_tag->setContent($this->title);
+            $header_tag->display();
+        }
 
-	/**
-	 * Creates a new note
-	 *
-	 * @param string $id a non-visible unique id for this widget.
-	 *
-	 * @see SwatWidget::__construct()
-	 */
-	public function __construct($id = null)
-	{
-		parent::__construct($id);
-		$this->addStyleSheet('packages/admin/styles/admin-note.css');
-	}
+        if ($this->content != '') {
+            $content_div = new SwatHtmlTag('div');
+            $content_div->class = 'admin-note-content';
+            $content_div->setContent($this->content, $this->content_type);
+            $content_div->display();
+        }
 
+        $div->close();
+    }
 
+    /**
+     * Gets the array of CSS classes that are applied to this note.
+     *
+     * @return array the array of CSS classes that are applied to this note
+     */
+    protected function getCSSClassNames()
+    {
+        $classes = ['admin-note'];
 
-
-	/**
-	 * Displays this content
-	 *
-	 * Merely performs an echo of the content.
-	 */
-	public function display()
-	{
-		if (!$this->visible)
-			return;
-
-		SwatWidget::display();
-
-		$div = new SwatHtmlTag('div');
-		$div->id = $this->id;
-		$div->class = $this->getCSSClassString();
-		$div->open();
-
-		if ($this->title != '') {
-			$header_tag = new SwatHtmlTag('h3');
-			$header_tag->class = 'admin-note-title';
-			$header_tag->setContent($this->title);
-			$header_tag->display();
-		}
-
-		if ($this->content != '') {
-			$content_div = new SwatHtmlTag('div');
-			$content_div->class = 'admin-note-content';
-			$content_div->setContent($this->content, $this->content_type);
-			$content_div->display();
-		}
-
-		$div->close();
-	}
-
-
-
-
-	/**
-	 * Gets the array of CSS classes that are applied to this note
-	 *
-	 * @return array the array of CSS classes that are applied to this note.
-	 */
-	protected function getCSSClassNames()
-	{
-		$classes = array('admin-note');
-		$classes = array_merge($classes, $this->classes);
-		return $classes;
-	}
-
-
+        return array_merge($classes, $this->classes);
+    }
 }
-
-?>

--- a/Admin/AdminPageRequest.php
+++ b/Admin/AdminPageRequest.php
@@ -9,7 +9,7 @@
  */
 class AdminPageRequest extends SiteObject
 {
-	// {{{ protected properties
+
 
 	protected $source;
 	protected $component;
@@ -18,8 +18,8 @@ class AdminPageRequest extends SiteObject
 	protected $app;
 	protected $class_prefix;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new page request and resolves the component for the request
@@ -120,8 +120,8 @@ class AdminPageRequest extends SiteObject
 		}
 	}
 
-	// }}}
-	// {{{ public function getClassName()
+
+
 
 	public function getClassName()
 	{
@@ -145,40 +145,40 @@ class AdminPageRequest extends SiteObject
 		return $class_name;
 	}
 
-	// }}}
-	// {{{ public function getTitle()
+
+
 
 	public function getTitle()
 	{
 		return $this->title;
 	}
 
-	// }}}
-	// {{{ public function getComponent()
+
+
 
 	public function getComponent()
 	{
 		return $this->component;
 	}
 
-	// }}}
-	// {{{ public function getSubComponent()
+
+
 
 	public function getSubComponent()
 	{
 		return $this->subcomponent;
 	}
 
-	// }}}
-	// {{{ public function getSource()
+
+
 
 	public function getSource()
 	{
 		return $this->source;
 	}
 
-	// }}}
-	// {{{ protected function getAdminSiteTitles()
+
+
 
 	public function getAdminSiteTitles()
 	{
@@ -196,7 +196,7 @@ class AdminPageRequest extends SiteObject
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminPageRequest.php
+++ b/Admin/AdminPageRequest.php
@@ -1,202 +1,184 @@
 <?php
 
 /**
- * Page request
+ * Page request.
  *
- * @package   Admin
  * @copyright 2004-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminPageRequest extends SiteObject
 {
+    protected $source;
+    protected $component;
+    protected $subcomponent;
+    protected $title;
+    protected $app;
+    protected $class_prefix;
 
+    /**
+     * Creates a new page request and resolves the component for the request.
+     *
+     * @param AdminApplication $app    the admin application creating the page
+     *                                 request
+     * @param string           $source the source of the page request
+     */
+    public function __construct(AdminApplication $app, $source)
+    {
+        $this->source = $source;
+        $this->app = $app;
 
-	protected $source;
-	protected $component;
-	protected $subcomponent;
-	protected $title;
-	protected $app;
-	protected $class_prefix;
+        if ($this->source == '') {
+            $this->source = $this->app->getFrontSource();
+        }
 
+        $allow_reset_password =
+            (bool) $app->config->admin->allow_reset_password;
 
+        if ($this->app->session->isLoggedIn()) {
+            $source_exp = explode('/', $this->source);
 
+            if (count($source_exp) == 1) {
+                $this->component = $this->source;
+                $this->subcomponent = $this->app->getDefaultSubComponent();
+            } elseif (count($source_exp) == 2) {
+                [$this->component, $this->subcomponent] = $source_exp;
+            } else {
+                throw new AdminNotFoundException(sprintf(
+                    Admin::_(
+                        "Invalid source '%s'."
+                    ),
+                    $this->source
+                ));
+            }
 
-	/**
-	 * Creates a new page request and resolves the component for the request
-	 *
-	 * @param AdminApplication $app the admin application creating the page
-	 *                               request.
-	 * @param string $source the source of the page request.
-	 */
-	public function __construct(AdminApplication $app, $source)
-	{
-		$this->source = $source;
-		$this->app = $app;
+            if ($this->component == 'AdminSite') {
+                $admin_titles = $this->getAdminSiteTitles();
 
-		if ($this->source == '')
-			$this->source = $this->app->getFrontSource();
+                if (isset($admin_titles[$this->subcomponent])) {
+                    $this->title = $admin_titles[$this->subcomponent];
+                } else {
+                    throw new AdminNotFoundException(
+                        sprintf(
+                            Admin::_("Component not found for source '%s'."),
+                            $this->source
+                        )
+                    );
+                }
+            } else {
+                $component = new AdminComponent();
+                $component->setDatabase($this->app->db);
+                if (!$component->loadFromShortname($this->component)) {
+                    throw new AdminNotFoundException(sprintf(
+                        Admin::_(
+                            "Component not found for source '%s'."
+                        ),
+                        $this->source
+                    ));
+                }
+                $this->title = $component->title;
 
-		$allow_reset_password =
-			(boolean)$app->config->admin->allow_reset_password;
+                if (!$this->app->session->user->hasAccess($component)) {
+                    $user = $this->app->session->user;
 
-		if ($this->app->session->isLoggedIn()) {
-			$source_exp = explode('/', $this->source);
+                    throw new AdminNoAccessException(sprintf(Admin::_(
+                        'Access to the requested component is forbidden for ' .
+                        "user '%s'."
+                    ), $user->id), 0, $user);
+                }
+            }
+        } else {
+            switch ($this->source) {
+                case 'AdminSite/ChangePassword':
+                    $this->subcomponent = 'ChangePassword';
+                    break;
 
-			if (count($source_exp) == 1) {
-				$this->component = $this->source;
-				$this->subcomponent = $this->app->getDefaultSubComponent();
-			} elseif (count($source_exp) == 2) {
-				list($this->component, $this->subcomponent) = $source_exp;
-			} else {
-				throw new AdminNotFoundException(sprintf(Admin::_(
-					"Invalid source '%s'."),
-					$this->source));
-			}
+                case 'AdminSite/TwoFactorAuthentication':
+                    $this->subcomponent = 'TwoFactorAuthentication';
+                    break;
 
-			if ($this->component == 'AdminSite') {
-				$admin_titles = $this->getAdminSiteTitles();
+                case 'AdminSite/ForgotPassword':
+                    if (!$allow_reset_password) {
+                        throw new AdminNotFoundException(sprintf(
+                            Admin::_(
+                                "Component not found for source '%s'."
+                            ),
+                            $this->source
+                        ));
+                    }
 
-				if (isset($admin_titles[$this->subcomponent])) {
-					$this->title = $admin_titles[$this->subcomponent];
-				} else {
-					throw new AdminNotFoundException(
-						sprintf(
-							Admin::_("Component not found for source '%s'."),
-							$this->source
-						)
-					);
-				}
+                    $this->subcomponent = 'ForgotPassword';
+                    break;
 
-			} else {
-				$component = new AdminComponent();
-				$component->setDatabase($this->app->db);
-				if (!$component->loadFromShortname($this->component)) {
-					throw new AdminNotFoundException(sprintf(Admin::_(
-						"Component not found for source '%s'."),
-						$this->source));
-				} else {
-					$this->title = $component->title;
-				}
+                case 'AdminSite/ResetPassword':
+                    $this->subcomponent = 'ResetPassword';
+                    break;
 
-				if (!$this->app->session->user->hasAccess($component)) {
-					$user = $this->app->session->user;
-					throw new AdminNoAccessException(sprintf(Admin::_(
-						"Access to the requested component is forbidden for ".
-						"user '%s'."), $user->id), 0, $user);
-				}
-			}
-		} else {
-			switch ($this->source) {
-			case 'AdminSite/ChangePassword':
-				$this->subcomponent = 'ChangePassword';
-				break;
+                default:
+                    $this->subcomponent = 'Login';
+                    break;
+            }
 
-			case 'AdminSite/TwoFactorAuthentication':
-				$this->subcomponent = 'TwoFactorAuthentication';
-				break;
+            $admin_titles = $this->getAdminSiteTitles();
+            $this->title = $admin_titles[$this->subcomponent];
+            $this->component = 'AdminSite';
+        }
+    }
 
-			case 'AdminSite/ForgotPassword':
-				if (!$allow_reset_password) {
-					throw new AdminNotFoundException(sprintf(Admin::_(
-						"Component not found for source '%s'."),
-						$this->source));
-				}
+    public function getClassName()
+    {
+        $class_name = null;
 
-				$this->subcomponent = 'ForgotPassword';
-				break;
+        $prefixes = array_keys($this->app->getComponentIncludePaths());
 
-			case 'AdminSite/ResetPassword':
-				$this->subcomponent = 'ResetPassword';
-				break;
+        // Try non-prefixed class first.
+        array_unshift($prefixes, null);
 
-			default:
-				$this->subcomponent = 'Login';
-				break;
-			}
+        foreach ($prefixes as $prefix) {
+            $class_name = ($prefix === null)
+                ? $this->component . $this->subcomponent
+                : $prefix . $this->component . $this->subcomponent;
 
-			$admin_titles = $this->getAdminSiteTitles();
-			$this->title = $admin_titles[$this->subcomponent];
-			$this->component = 'AdminSite';
-		}
-	}
+            if (class_exists($class_name)) {
+                break;
+            }
+        }
 
+        return $class_name;
+    }
 
+    public function getTitle()
+    {
+        return $this->title;
+    }
 
+    public function getComponent()
+    {
+        return $this->component;
+    }
 
-	public function getClassName()
-	{
-		$class_name = null;
+    public function getSubComponent()
+    {
+        return $this->subcomponent;
+    }
 
-		$prefixes = array_keys($this->app->getComponentIncludePaths());
+    public function getSource()
+    {
+        return $this->source;
+    }
 
-		// Try non-prefixed class first.
-		array_unshift($prefixes, null);
-
-		foreach ($prefixes as $prefix) {
-			$class_name = ($prefix === null)
-				? $this->component.$this->subcomponent
-				: $prefix.$this->component.$this->subcomponent;
-
-			if (class_exists($class_name)) {
-				break;
-			}
-		}
-
-		return $class_name;
-	}
-
-
-
-
-	public function getTitle()
-	{
-		return $this->title;
-	}
-
-
-
-
-	public function getComponent()
-	{
-		return $this->component;
-	}
-
-
-
-
-	public function getSubComponent()
-	{
-		return $this->subcomponent;
-	}
-
-
-
-
-	public function getSource()
-	{
-		return $this->source;
-	}
-
-
-
-
-	public function getAdminSiteTitles()
-	{
-		return array(
-			'Profile'                 => Admin::_('Edit User Profile'),
-			'Logout'                  => Admin::_('Logout'),
-			'Login'                   => Admin::_('Login'),
-			'Exception'               => Admin::_('Exception'),
-			'Front'                   => Admin::_('Index'),
-			'ChangePassword'          => Admin::_('Change Password'),
-			'ResetPassword'           => Admin::_('Update Password'),
-			'ForgotPassword'          => Admin::_('Reset Forgotten Password'),
-			'TwoFactorAuthentication' => Admin::_('Two Factor Authentication'),
-			'MenuViewServer'          => '',
-		);
-	}
-
-
+    public function getAdminSiteTitles()
+    {
+        return [
+            'Profile'                 => Admin::_('Edit User Profile'),
+            'Logout'                  => Admin::_('Logout'),
+            'Login'                   => Admin::_('Login'),
+            'Exception'               => Admin::_('Exception'),
+            'Front'                   => Admin::_('Index'),
+            'ChangePassword'          => Admin::_('Change Password'),
+            'ResetPassword'           => Admin::_('Update Password'),
+            'ForgotPassword'          => Admin::_('Reset Forgotten Password'),
+            'TwoFactorAuthentication' => Admin::_('Two Factor Authentication'),
+            'MenuViewServer'          => '',
+        ];
+    }
 }
-
-?>

--- a/Admin/AdminPagination.php
+++ b/Admin/AdminPagination.php
@@ -1,80 +1,68 @@
 <?php
 
 /**
- * A pagination widget that preserves HTTP GET variables
+ * A pagination widget that preserves HTTP GET variables.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminPagination extends SwatPagination
 {
+    /**
+     * HTTP GET varables that are not to be preserved.
+     *
+     * @var array
+     */
+    public $unset_get_vars = [];
 
+    /**
+     * Processes this pagination widget.
+     *
+     * Sets the current_page and current_record properties.
+     */
+    public function process()
+    {
+        parent::process();
 
-	/**
-	 * HTTP GET varables that are not to be preserved
-	 *
-	 * @var array
-	 */
-	public $unset_get_vars = array();
+        if (array_key_exists($this->id, $_GET)) {
+            $this->setCurrentPage($_GET[$this->id]);
+        }
+    }
 
+    /**
+     * Gets the base link for all page links.
+     *
+     * This removes all unwanted variables from the current HTTP GET variables
+     * and adds all wanted variables ones back into the link string.
+     *
+     * @return string the base link for all pages with cleaned HTTP GET
+     *                variables
+     */
+    protected function getLink()
+    {
+        $vars = $_GET;
 
+        $this->unset_get_vars[] = $this->id;
+        $this->unset_get_vars[] = 'source';
 
+        foreach ($vars as $name => $value) {
+            if (in_array($name, $this->unset_get_vars)) {
+                unset($vars[$name]);
+            }
+        }
 
-	/**
-	 * Processes this pagination widget
-	 *
-	 * Sets the current_page and current_record properties.
-	 */
-	public function process()
-	{
-		parent::process();
+        if ($this->link === null) {
+            $link = '?';
+        } else {
+            $link = $this->link . '?';
+        }
 
-		if (array_key_exists($this->id, $_GET))
-			$this->setCurrentPage($_GET[$this->id]);
-	}
+        foreach ($vars as $name => $value) {
+            $link .= $name . '=' . urlencode($value) . '&';
+        }
 
+        $link .= urlencode($this->id) . '=%s';
 
-
-
-	/**
-	 * Gets the base link for all page links
-	 *
-	 * This removes all unwanted variables from the current HTTP GET variables
-	 * and adds all wanted variables ones back into the link string.
-	 *
-	 * @return string the base link for all pages with cleaned HTTP GET
-	 *                 variables.
-	 */
-	protected function getLink()
-	{
-		$vars = $_GET;
-
-		$this->unset_get_vars[] = $this->id;
-		$this->unset_get_vars[] = 'source';
-
-		foreach($vars as $name => $value) {
-			if (in_array($name, $this->unset_get_vars)) {
-				unset($vars[$name]);
-			}
-		}
-
-		if ($this->link === null) {
-			$link = '?';
-		} else {
-			$link = $this->link.'?';
-		}
-
-		foreach($vars as $name => $value) {
-			$link.= $name.'='.urlencode($value).'&';
-		}
-
-		$link.= urlencode($this->id).'=%s';
-
-		return $link;
-	}
-
-
+        return $link;
+    }
 }
-
-?>

--- a/Admin/AdminPagination.php
+++ b/Admin/AdminPagination.php
@@ -9,7 +9,7 @@
  */
 class AdminPagination extends SwatPagination
 {
-	// {{{ public properties
+
 
 	/**
 	 * HTTP GET varables that are not to be preserved
@@ -18,8 +18,8 @@ class AdminPagination extends SwatPagination
 	 */
 	public $unset_get_vars = array();
 
-	// }}}
-	// {{{ public function process()
+
+
 
 	/**
 	 * Processes this pagination widget
@@ -34,8 +34,8 @@ class AdminPagination extends SwatPagination
 			$this->setCurrentPage($_GET[$this->id]);
 	}
 
-	// }}}
-	// {{{ protected function getLink()
+
+
 
 	/**
 	 * Gets the base link for all page links
@@ -74,7 +74,7 @@ class AdminPagination extends SwatPagination
 		return $link;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminResetPasswordMailMessage.php
+++ b/Admin/AdminResetPasswordMailMessage.php
@@ -23,7 +23,7 @@
  */
 class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The user this reset password mail message is intended for
@@ -40,8 +40,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 	 */
 	protected $password_link;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new reset password email
@@ -62,8 +62,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 		$this->admin_user = $user;
 	}
 
-	// }}}
-	// {{{ public function send()
+
+
 
 	/**
 	 * Sends this mail message
@@ -87,8 +87,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 		parent::send();
 	}
 
-	// }}}
-	// {{{ protected function getTextBody()
+
+
 
 	/**
 	 * Gets the plain-text content of this mail message
@@ -103,8 +103,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 			$this->getTextInstanceNote());
 	}
 
-	// }}}
-	// {{{ protected function getHtmlBody()
+
+
 
 	/**
 	 * Gets the HTML content of this mail message
@@ -119,8 +119,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 			$this->getHtmlInstanceNote());
 	}
 
-	// }}}
-	// {{{ protected function getHtmlInstanceNote()
+
+
 
 	protected function getHtmlInstanceNote()
 	{
@@ -156,8 +156,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 		return $instance_note;
 	}
 
-	// }}}
-	// {{{ protected function getTextInstanceNote()
+
+
 
 	protected function getTextInstanceNote()
 	{
@@ -191,8 +191,8 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 		return $instance_note;
 	}
 
-	// }}}
-	// {{{ protected function getFormattedBody()
+
+
 
 	protected function getFormattedBody($format_string, $formatted_link)
 	{
@@ -228,7 +228,7 @@ class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 				$this->app->config->site->title));
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminResetPasswordMailMessage.php
+++ b/Admin/AdminResetPasswordMailMessage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Email that is sent to an admin uuser when they request a new password
+ * Email that is sent to an admin uuser when they request a new password.
  *
  * To send a password reset message:
  * <code>
@@ -17,218 +17,204 @@
  * $email->send();
  * </code>
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminResetPasswordMailMessage extends SiteMultipartMailMessage
 {
+    /**
+     * The user this reset password mail message is intended for.
+     *
+     * @var AdminUser
+     */
+    protected $admin_user;
 
+    /**
+     * The URL of the application page that performs that password reset
+     * action.
+     *
+     * @var string
+     */
+    protected $password_link;
 
-	/**
-	 * The user this reset password mail message is intended for
-	 *
-	 * @var AdminUser
-	 */
-	protected $admin_user;
+    /**
+     * Creates a new reset password email.
+     *
+     * @param AdminApplication $app           the application sending the mail message
+     * @param AdminUser        $user          the user for which to create the email
+     * @param string           $password_link the URL of the application page that
+     *                                        performs the password reset
+     */
+    public function __construct(
+        AdminApplication $app,
+        AdminUser $user,
+        $password_link
+    ) {
+        parent::__construct($app);
 
-	/**
-	 * The URL of the application page that performs that password reset
-	 * action
-	 *
-	 * @var string
-	 */
-	protected $password_link;
+        $this->password_link = $password_link;
+        $this->admin_user = $user;
+    }
 
+    /**
+     * Sends this mail message.
+     */
+    public function send()
+    {
+        if ($this->admin_user->email === null) {
+            throw new AdminException('User requires an email address to ' .
+                'reset password. Make sure email is loaded on the user ' .
+                'object.');
+        }
 
+        if ($this->admin_user->name === null) {
+            throw new AdminException('User requires a fullname to reset ' .
+                'password. Make sure name is loaded on the user object.');
+        }
 
+        $this->to_address = $this->admin_user->email;
+        $this->to_name = $this->admin_user->name;
+        $this->text_body = $this->getTextBody();
+        $this->html_body = $this->getHtmlBody();
 
-	/**
-	 * Creates a new reset password email
-	 *
-	 * @param AdminApplication $app the application sending the mail message.
-	 * @param AdminUser $user the user for which to create the email.
-	 * @param string $password_link the URL of the application page that
-	 *                               performs the password reset.
-	 */
-	public function __construct(
-		AdminApplication $app,
-		AdminUser $user,
-		$password_link
-	) {
-		parent::__construct($app);
+        parent::send();
+    }
 
-		$this->password_link = $password_link;
-		$this->admin_user = $user;
-	}
+    /**
+     * Gets the plain-text content of this mail message.
+     *
+     * @return string the plain-text content of this mail message
+     */
+    protected function getTextBody()
+    {
+        return sprintf(
+            $this->getFormattedBody(
+                "%s\n\n%s\n\n%%s%s\n\n%s\n%s\n\n%s\n%s",
+                $this->password_link
+            ),
+            $this->getTextInstanceNote()
+        );
+    }
 
+    /**
+     * Gets the HTML content of this mail message.
+     *
+     * @return string the HTML content of this mail message
+     */
+    protected function getHtmlBody()
+    {
+        return sprintf(
+            $this->getFormattedBody(
+                '<p>%s</p><p>%s</p>%%s<p>%s</p><p>%s<br />%s</p><p>%s<br />%s</p>',
+                sprintf('<a href="%1$s">%1$s</a>', $this->password_link)
+            ),
+            $this->getHtmlInstanceNote()
+        );
+    }
 
+    protected function getHtmlInstanceNote()
+    {
+        $instance_note = '';
 
+        if ($this->app->hasModule('SiteMultipleInstanceModule')) {
+            $site_instance =
+                $this->app->getModule('SiteMultipleInstanceModule');
 
-	/**
-	 * Sends this mail message
-	 */
-	public function send()
-	{
-		if ($this->admin_user->email === null)
-			throw new AdminException('User requires an email address to '.
-				'reset password. Make sure email is loaded on the user '.
-				'object.');
+            if (count($this->admin_user->instances) > 1) {
+                $instance_note .= '<p>' . Admin::_(
+                    'Notice: Your admin password will also be updated ' .
+                    'for the following sites on which your admin account is ' .
+                    'used:'
+                ) .
+                    '</p><p><ul>';
 
-		if ($this->admin_user->name === null)
-			throw new AdminException('User requires a fullname to reset '.
-				'password. Make sure name is loaded on the user object.');
-
-		$this->to_address = $this->admin_user->email;
-		$this->to_name = $this->admin_user->name;
-		$this->text_body = $this->getTextBody();
-		$this->html_body = $this->getHtmlBody();
-
-		parent::send();
-	}
-
-
-
-
-	/**
-	 * Gets the plain-text content of this mail message
-	 *
-	 * @return string the plain-text content of this mail message.
-	 */
-	protected function getTextBody()
-	{
-		return sprintf($this->getFormattedBody(
-			"%s\n\n%s\n\n%%s%s\n\n%s\n%s\n\n%s\n%s",
-			$this->password_link),
-			$this->getTextInstanceNote());
-	}
-
-
-
-
-	/**
-	 * Gets the HTML content of this mail message
-	 *
-	 * @return string the HTML content of this mail message.
-	 */
-	protected function getHtmlBody()
-	{
-		return sprintf($this->getFormattedBody(
-			'<p>%s</p><p>%s</p>%%s<p>%s</p><p>%s<br />%s</p><p>%s<br />%s</p>',
-			sprintf('<a href="%1$s">%1$s</a>', $this->password_link)),
-			$this->getHtmlInstanceNote());
-	}
-
-
-
-
-	protected function getHtmlInstanceNote()
-	{
-		$instance_note = '';
-
-		if ($this->app->hasModule('SiteMultipleInstanceModule')) {
-			$site_instance =
-				$this->app->getModule('SiteMultipleInstanceModule');
-
-			if (count($this->admin_user->instances) > 1) {
-				$instance_note.= '<p>'.Admin::_(
-					'Notice: Your admin password will also be updated '.
-					'for the following sites on which your admin account is '.
-					'used:').
-					'</p><p><ul>';
-
-				foreach ($this->admin_user->instances as $instance) {
-					if ($instance->id !== $site_instance->getId()) {
-						$sql = sprintf('select value from InstanceConfigSetting
+                foreach ($this->admin_user->instances as $instance) {
+                    if ($instance->id !== $site_instance->getId()) {
+                        $sql = sprintf(
+                            'select value from InstanceConfigSetting
 							where instance = %s and name = \'site.title\'',
-							$this->app->db->quote($instance->id, 'integer'));
+                            $this->app->db->quote($instance->id, 'integer')
+                        );
 
-						$title = SwatDB::queryOne($this->app->db, $sql, 'text');
-						$instance_note.=
-							'<li>'.SwatString::minimizeEntities($title).'</li>';
-					}
-				}
+                        $title = SwatDB::queryOne($this->app->db, $sql, 'text');
+                        $instance_note .=
+                            '<li>' . SwatString::minimizeEntities($title) . '</li>';
+                    }
+                }
 
-				$instance_note.= '</ul></p>';
-			}
-		}
+                $instance_note .= '</ul></p>';
+            }
+        }
 
-		return $instance_note;
-	}
+        return $instance_note;
+    }
 
+    protected function getTextInstanceNote()
+    {
+        $instance_note = '';
 
+        if ($this->app->hasModule('SiteMultipleInstanceModule')) {
+            $site_instance =
+                $this->app->getModule('SiteMultipleInstanceModule');
 
+            if (count($this->admin_user->instances) > 1) {
+                $instance_note .= Admin::_(
+                    'Notice: Your admin password will also be updated ' .
+                    'for the following sites on which your admin account is ' .
+                    'used:'
+                ) . "\n\n";
 
-	protected function getTextInstanceNote()
-	{
-		$instance_note = '';
-
-		if ($this->app->hasModule('SiteMultipleInstanceModule')) {
-			$site_instance =
-				$this->app->getModule('SiteMultipleInstanceModule');
-
-			if (count($this->admin_user->instances) > 1) {
-				$instance_note.= Admin::_(
-					'Notice: Your admin password will also be updated '.
-					'for the following sites on which your admin account is '.
-					'used:')."\n\n";
-
-				foreach ($this->admin_user->instances as $instance) {
-					if ($instance->id !== $site_instance->getId()) {
-						$sql = sprintf('select value from InstanceConfigSetting
+                foreach ($this->admin_user->instances as $instance) {
+                    if ($instance->id !== $site_instance->getId()) {
+                        $sql = sprintf(
+                            'select value from InstanceConfigSetting
 							where instance = %s and name = \'site.title\'',
-							$this->app->db->quote($instance->id, 'integer'));
+                            $this->app->db->quote($instance->id, 'integer')
+                        );
 
-						$title = SwatDB::queryOne($this->app->db, $sql, 'text');
-						$instance_note.= " - ".$title."\n";
-					}
-				}
+                        $title = SwatDB::queryOne($this->app->db, $sql, 'text');
+                        $instance_note .= ' - ' . $title . "\n";
+                    }
+                }
 
-				$instance_note.= "\n";
-			}
-		}
+                $instance_note .= "\n";
+            }
+        }
 
-		return $instance_note;
-	}
+        return $instance_note;
+    }
 
-
-
-
-	protected function getFormattedBody($format_string, $formatted_link)
-	{
-		return sprintf($format_string,
-			sprintf(Admin::_('This email is in response to your recent '.
-			'request for a new password for your %s account. Your password '.
-			'has not yet been changed. Please click on the following link '.
-			'and follow the steps to change your account password:'),
-				$this->app->config->site->title),
-
-			$formatted_link,
-
-			Admin::_('Clicking on the above link will take you to a page that '.
-			'requires you to enter in and confirm a new password. Once you '.
-			'have chosen and confirmed your new password you will be taken to '.
-			'your account page.'),
-
-			Admin::_('Why did I get this email?'),
-
-			Admin::_('When someone forgets their password the best way '.
-			'for us to verify their identity is to send an email to the '.
-			'address listed in their account. By clicking on the link above '.
-			'you are verifying that you requested a new password for your '.
-			'account.'),
-
-			Admin::_('I did not request a new password:'),
-
-			sprintf(Admin::_('If you did not request a new password from %s '.
-			'then someone may have accidentally entered your email when '.
-			'requesting a new password. Have no fear! Your account '.
-			'information is safe. Simply ignore this email and continue '.
-			'using your existing password.'),
-				$this->app->config->site->title));
-	}
-
-
+    protected function getFormattedBody($format_string, $formatted_link)
+    {
+        return sprintf(
+            $format_string,
+            sprintf(
+                Admin::_('This email is in response to your recent ' .
+            'request for a new password for your %s account. Your password ' .
+            'has not yet been changed. Please click on the following link ' .
+            'and follow the steps to change your account password:'),
+                $this->app->config->site->title
+            ),
+            $formatted_link,
+            Admin::_('Clicking on the above link will take you to a page that ' .
+            'requires you to enter in and confirm a new password. Once you ' .
+            'have chosen and confirmed your new password you will be taken to ' .
+            'your account page.'),
+            Admin::_('Why did I get this email?'),
+            Admin::_('When someone forgets their password the best way ' .
+            'for us to verify their identity is to send an email to the ' .
+            'address listed in their account. By clicking on the link above ' .
+            'you are verifying that you requested a new password for your ' .
+            'account.'),
+            Admin::_('I did not request a new password:'),
+            sprintf(
+                Admin::_('If you did not request a new password from %s ' .
+            'then someone may have accidentally entered your email when ' .
+            'requesting a new password. Have no fear! Your account ' .
+            'information is safe. Simply ignore this email and continue ' .
+            'using your existing password.'),
+                $this->app->config->site->title
+            )
+        );
+    }
 }
-
-?>

--- a/Admin/AdminResetPasswordSuccessMailMessage.php
+++ b/Admin/AdminResetPasswordSuccessMailMessage.php
@@ -10,7 +10,7 @@
  */
 class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The user this reset password mail message is intended for
@@ -19,8 +19,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 	 */
 	protected $admin_user;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new reset password email
@@ -36,8 +36,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 		$this->admin_user = $user;
 	}
 
-	// }}}
-	// {{{ public function send()
+
+
 
 	/**
 	 * Sends this mail message
@@ -61,8 +61,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 		parent::send();
 	}
 
-	// }}}
-	// {{{ protected function getTextBody()
+
+
 
 	/**
 	 * Gets the plain-text content of this mail message
@@ -76,8 +76,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 			$this->getTextInstanceNote());
 	}
 
-	// }}}
-	// {{{ protected function getHtmlBody()
+
+
 
 	/**
 	 * Gets the HTML content of this mail message
@@ -91,8 +91,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 			$this->getHtmlInstanceNote());
 	}
 
-	// }}}
-	// {{{ protected function getHtmlInstanceNote()
+
+
 
 	protected function getHtmlInstanceNote()
 	{
@@ -128,8 +128,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 		return $instance_note;
 	}
 
-	// }}}
-	// {{{ protected function getTextInstanceNote()
+
+
 
 	protected function getTextInstanceNote()
 	{
@@ -163,8 +163,8 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 		return $instance_note;
 	}
 
-	// }}}
-	// {{{ protected function getFormattedBody()
+
+
 
 	protected function getFormattedBody($format_string)
 	{
@@ -187,7 +187,7 @@ class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 				$this->app->config->site->title));
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminResetPasswordSuccessMailMessage.php
+++ b/Admin/AdminResetPasswordSuccessMailMessage.php
@@ -2,192 +2,180 @@
 
 /**
  * Email that is sent to an admin user when their password has successfully
- * been reset
+ * been reset.
  *
- * @package   Admin
  * @copyright 2008-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminResetPasswordSuccessMailMessage extends SiteMultipartMailMessage
 {
+    /**
+     * The user this reset password mail message is intended for.
+     *
+     * @var AdminUser
+     */
+    protected $admin_user;
 
+    /**
+     * Creates a new reset password email.
+     *
+     * @param AdminApplication $app  the application sending the mail message
+     * @param AdminUser        $user the user for which to create the email
+     */
+    public function __construct(AdminApplication $app, AdminUser $user)
+    {
+        parent::__construct($app);
+        $this->admin_user = $user;
+    }
 
-	/**
-	 * The user this reset password mail message is intended for
-	 *
-	 * @var AdminUser
-	 */
-	protected $admin_user;
+    /**
+     * Sends this mail message.
+     */
+    public function send()
+    {
+        if ($this->admin_user->email === null) {
+            throw new AdminException('User requires an email address to ' .
+                'send message. Make sure email is loaded on the user ' .
+                'object.');
+        }
 
+        if ($this->admin_user->name === null) {
+            throw new AdminException('User requires a fullname to send ' .
+                'message. Make sure name is loaded on the user object.');
+        }
 
+        $this->to_address = $this->admin_user->email;
+        $this->to_name = $this->admin_user->name;
+        $this->text_body = $this->getTextBody();
+        $this->html_body = $this->getHtmlBody();
 
+        parent::send();
+    }
 
-	/**
-	 * Creates a new reset password email
-	 *
-	 * @param AdminApplication $app the application sending the mail message.
-	 * @param AdminUser $user the user for which to create the email.
-	 * @param string $password_link the URL of the application page that
-	 *                               performs the password reset.
-	 */
-	public function __construct(AdminApplication $app, AdminUser $user)
-	{
-		parent::__construct($app);
-		$this->admin_user = $user;
-	}
+    /**
+     * Gets the plain-text content of this mail message.
+     *
+     * @return string the plain-text content of this mail message
+     */
+    protected function getTextBody()
+    {
+        return sprintf(
+            $this->getFormattedBody(
+                "%s\n\n%%s%s\n%s\n\n%s\n%s"
+            ),
+            $this->getTextInstanceNote()
+        );
+    }
 
+    /**
+     * Gets the HTML content of this mail message.
+     *
+     * @return string the HTML content of this mail message
+     */
+    protected function getHtmlBody()
+    {
+        return sprintf(
+            $this->getFormattedBody(
+                '<p>%s</p>%%s<p>%s<br />%s</p><p>%s<br />%s</p>'
+            ),
+            $this->getHtmlInstanceNote()
+        );
+    }
 
+    protected function getHtmlInstanceNote()
+    {
+        $instance_note = '';
 
+        if ($this->app->hasModule('SiteMultipleInstanceModule')) {
+            $site_instance =
+                $this->app->getModule('SiteMultipleInstanceModule');
 
-	/**
-	 * Sends this mail message
-	 */
-	public function send()
-	{
-		if ($this->admin_user->email === null)
-			throw new AdminException('User requires an email address to '.
-				'send message. Make sure email is loaded on the user '.
-				'object.');
+            if (count($this->admin_user->instances) > 1) {
+                $instance_note .= '<p>' . Admin::_(
+                    'Notice: Your admin password was also updated ' .
+                    'for the following sites on which your admin account is ' .
+                    'used:'
+                ) .
+                    '</p><p><ul>';
 
-		if ($this->admin_user->name === null)
-			throw new AdminException('User requires a fullname to send '.
-				'message. Make sure name is loaded on the user object.');
-
-		$this->to_address = $this->admin_user->email;
-		$this->to_name = $this->admin_user->name;
-		$this->text_body = $this->getTextBody();
-		$this->html_body = $this->getHtmlBody();
-
-		parent::send();
-	}
-
-
-
-
-	/**
-	 * Gets the plain-text content of this mail message
-	 *
-	 * @return string the plain-text content of this mail message.
-	 */
-	protected function getTextBody()
-	{
-		return sprintf($this->getFormattedBody(
-			"%s\n\n%%s%s\n%s\n\n%s\n%s"),
-			$this->getTextInstanceNote());
-	}
-
-
-
-
-	/**
-	 * Gets the HTML content of this mail message
-	 *
-	 * @return string the HTML content of this mail message.
-	 */
-	protected function getHtmlBody()
-	{
-		return sprintf($this->getFormattedBody(
-			'<p>%s</p>%%s<p>%s<br />%s</p><p>%s<br />%s</p>'),
-			$this->getHtmlInstanceNote());
-	}
-
-
-
-
-	protected function getHtmlInstanceNote()
-	{
-		$instance_note = '';
-
-		if ($this->app->hasModule('SiteMultipleInstanceModule')) {
-			$site_instance =
-				$this->app->getModule('SiteMultipleInstanceModule');
-
-			if (count($this->admin_user->instances) > 1) {
-				$instance_note.= '<p>'.Admin::_(
-					'Notice: Your admin password was also updated '.
-					'for the following sites on which your admin account is '.
-					'used:').
-					'</p><p><ul>';
-
-				foreach ($this->admin_user->instances as $instance) {
-					if ($instance->id !== $site_instance->getId()) {
-						$sql = sprintf('select value from InstanceConfigSetting
+                foreach ($this->admin_user->instances as $instance) {
+                    if ($instance->id !== $site_instance->getId()) {
+                        $sql = sprintf(
+                            'select value from InstanceConfigSetting
 							where instance = %s and name = \'site.title\'',
-							$this->app->db->quote($instance->id, 'integer'));
+                            $this->app->db->quote($instance->id, 'integer')
+                        );
 
-						$title = SwatDB::queryOne($this->app->db, $sql, 'text');
-						$instance_note.=
-							'<li>'.SwatString::minimizeEntities($title).'</li>';
-					}
-				}
+                        $title = SwatDB::queryOne($this->app->db, $sql, 'text');
+                        $instance_note .=
+                            '<li>' . SwatString::minimizeEntities($title) . '</li>';
+                    }
+                }
 
-				$instance_note.= '</ul></p>';
-			}
-		}
+                $instance_note .= '</ul></p>';
+            }
+        }
 
-		return $instance_note;
-	}
+        return $instance_note;
+    }
 
+    protected function getTextInstanceNote()
+    {
+        $instance_note = '';
 
+        if ($this->app->hasModule('SiteMultipleInstanceModule')) {
+            $site_instance =
+                $this->app->getModule('SiteMultipleInstanceModule');
 
+            if (count($this->admin_user->instances) > 1) {
+                $instance_note .= Admin::_(
+                    'Notice: Your admin password was also updated ' .
+                    'for the following sites on which your admin account is ' .
+                    'used:'
+                ) . "\n\n";
 
-	protected function getTextInstanceNote()
-	{
-		$instance_note = '';
-
-		if ($this->app->hasModule('SiteMultipleInstanceModule')) {
-			$site_instance =
-				$this->app->getModule('SiteMultipleInstanceModule');
-
-			if (count($this->admin_user->instances) > 1) {
-				$instance_note.= Admin::_(
-					'Notice: Your admin password was also updated '.
-					'for the following sites on which your admin account is '.
-					'used:')."\n\n";
-
-				foreach ($this->admin_user->instances as $instance) {
-					if ($instance->id !== $site_instance->getId()) {
-						$sql = sprintf('select value from InstanceConfigSetting
+                foreach ($this->admin_user->instances as $instance) {
+                    if ($instance->id !== $site_instance->getId()) {
+                        $sql = sprintf(
+                            'select value from InstanceConfigSetting
 							where instance = %s and name = \'site.title\'',
-							$this->app->db->quote($instance->id, 'integer'));
+                            $this->app->db->quote($instance->id, 'integer')
+                        );
 
-						$title = SwatDB::queryOne($this->app->db, $sql, 'text');
-						$instance_note.= " - ".$title."\n";
-					}
-				}
+                        $title = SwatDB::queryOne($this->app->db, $sql, 'text');
+                        $instance_note .= ' - ' . $title . "\n";
+                    }
+                }
 
-				$instance_note.= "\n";
-			}
-		}
+                $instance_note .= "\n";
+            }
+        }
 
-		return $instance_note;
-	}
+        return $instance_note;
+    }
 
-
-
-
-	protected function getFormattedBody($format_string)
-	{
-		return sprintf($format_string,
-			sprintf(Admin::_('Your password for your %s account has '.
-			'successfully been updated.'),
-				$this->app->config->site->title),
-
-			Admin::_('Why did I get this email?'),
-
-			sprintf(Admin::_('This email confirms your password was '.
-			'successfully updated after requesting a new password.'),
-				$this->app->config->site->title),
-
-			Admin::_('I did not request a new password:'),
-
-			sprintf(Admin::_('If you did not request a new password from %s '.
-			'someone else has gained access to your account. If this is the '.
-			'case, please contact your system administrator immediately.'),
-				$this->app->config->site->title));
-	}
-
-
+    protected function getFormattedBody($format_string)
+    {
+        return sprintf(
+            $format_string,
+            sprintf(
+                Admin::_('Your password for your %s account has ' .
+            'successfully been updated.'),
+                $this->app->config->site->title
+            ),
+            Admin::_('Why did I get this email?'),
+            sprintf(
+                Admin::_('This email confirms your password was ' .
+            'successfully updated after requesting a new password.'),
+                $this->app->config->site->title
+            ),
+            Admin::_('I did not request a new password:'),
+            sprintf(
+                Admin::_('If you did not request a new password from %s ' .
+            'someone else has gained access to your account. If this is the ' .
+            'case, please contact your system administrator immediately.'),
+                $this->app->config->site->title
+            )
+        );
+    }
 }
-
-?>

--- a/Admin/AdminSearchClause.php
+++ b/Admin/AdminSearchClause.php
@@ -1,188 +1,174 @@
 <?php
 
 /**
- * Object for building SQL search clauses
+ * Object for building SQL search clauses.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSearchClause
 {
+    public const OP_EQUALS = 1;
+    public const OP_GT = 2;
+    public const OP_GTE = 3;
+    public const OP_LT = 4;
+    public const OP_LTE = 5;
+    public const OP_CONTAINS = 6;
+    public const OP_STARTS_WITH = 7;
+    public const OP_ENDS_WITH = 8;
 
+    /**
+     * Database field of this search clause.
+     *
+     * @var SwatDBField
+     */
+    private $field;
 
-	const OP_EQUALS      = 1;
-	const OP_GT          = 2;
-	const OP_GTE         = 3;
-	const OP_LT          = 4;
-	const OP_LTE         = 5;
-	const OP_CONTAINS    = 6;
-	const OP_STARTS_WITH = 7;
-	const OP_ENDS_WITH   = 8;
+    /**
+     * Value of this search clause.
+     *
+     * This value is always passed through PHP's trim() function.
+     *
+     * @var mixed
+     */
+    public $value;
 
+    /**
+     * Table prefix for the field.
+     *
+     * @var string
+     */
+    public $table;
 
+    /**
+     * Whether or not the search match should be case-sensitive.
+     *
+     * @var bool
+     */
+    public $case_sensitive = false;
 
+    /**
+     * Search operator.
+     *
+     * This value should be one of the AdminSearchClause::OP_* constants.
+     *
+     * @var int
+     */
+    public $operator = self::OP_EQUALS;
 
-	/**
-	 * Database field of this search clause
-	 *
-	 * @var SwatDBField
-	 */
-	private $field;
+    /**
+     * Creates a new search clause object.
+     *
+     * @param string $field a string representation of the database field to
+     *                      search in the form [<type>:]<name> where <name> is
+     *                      the name of the database field and <type> is any
+     *                      standard MDB2 datatype
+     * @param mixed  $value the value to search for
+     */
+    public function __construct($field, $value = null)
+    {
+        $this->field = new SwatDBField($field);
+        $this->value = $value;
+    }
 
+    /**
+     * Gets this search clause as a string that can be included in a SQL
+     * 'where' clause.
+     *
+     * @param MDB2_Driver_Common the database connection to use. This is used
+     *                            for correctly quoting the value of this
+     *                            search clause.
+     * @param string $logic_operator optional. The logical operator for this
+     *                               search clause. If no logical operator is
+     *                               needed, use a blank string. Defaults to
+     *                               'and'.
+     *
+     * @return string this search clause as a string that can be included in a
+     *                SQL 'where' clause
+     */
+    public function getClause(MDB2_Driver_Common $db, $logic_operator = 'and')
+    {
+        if ($this->value === null) {
+            return '';
+        }
 
+        $field = ($this->table === null) ? '' : $this->table . '.';
+        $field .= $this->field->name;
+        $value = trim($this->value);
 
+        if ($this->field->type == 'text') {
+            if (trim($this->value) == '') {
+                return null;
+            }
 
-	/**
-	 * Value of this search clause
-	 *
-	 * This value is always passed through PHP's trim() function.
-	 *
-	 * @var mixed
-	 */
-	public $value;
+            if (!$this->case_sensitive) {
+                $field = 'lower(' . $field . ')';
+                $value = mb_strtolower($value);
+            }
 
-	/**
-	 * Table prefix for the field
-	 *
-	 * @var string
-	 */
-	public $table = null;
+            if ($this->operator == self::OP_CONTAINS) {
+                $value = "%{$value}%";
+            } elseif ($this->operator == self::OP_STARTS_WITH) {
+                $value = "{$value}%";
+            } elseif ($this->operator == self::OP_ENDS_WITH) {
+                $value = "%{$value}";
+            }
+        } elseif ($this->field->type == 'integer') {
+            if (trim((string) $this->value) == '') {
+                return null;
+            }
+        } elseif ($this->field->type == 'date') {
+            if (is_object($value) && $value instanceof SwatDate) {
+                $value = $value->getDate();
+            }
+        }
 
-	/**
-	 * Whether or not the search match should be case-sensitive
-	 *
-	 * @var boolean
-	 */
-	public $case_sensitive = false;
+        $value = $db->quote($value, $this->field->type);
+        $operator = self::getOperatorString($this->operator);
 
-	/**
-	 * Search operator
-	 *
-	 * This value should be one of the AdminSearchClause::OP_* constants.
-	 *
-	 * @var integer
-	 */
-	public $operator = self::OP_EQUALS;
+        return " {$logic_operator} {$field} {$operator} {$value} ";
+    }
 
+    /**
+     * Gets a search clause operator constant as an SQL string.
+     *
+     * @param int $operator the search clause operator to get as an SQL
+     *                      string
+     *
+     * @return string the search clause operator as an SQL string. For example,
+     *                {AdminSearchClause::OP_GTE} returns '&gt;='.
+     */
+    private static function getOperatorString($operator)
+    {
+        $operator = intval($operator);
 
+        switch ($operator) {
+            case self::OP_EQUALS:
+                return '=';
 
+            case self::OP_GT:
+                return '>';
 
-	/**
-	 * Creates a new search clause object
-	 *
-	 * @param string $field a string representation of the database field to
-	 *                       search in the form [<type>:]<name> where <name> is
-	 *                       the name of the database field and <type> is any
-	 *                       standard MDB2 datatype.
-	 *
-	 * @param mixed $value the value to search for.
-	 */
-	public function __construct($field, $value = null)
-	{
-		$this->field = new SwatDBField($field);
-		$this->value = $value;
-	}
+            case self::OP_GTE:
+                return '>=';
 
+            case self::OP_LT:
+                return '<';
 
+            case self::OP_LTE:
+                return '<=';
 
+            case self::OP_CONTAINS:
+                return 'like';
 
-	/**
-	 * Gets this search clause as a string that can be included in a SQL
-	 * 'where' clause
-	 *
-	 * @param MDB2_Driver_Common the database connection to use. This is used
-	 *                            for correctly quoting the value of this
-	 *                            search clause.
-	 * @param string $logic_operator optional. The logical operator for this
-	 *                                search clause. If no logical operator is
-	 *                                needed, use a blank string. Defaults to
-	 *                                'and'.
-	 *
-	 * @return string this search clause as a string that can be included in a
-	 *                 SQL 'where' clause.
-	 */
-	public function getClause(MDB2_Driver_Common $db, $logic_operator = 'and')
-	{
-		if ($this->value === null)
-			return '';
+            case self::OP_STARTS_WITH:
+                return 'like';
 
-		$field = ($this->table === null) ? '' : $this->table.'.';
-		$field.= $this->field->name;
-		$value = trim($this->value);
+            case self::OP_ENDS_WITH:
+                return 'like';
 
-		if ($this->field->type == 'text') {
-			if (trim($this->value) == '')
-				return null;
-
-			if (!$this->case_sensitive) {
-				$field = 'lower('.$field.')';
-				$value = mb_strtolower($value);
-			}
-
-			if ($this->operator == self::OP_CONTAINS)
-				$value = "%{$value}%";
-			elseif ($this->operator == self::OP_STARTS_WITH)
-				$value = "{$value}%";
-			elseif ($this->operator == self::OP_ENDS_WITH)
-				$value = "%{$value}";
-
-		} elseif ($this->field->type == 'integer') {
-			if (trim((string)$this->value) == '')
-				return null;
-
-		} elseif ($this->field->type == 'date') {
-			if (is_object($value) && $value instanceof SwatDate) {
-				$value = $value->getDate();
-			}
-		}
-
-		$value = $db->quote($value, $this->field->type);
-		$operator = self::getOperatorString($this->operator);
-		$clause = " {$logic_operator} {$field} {$operator} {$value} ";
-
-		return $clause;
-	}
-
-
-
-
-	/**
-	 * Gets a search clause operator constant as an SQL string
-	 *
-	 * @param integer $operator the search clause operator to get as an SQL
-	 *                           string.
-	 *
-	 * @return string the search clause operator as an SQL string. For example,
-	 *                 {AdminSearchClause::OP_GTE} returns '&gt;='.
-	 */
-	private static function getOperatorString($operator)
-	{
-		$operator = intval($operator);
-
-		switch ($operator) {
-		case self::OP_EQUALS:
-			return '=';
-		case self::OP_GT:
-			return '>';
-		case self::OP_GTE:
-			return '>=';
-		case self::OP_LT:
-			return '<';
-		case self::OP_LTE:
-			return '<=';
-		case self::OP_CONTAINS:
-			return 'like';
-		case self::OP_STARTS_WITH:
-			return 'like';
-		case self::OP_ENDS_WITH:
-			return 'like';
-		default:
-			throw new AdminException('Unknown operator in clause: '.$operator);
-		}
-	}
-
-
+            default:
+                throw new AdminException('Unknown operator in clause: ' . $operator);
+        }
+    }
 }
-
-?>

--- a/Admin/AdminSearchClause.php
+++ b/Admin/AdminSearchClause.php
@@ -9,7 +9,7 @@
  */
 class AdminSearchClause
 {
-	// {{{ constants
+
 
 	const OP_EQUALS      = 1;
 	const OP_GT          = 2;
@@ -20,8 +20,8 @@ class AdminSearchClause
 	const OP_STARTS_WITH = 7;
 	const OP_ENDS_WITH   = 8;
 
-	// }}}
-	// {{{ private properties
+
+
 
 	/**
 	 * Database field of this search clause
@@ -30,8 +30,8 @@ class AdminSearchClause
 	 */
 	private $field;
 
-	// }}}
-	// {{{ public properties
+
+
 
 	/**
 	 * Value of this search clause
@@ -65,8 +65,8 @@ class AdminSearchClause
 	 */
 	public $operator = self::OP_EQUALS;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new search clause object
@@ -84,8 +84,8 @@ class AdminSearchClause
 		$this->value = $value;
 	}
 
-	// }}}
-	// {{{ public function getClause()
+
+
 
 	/**
 	 * Gets this search clause as a string that can be included in a SQL
@@ -144,8 +144,8 @@ class AdminSearchClause
 		return $clause;
 	}
 
-	// }}}
-	// {{{ private static function getOperatorString()
+
+
 
 	/**
 	 * Gets a search clause operator constant as an SQL string
@@ -182,7 +182,7 @@ class AdminSearchClause
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminSearchOperatorFlydown.php
+++ b/Admin/AdminSearchOperatorFlydown.php
@@ -9,7 +9,7 @@
  */
 class AdminSearchOperatorFlydown extends SwatFlydown
 {
-	// {{{ public properties
+
 
 	/**
 	 * Operators
@@ -26,8 +26,8 @@ class AdminSearchOperatorFlydown extends SwatFlydown
 		AdminSearchClause::OP_EQUALS,
 	);
 
-	// }}}
-	// {{{ public function display()
+
+
 
 	public function display()
 	{
@@ -44,8 +44,8 @@ class AdminSearchOperatorFlydown extends SwatFlydown
 		parent::display();
 	}
 
-	// }}}
-	// {{{ private static function getOperatorTitle()
+
+
 
 	private static function getOperatorTitle($id)
 	{
@@ -71,7 +71,7 @@ class AdminSearchOperatorFlydown extends SwatFlydown
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminSearchOperatorFlydown.php
+++ b/Admin/AdminSearchOperatorFlydown.php
@@ -3,75 +3,71 @@
 /**
  * A flydown selection widget for search operators.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSearchOperatorFlydown extends SwatFlydown
 {
+    /**
+     * Operators.
+     *
+     * An array of operator constants to display as option. The constants are
+     * defined in {@link AdminSearchClause}.
+     *
+     * @var array
+     */
+    public $operators = [
+        AdminSearchClause::OP_CONTAINS,
+        AdminSearchClause::OP_STARTS_WITH,
+        AdminSearchClause::OP_ENDS_WITH,
+        AdminSearchClause::OP_EQUALS,
+    ];
 
+    public function display()
+    {
+        if (!$this->visible) {
+            return;
+        }
 
-	/**
-	 * Operators
-	 *
-	 * An array of operator constants to display as option. The constants are
-	 * defined in {@link AdminSearchClause}.
-	 *
-	 * @var array
-	 */
-	public $operators = array(
-		AdminSearchClause::OP_CONTAINS,
-		AdminSearchClause::OP_STARTS_WITH,
-		AdminSearchClause::OP_ENDS_WITH,
-		AdminSearchClause::OP_EQUALS,
-	);
+        $this->options = [];
+        $this->show_blank = false;
 
+        foreach ($this->operators as $op) {
+            $this->addOption($op, self::getOperatorTitle($op));
+        }
 
+        parent::display();
+    }
 
+    private static function getOperatorTitle($id)
+    {
+        switch ($id) {
+            case AdminSearchClause::OP_EQUALS:
+                return Admin::_('is');
 
-	public function display()
-	{
-		if (!$this->visible)
-			return;
+            case AdminSearchClause::OP_GT:
+                return '>';
 
-		$this->options = array();
-		$this->show_blank = false;
+            case AdminSearchClause::OP_GTE:
+                return '>=';
 
-		foreach ($this->operators as $op) {
-			$this->addOption($op, self::getOperatorTitle($op));
-		}
+            case AdminSearchClause::OP_LT:
+                return '<';
 
-		parent::display();
-	}
+            case AdminSearchClause::OP_LTE:
+                return '<=';
 
+            case AdminSearchClause::OP_CONTAINS:
+                return Admin::_('contains');
 
+            case AdminSearchClause::OP_STARTS_WITH:
+                return Admin::_('starts with');
 
+            case AdminSearchClause::OP_ENDS_WITH:
+                return Admin::_('ends with');
 
-	private static function getOperatorTitle($id)
-	{
-		switch ($id) {
-		case AdminSearchClause::OP_EQUALS:
-			return Admin::_('is');
-		case AdminSearchClause::OP_GT:
-			return '>';
-		case AdminSearchClause::OP_GTE:
-			return '>=';
-		case AdminSearchClause::OP_LT:
-			return '<';
-		case AdminSearchClause::OP_LTE:
-			return '<=';
-		case AdminSearchClause::OP_CONTAINS:
-			return Admin::_('contains');
-		case AdminSearchClause::OP_STARTS_WITH:
-			return Admin::_('starts with');
-		case AdminSearchClause::OP_ENDS_WITH:
-			return Admin::_('ends with');
-		default:
-			throw new Exception('AdminSearchOperatorFlydown: unknown operator');
-		}
-	}
-
-
+            default:
+                throw new Exception('AdminSearchOperatorFlydown: unknown operator');
+        }
+    }
 }
-
-?>

--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -9,7 +9,7 @@
  */
 class AdminSessionModule extends SiteSessionModule
 {
-	// {{{ protected properties
+
 
 	/**
 	 * @var array
@@ -17,8 +17,8 @@ class AdminSessionModule extends SiteSessionModule
 	 */
 	protected $login_callbacks = array();
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a admin session module
@@ -39,8 +39,8 @@ class AdminSessionModule extends SiteSessionModule
 		parent::__construct($app);
 	}
 
-	// }}}
-	// {{{ public function init()
+
+
 
 	public function init()
 	{
@@ -59,8 +59,8 @@ class AdminSessionModule extends SiteSessionModule
 		}
 	}
 
-	// }}}
-	// {{{ public function depends()
+
+
 
 	/**
 	 * Gets the module features this module depends on
@@ -80,8 +80,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $depends;
 	}
 
-	// }}}
-	// {{{ public function login()
+
+
 
 	/**
 	 * Logs an admin user into an admin
@@ -126,8 +126,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $this->isLoggedIn();
 	}
 
-	// }}}
-	// {{{ public function logout()
+
+
 
 	/**
 	 * Logs the current admin user out of an admin
@@ -138,8 +138,8 @@ class AdminSessionModule extends SiteSessionModule
 		$this->user = null;
 	}
 
-	// }}}
-	// {{{ public function isLoggedIn()
+
+
 
 	/**
 	 * Gets whether or not an admin user is logged in
@@ -153,8 +153,8 @@ class AdminSessionModule extends SiteSessionModule
 			$this->user->isAuthenticated($this->app));
 	}
 
-	// }}}
-	// {{{ public function getUser()
+
+
 
 	/**
 	 * Gets the current admin user
@@ -170,8 +170,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $this->user;
 	}
 
-	// }}}
-	// {{{ public function getUserID()
+
+
 
 	/**
 	 * Gets the current admin user's user identifier
@@ -187,8 +187,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $this->user->id;
 	}
 
-	// }}}
-	// {{{ public function getEmailAddress()
+
+
 
 	/**
 	 * Gets the current admin user's email address
@@ -204,8 +204,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $this->user->email;
 	}
 
-	// }}}
-	// {{{ public function getName()
+
+
 
 	/**
 	 * Gets the current admin user's name
@@ -221,8 +221,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $this->user->name;
 	}
 
-	// }}}
-	// {{{ public function loginWithTwoFactorAuthentication()
+
+
 
 	/**
 	 * loginWithTwoFactorAuthentication
@@ -250,8 +250,8 @@ class AdminSessionModule extends SiteSessionModule
 		return $success;
 	}
 
-	// }}}
-	// {{{ public function registerLoginCallback()
+
+
 
 	/**
 	 * Registers a callback function that is executed when a successful session
@@ -282,8 +282,8 @@ class AdminSessionModule extends SiteSessionModule
 		);
 	}
 
-	// }}}
-	// {{{ protected function startSession()
+
+
 
 	protected function startSession()
 	{
@@ -294,8 +294,8 @@ class AdminSessionModule extends SiteSessionModule
 		}
 	}
 
-	// }}}
-	// {{{ protected function insertUserHistory()
+
+
 
 	/**
 	 * Inserts login history for a user
@@ -334,8 +334,8 @@ class AdminSessionModule extends SiteSessionModule
 			$values);
 	}
 
-	// }}}
-	// {{{ protected function runLoginCallbacks()
+
+
 
 	protected function runLoginCallbacks()
 	{
@@ -346,7 +346,7 @@ class AdminSessionModule extends SiteSessionModule
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -1,352 +1,315 @@
 <?php
 
 /**
- * Web application module for sessions
+ * Web application module for sessions.
  *
- * @package   Admin
  * @copyright 2005-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSessionModule extends SiteSessionModule
 {
-
-
-	/**
-	 * @var array
-	 * @see AdminSessionModule::registerLoginCallback()
-	 */
-	protected $login_callbacks = array();
-
-
-
-
-	/**
-	 * Creates a admin session module
-	 *
-	 * @param SiteApplication $app the application this module belongs to.
-	 *
-	 * @throws AdminException if there is no cookie module loaded the session
-	 *                         module throws an exception.
-	 *
-	 * @throws AdminException if there is no database module loaded the session
-	 *                         module throws an exception.
-	 */
-	public function __construct(SiteApplication $app)
-	{
-		$this->registerLoginCallback(
-			array($this, 'regenerateAuthenticationToken'));
-
-		parent::__construct($app);
-	}
-
-
-
-
-	public function init()
-	{
-		parent::init();
-
-		// always activate the session for an admin
-		if (!$this->isActive())
-			$this->activate();
-
-		if (!isset($this->user)) {
-			$this->user = null;
-			$this->history = array();
-		} elseif ($this->user !== null) {
-			$this->app->cookie->setCookie('email', $this->getEmailAddress(),
-				strtotime('+1 day'), '/');
-		}
-	}
-
-
-
-
-	/**
-	 * Gets the module features this module depends on
-	 *
-	 * The admin session module depends on the SiteCookieModule and
-	 * SiteDatabaseModule features.
-	 *
-	 * @return array an array of {@link SiteModuleDependency} objects defining
-	 *                        the features this module depends on.
-	 */
-	public function depends()
-	{
-		$depends = parent::depends();
-		$depends[] = new SiteApplicationModuleDependency('SiteCookieModule');
-		$depends[] = new SiteApplicationModuleDependency('SiteCryptModule');
-		$depends[] = new SiteApplicationModuleDependency('SiteDatabaseModule');
-		return $depends;
-	}
-
-
-
-
-	/**
-	 * Logs an admin user into an admin
-	 *
-	 * @param string $email
-	 * @param string $password
-	 *
-	 * @return boolean true if the admin user was logged in is successfully and
-	 *                  false if the admin user could not log in.
-	 */
-	public function login($email, $password)
-	{
-		$this->logout(); // make sure user is logged out before logging in
-
-		$class_name = SwatDBClassMap::get('AdminUser');
-		$user = new $class_name();
-		$user->setDatabase($this->app->db);
-
-		if ($user->loadFromEmail($email)) {
-			$password_hash = $user->password;
-			$password_salt = $user->password_salt;
-
-			$crypt = $this->app->getModule('SiteCryptModule');
-
-			if ($crypt->verifyHash($password, $password_hash, $password_salt)) {
-				// No Crypt?! Crypt!
-				if ($crypt->shouldUpdateHash($password_hash)) {
-					$user->setPasswordHash($crypt->generateHash($password));
-					$user->save();
-				}
-
-				$this->user = $user;
-				$this->user->set2FaAuthenticated(false);
-
-				if ($user->isAuthenticated($this->app)) {
-					$this->insertUserHistory($user);
-					$this->runLoginCallbacks();
-				}
-			}
-		}
-
-		return $this->isLoggedIn();
-	}
-
-
-
-
-	/**
-	 * Logs the current admin user out of an admin
-	 */
-	public function logout()
-	{
-		$this->clear();
-		$this->user = null;
-	}
-
-
-
-
-	/**
-	 * Gets whether or not an admin user is logged in
-	 *
-	 * @return boolean true if an admin user is logged in and false if an
-	 *                  admin user is not logged in.
-	 */
-	public function isLoggedIn()
-	{
-		return (isset($this->user) && $this->user !== null &&
-			$this->user->isAuthenticated($this->app));
-	}
-
-
-
-
-	/**
-	 * Gets the current admin user
-	 *
-	 * @return AdminUser the current admin user object, or null if an
-	 *                   admin user is not logged in.
-	 */
-	public function getUser()
-	{
-		if (!$this->isLoggedIn())
-			return null;
-
-		return $this->user;
-	}
-
-
-
-
-	/**
-	 * Gets the current admin user's user identifier
-	 *
-	 * @return string the current admin user's user identifier, or null if an
-	 *                 admin user is not logged in.
-	 */
-	public function getUserID()
-	{
-		if (!$this->isLoggedIn())
-			return null;
-
-		return $this->user->id;
-	}
-
-
-
-
-	/**
-	 * Gets the current admin user's email address
-	 *
-	 * @return string the current admin user's email address, or null if an
-	 *                 admin user is not logged in.
-	 */
-	public function getEmailAddress()
-	{
-		if (!$this->isLoggedIn())
-			return null;
-
-		return $this->user->email;
-	}
-
-
-
-
-	/**
-	 * Gets the current admin user's name
-	 *
-	 * @return string the current admin user's name, or null if an admin user
-	 *                 is not logged in.
-	 */
-	public function getName()
-	{
-		if (!$this->isLoggedIn())
-			return null;
-
-		return $this->user->name;
-	}
-
-
-
-
-	/**
-	 * loginWithTwoFactorAuthentication
-	 *
-	 * @param string $token
-	 *
-	 * @return boolean true if the admin user was logged in is successfully and
-	 *                  false if the admin user could not log in.
-	 */
-	public function loginWithTwoFactorAuthentication($token)
-	{
-		$two_factor_authentication = new AdminTwoFactorAuthentication();
-		$success = $two_factor_authentication->validateToken(
-			$this->user->two_fa_secret,
-			$token,
-			$this->user->two_fa_timeslice
-		);
-
-		if ($success) {
-			$this->user->save();
-			$this->insertUserHistory($this->user);
-			$this->runLoginCallbacks();
-		}
-
-		return $success;
-	}
-
-
-
-
-	/**
-	 * Registers a callback function that is executed when a successful session
-	 * login is performed
-	 *
-	 * @param callback $callback the callback to call when a successful login
-	 *                            is performed.
-	 * @param array $parameters optional. The paramaters to pass to the
-	 *                           callback.
-	 *
-	 * @throws AdminException when the <i>$callback</i> parameter is not
-	 *                        callable.
-	 * @throws AdminException when the <i>$parameters</i> parameter is not an
-	 *                        array.
-	 */
-	public function registerLoginCallback($callback, $parameters = array())
-	{
-		if (!is_callable($callback))
-			throw new AdminException('Cannot register invalid callback.');
-
-		if (!is_array($parameters))
-			throw new AdminException('Callback parameters must be specified '.
-				'in an array.');
-
-		$this->login_callbacks[] = array(
-			'callback' => $callback,
-			'parameters' => $parameters
-		);
-	}
-
-
-
-
-	protected function startSession()
-	{
-		parent::startSession();
-
-		if (isset($this->user) && $this->user instanceof AdminUser) {
-			$this->user->setDatabase($this->app->database->getConnection());
-		}
-	}
-
-
-
-
-	/**
-	 * Inserts login history for a user
-	 *
-	 * @param AdminUser $user_id the user to record login history for.
-	 */
-	protected function insertUserHistory(AdminUser $user)
-	{
-		$login_agent = (isset($_SERVER['HTTP_USER_AGENT'])) ?
-			$_SERVER['HTTP_USER_AGENT'] : null;
-
-		$remote_ip = $this->app->getRemoteIP();
-
-		if (mb_strlen($login_agent) > 255) {
-			$login_agent = mb_substr($login_agent, 0, 253).' …';
-		}
-		if (mb_strlen($remote_ip) > 15) {
-			$remote_ip = mb_substr($remote_ip, 0, 13).' …';
-		}
-
-		$login_date = new SwatDate();
-		$login_date->toUTC();
-
-		$fields = array('integer:usernum','date:login_date',
-			'text:login_agent', 'text:remote_ip', 'integer:instance');
-
-		$values = array(
-			'usernum'     => $user->id,
-			'login_date'  => $login_date->getDate(),
-			'login_agent' => $login_agent,
-			'remote_ip'   => $remote_ip,
-			'instance'    => $this->app->getInstanceId(),
-		);
-
-		SwatDB::insertRow($this->app->db, 'AdminUserHistory', $fields,
-			$values);
-	}
-
-
-
-
-	protected function runLoginCallbacks()
-	{
-		foreach ($this->login_callbacks as $login_callback) {
-			$callback = $login_callback['callback'];
-			$parameters = $login_callback['parameters'];
-			call_user_func_array($callback, $parameters);
-		}
-	}
-
-
+    /**
+     * @var array
+     *
+     * @see AdminSessionModule::registerLoginCallback()
+     */
+    protected $login_callbacks = [];
+
+    /**
+     * Creates a admin session module.
+     *
+     * @param SiteApplication $app the application this module belongs to
+     *
+     * @throws AdminException if there is no cookie module loaded the session
+     *                        module throws an exception
+     * @throws AdminException if there is no database module loaded the session
+     *                        module throws an exception
+     */
+    public function __construct(SiteApplication $app)
+    {
+        $this->registerLoginCallback(
+            [$this, 'regenerateAuthenticationToken']
+        );
+
+        parent::__construct($app);
+    }
+
+    public function init()
+    {
+        parent::init();
+
+        // always activate the session for an admin
+        if (!$this->isActive()) {
+            $this->activate();
+        }
+
+        if (!isset($this->user)) {
+            $this->user = null;
+            $this->history = [];
+        } elseif ($this->user !== null) {
+            $this->app->cookie->setCookie(
+                'email',
+                $this->getEmailAddress(),
+                strtotime('+1 day'),
+                '/'
+            );
+        }
+    }
+
+    /**
+     * Gets the module features this module depends on.
+     *
+     * The admin session module depends on the SiteCookieModule and
+     * SiteDatabaseModule features.
+     *
+     * @return array an array of {@link SiteModuleDependency} objects defining
+     *               the features this module depends on
+     */
+    public function depends()
+    {
+        $depends = parent::depends();
+        $depends[] = new SiteApplicationModuleDependency('SiteCookieModule');
+        $depends[] = new SiteApplicationModuleDependency('SiteCryptModule');
+        $depends[] = new SiteApplicationModuleDependency('SiteDatabaseModule');
+
+        return $depends;
+    }
+
+    /**
+     * Logs an admin user into an admin.
+     *
+     * @param string $email
+     * @param string $password
+     *
+     * @return bool true if the admin user was logged in is successfully and
+     *              false if the admin user could not log in
+     */
+    public function login($email, $password)
+    {
+        $this->logout(); // make sure user is logged out before logging in
+
+        $class_name = SwatDBClassMap::get('AdminUser');
+        $user = new $class_name();
+        $user->setDatabase($this->app->db);
+
+        if ($user->loadFromEmail($email)) {
+            $password_hash = $user->password;
+            $password_salt = $user->password_salt;
+
+            $crypt = $this->app->getModule('SiteCryptModule');
+
+            if ($crypt->verifyHash($password, $password_hash, $password_salt)) {
+                // No Crypt?! Crypt!
+                if ($crypt->shouldUpdateHash($password_hash)) {
+                    $user->setPasswordHash($crypt->generateHash($password));
+                    $user->save();
+                }
+
+                $this->user = $user;
+                $this->user->set2FaAuthenticated(false);
+
+                if ($user->isAuthenticated($this->app)) {
+                    $this->insertUserHistory($user);
+                    $this->runLoginCallbacks();
+                }
+            }
+        }
+
+        return $this->isLoggedIn();
+    }
+
+    /**
+     * Logs the current admin user out of an admin.
+     */
+    public function logout()
+    {
+        $this->clear();
+        $this->user = null;
+    }
+
+    /**
+     * Gets whether or not an admin user is logged in.
+     *
+     * @return bool true if an admin user is logged in and false if an
+     *              admin user is not logged in
+     */
+    public function isLoggedIn()
+    {
+        return isset($this->user) && $this->user !== null
+            && $this->user->isAuthenticated($this->app);
+    }
+
+    /**
+     * Gets the current admin user.
+     *
+     * @return AdminUser the current admin user object, or null if an
+     *                   admin user is not logged in
+     */
+    public function getUser()
+    {
+        if (!$this->isLoggedIn()) {
+            return null;
+        }
+
+        return $this->user;
+    }
+
+    /**
+     * Gets the current admin user's user identifier.
+     *
+     * @return string the current admin user's user identifier, or null if an
+     *                admin user is not logged in
+     */
+    public function getUserID()
+    {
+        if (!$this->isLoggedIn()) {
+            return null;
+        }
+
+        return $this->user->id;
+    }
+
+    /**
+     * Gets the current admin user's email address.
+     *
+     * @return string the current admin user's email address, or null if an
+     *                admin user is not logged in
+     */
+    public function getEmailAddress()
+    {
+        if (!$this->isLoggedIn()) {
+            return null;
+        }
+
+        return $this->user->email;
+    }
+
+    /**
+     * Gets the current admin user's name.
+     *
+     * @return string the current admin user's name, or null if an admin user
+     *                is not logged in
+     */
+    public function getName()
+    {
+        if (!$this->isLoggedIn()) {
+            return null;
+        }
+
+        return $this->user->name;
+    }
+
+    /**
+     * loginWithTwoFactorAuthentication.
+     *
+     * @param string $token
+     *
+     * @return bool true if the admin user was logged in is successfully and
+     *              false if the admin user could not log in
+     */
+    public function loginWithTwoFactorAuthentication($token)
+    {
+        $two_factor_authentication = new AdminTwoFactorAuthentication();
+        $success = $two_factor_authentication->validateToken(
+            $this->user->two_fa_secret,
+            $token,
+            $this->user->two_fa_timeslice
+        );
+
+        if ($success) {
+            $this->user->save();
+            $this->insertUserHistory($this->user);
+            $this->runLoginCallbacks();
+        }
+
+        return $success;
+    }
+
+    /**
+     * Registers a callback function that is executed when a successful session
+     * login is performed.
+     *
+     * @param callable $callback   the callback to call when a successful login
+     *                             is performed
+     * @param array    $parameters optional. The paramaters to pass to the
+     *                             callback.
+     *
+     * @throws AdminException when the <i>$callback</i> parameter is not
+     *                        callable
+     * @throws AdminException when the <i>$parameters</i> parameter is not an
+     *                        array
+     */
+    public function registerLoginCallback($callback, $parameters = [])
+    {
+        if (!is_callable($callback)) {
+            throw new AdminException('Cannot register invalid callback.');
+        }
+
+        if (!is_array($parameters)) {
+            throw new AdminException('Callback parameters must be specified ' .
+                'in an array.');
+        }
+
+        $this->login_callbacks[] = [
+            'callback'   => $callback,
+            'parameters' => $parameters,
+        ];
+    }
+
+    protected function startSession()
+    {
+        parent::startSession();
+
+        if (isset($this->user) && $this->user instanceof AdminUser) {
+            $this->user->setDatabase($this->app->database->getConnection());
+        }
+    }
+
+    /**
+     * Inserts login history for a user.
+     */
+    protected function insertUserHistory(AdminUser $user)
+    {
+        $login_agent = (isset($_SERVER['HTTP_USER_AGENT'])) ?
+            $_SERVER['HTTP_USER_AGENT'] : null;
+
+        $remote_ip = $this->app->getRemoteIP();
+
+        if (mb_strlen($login_agent) > 255) {
+            $login_agent = mb_substr($login_agent, 0, 253) . ' …';
+        }
+        if (mb_strlen($remote_ip) > 15) {
+            $remote_ip = mb_substr($remote_ip, 0, 13) . ' …';
+        }
+
+        $login_date = new SwatDate();
+        $login_date->toUTC();
+
+        $fields = ['integer:usernum', 'date:login_date',
+            'text:login_agent', 'text:remote_ip', 'integer:instance'];
+
+        $values = [
+            'usernum'     => $user->id,
+            'login_date'  => $login_date->getDate(),
+            'login_agent' => $login_agent,
+            'remote_ip'   => $remote_ip,
+            'instance'    => $this->app->getInstanceId(),
+        ];
+
+        SwatDB::insertRow(
+            $this->app->db,
+            'AdminUserHistory',
+            $fields,
+            $values
+        );
+    }
+
+    protected function runLoginCallbacks()
+    {
+        foreach ($this->login_callbacks as $login_callback) {
+            $callback = $login_callback['callback'];
+            $parameters = $login_callback['parameters'];
+            call_user_func_array($callback, $parameters);
+        }
+    }
 }
-
-?>

--- a/Admin/AdminSessionModule.php
+++ b/Admin/AdminSessionModule.php
@@ -88,7 +88,7 @@ class AdminSessionModule extends SiteSessionModule
     {
         $this->logout(); // make sure user is logged out before logging in
 
-        $class_name = SwatDBClassMap::get('AdminUser');
+        $class_name = SwatDBClassMap::get(AdminUser::class);
         $user = new $class_name();
         $user->setDatabase($this->app->db);
 

--- a/Admin/AdminSummaryDependency.php
+++ b/Admin/AdminSummaryDependency.php
@@ -1,195 +1,195 @@
 <?php
 
 /**
- * A dependency that displays a one line summary of dependent items
+ * A dependency that displays a one line summary of dependent items.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSummaryDependency extends AdminDependency
 {
+    /**
+     * Array of {@link AdminDependencySummary} objects to be displayed.
+     *
+     * While this is a flat array, the objects in the array contain tree
+     * structure information in their properties.
+     *
+     * Such an array may be automatically constructed from database data by
+     * calling the static convenience method
+     * {@link AdminSummaryDependency::querySummaries()}.
+     *
+     * @var array
+     *
+     * @see AdminDependencySummary, AdminDependencySummaryWrapper
+     */
+    public $summaries = [];
 
+    /**
+     * Gets the number of items in this dependency at a given status level.
+     *
+     * The number of items is calculated as the total summary count at the
+     * given status level.
+     *
+     * @param int $status_level the status level to count items in
+     *
+     * @return int the number of items at the given status level in this
+     *             dependency
+     */
+    public function getStatusLevelCount($status_level)
+    {
+        $count = 0;
+        foreach ($this->summaries as &$summary) {
+            if ($summary->status_level === $status_level) {
+                $count += $summary->count;
+            }
+        }
 
-	/**
-	 * Array of {@link AdminDependencySummary} objects to be displayed
-	 *
-	 * While this is a flat array, the objects in the array contain tree
-	 * structure information in their properties.
-	 *
-	 * Such an array may be automatically constructed from database data by
-	 * calling the static convenience method
-	 * {@link AdminSummaryDependency::querySummaries()}.
-	 *
-	 * @var array
-	 * @see AdminDependencySummary, AdminDependencySummaryWrapper
-	 */
-	public $summaries = array();
+        return $count;
+    }
 
+    /**
+     * Counts the number of items in this dependency.
+     *
+     * The count is calculated as the total of all the summary counts.
+     *
+     * @return int the number of items in this dependency
+     */
+    public function getItemCount()
+    {
+        $total = 0;
+        foreach ($this->summaries as &$summary) {
+            $total += $summary->count;
+        }
 
+        return $total;
+    }
 
+    /**
+     * Processes the status level of summaries in this dependency.
+     *
+     * @param $parent mixed the parent identifier of summaries to process
+     *
+     * @see AdminDependency::processItemStatuses()
+     */
+    public function processItemStatuses($parent = null)
+    {
+        $return = self::DELETE;
 
-	/**
-	 * Gets the number of items in this dependency at a given status level
-	 *
-	 * The number of items is calculated as the total summary count at the
-	 * given status level.
-	 *
-	 * @param integer $status_level the status level to count items in.
-	 *
-	 * @return integer the number of items at the given status level in this
-	 *                  dependency.
-	 */
-	public function getStatusLevelCount($status_level)
-	{
-		$count = 0;
-		foreach ($this->summaries as &$summary)
-			if ($summary->status_level === $status_level)
-				$count += $summary->count;
+        foreach ($this->summaries as &$summary) {
+            if ($parent === null || $summary->parent === $parent) {
+                $return = max($return, $summary->status_level);
+            }
+        }
 
-		return $count;
-	}
+        return $return;
+    }
 
+    /**
+     * Displays dependency summaries for the given parent at a given status
+     * level.
+     *
+     * @param int $parent       the id of the parent to display summaries for
+     * @param int $status_level the status level to display the summaries
+     *                          for
+     */
+    public function displayDependencies($parent, $status_level)
+    {
+        $count = 0;
+        foreach ($this->summaries as $summary) {
+            if ($summary->parent == $parent
+                && $summary->status_level === $status_level) {
+                $count += $summary->count;
+            }
+        }
 
+        if ($count > 0) {
+            $span_tag = new SwatHtmlTag('span');
+            $span_tag->class = 'admin-light';
+            $span_tag->setContent($this->getDependencyText($count));
 
+            $span_tag->open();
+            echo ' (';
+            $span_tag->displayContent();
+            echo ')';
+            $span_tag->close();
+        }
+    }
 
-	/**
-	 * Counts the number of items in this dependency
-	 *
-	 * The count is calculated as the total of all the summary counts.
-	 *
-	 * @return integer the number of items in this dependency.
-	 */
-	public function getItemCount()
-	{
-		$total = 0;
-		foreach ($this->summaries as &$summary)
-			$total += $summary->count;
+    /**
+     * @param mixed      $db
+     * @param mixed      $table
+     * @param mixed      $id_field
+     * @param mixed      $parent_field
+     * @param mixed|null $where_clause
+     * @param mixed      $status_level
+     */
+    public static function &querySummaries(
+        $db,
+        $table,
+        $id_field,
+        $parent_field,
+        $where_clause = null,
+        $status_level = 0
+    ) {
+        $id_field = new SwatDBField($id_field, 'integer');
 
-		return $total;
-	}
+        if ($parent_field === null) {
+            $parent_value = 'null';
+            $types = [$id_field->type, 'integer', 'integer'];
+        } else {
+            $parent_field = new SwatDBField($parent_field, 'integer');
+            $parent_value = $parent_field->name;
+            $types = [$id_field->type, $parent_field->type, 'integer'];
+        }
 
-
-
-
-	/**
-	 * Processes the status level of summaries in this dependency
-	 *
-	 * @param $parent mixed the parent identifier of summaries to process.
-	 *
-	 * @see AdminDependency::processItemStatuses()
-	 */
-	public function processItemStatuses($parent = null)
-	{
-		$return = self::DELETE;
-
-		foreach ($this->summaries as &$summary)
-			if ($parent === null || $summary->parent === $parent)
-				$return = max($return, $summary->status_level);
-
-		return $return;
-	}
-
-
-
-
-	/**
-	 * Displays dependency summaries for the given parent at a given status
-	 * level
-	 *
-	 * @param integer $parent the id of the parent to display summaries for.
-	 * @param integer $status_level the status level to display the summaries
-	 *                               for.
-	 */
-	public function displayDependencies($parent, $status_level)
-	{
-		$count = 0;
-		foreach ($this->summaries as $summary)
-			if ($summary->parent == $parent &&
-				$summary->status_level === $status_level)
-				$count += $summary->count;
-
-		if ($count > 0) {
-			$span_tag = new SwatHtmlTag('span');
-			$span_tag->class = 'admin-light';
-			$span_tag->setContent($this->getDependencyText($count));
-
-			$span_tag->open();
-			echo ' (';
-			$span_tag->displayContent();
-			echo ')';
-			$span_tag->close();
-		}
-	}
-
-
-
-
-	/**
-	 *
-	 * @return
-	 */
-	public static function &querySummaries(
-		$db,
-		$table,
-		$id_field,
-		$parent_field,
-		$where_clause = null,
-		$status_level = 0
-	) {
-		$id_field = new SwatDBField($id_field, 'integer');
-
-		if ($parent_field === null) {
-			$parent_value = 'null';
-			$types = array($id_field->type, 'integer', 'integer');
-		} else {
-			$parent_field = new SwatDBField($parent_field, 'integer');
-			$parent_value = $parent_field->name;
-			$types = array($id_field->type, $parent_field->type, 'integer');
-		}
-
-		$sql = sprintf('select count(%s) as count, %s as parent,
+        $sql = sprintf(
+            'select count(%s) as count, %s as parent,
 				%s::integer as status_level from %s',
-			$id_field->name, $parent_value, $status_level, $table);
+            $id_field->name,
+            $parent_value,
+            $status_level,
+            $table
+        );
 
-		if ($where_clause !== null)
-			$sql.= ' where '.$where_clause;
+        if ($where_clause !== null) {
+            $sql .= ' where ' . $where_clause;
+        }
 
-		if ($parent_field !== null)
-			$sql.= ' group by '.$parent_field->name;
+        if ($parent_field !== null) {
+            $sql .= ' group by ' . $parent_field->name;
+        }
 
-		$entries = SwatDB::query($db, $sql, 'AdminDependencySummaryWrapper',
-			$types);
+        $entries = SwatDB::query(
+            $db,
+            $sql,
+            'AdminDependencySummaryWrapper',
+            $types
+        );
 
-		$entry_array = $entries->getArray();
-		return $entry_array;
-	}
+        $entry_array = $entries->getArray();
 
+        return $entry_array;
+    }
 
+    /**
+     * Gets the text for a dependency list summary for this dependency.
+     *
+     * Sub-classes are encouraged to override this method to provide more
+     * descriptive or meaningful text.
+     *
+     * @param int $count the number of items
+     *
+     * @return string the text for a summary item in this dependency
+     */
+    protected function getDependencyText($count)
+    {
+        $title = $this->getTitle($count);
+        $message = Admin::ngettext(
+            '%s dependent %s',
+            '%s dependent %s',
+            $count
+        );
 
-
-	/**
-	 * Gets the text for a dependency list summary for this dependency
-	 *
-	 * Sub-classes are encouraged to override this method to provide more
-	 * descriptive or meaningful text.
-	 *
-	 * @param integer $count the number of items.
-	 *
-	 * @return string the text for a summary item in this dependency.
-	 */
-	protected function getDependencyText($count)
-	{
-		$title = $this->getTitle($count);
-		$message = Admin::ngettext(
-			'%s dependent %s',
-			'%s dependent %s', $count);
-
-		$message = sprintf($message, SwatString::numberFormat($count), $title);
-		return $message;
-	}
-
-
+        return sprintf($message, SwatString::numberFormat($count), $title);
+    }
 }
-
-?>

--- a/Admin/AdminSummaryDependency.php
+++ b/Admin/AdminSummaryDependency.php
@@ -9,7 +9,7 @@
  */
 class AdminSummaryDependency extends AdminDependency
 {
-	// {{{ public properties
+
 
 	/**
 	 * Array of {@link AdminDependencySummary} objects to be displayed
@@ -26,8 +26,8 @@ class AdminSummaryDependency extends AdminDependency
 	 */
 	public $summaries = array();
 
-	// }}}
-	// {{{ public functions getStatusLevelCount()
+
+
 
 	/**
 	 * Gets the number of items in this dependency at a given status level
@@ -50,8 +50,8 @@ class AdminSummaryDependency extends AdminDependency
 		return $count;
 	}
 
-	// }}}
-	// {{{ public function getItemCount()
+
+
 
 	/**
 	 * Counts the number of items in this dependency
@@ -69,8 +69,8 @@ class AdminSummaryDependency extends AdminDependency
 		return $total;
 	}
 
-	// }}}
-	// {{{ public function processItemStatuses()
+
+
 
 	/**
 	 * Processes the status level of summaries in this dependency
@@ -90,8 +90,8 @@ class AdminSummaryDependency extends AdminDependency
 		return $return;
 	}
 
-	// }}}
-	// {{{ public function displayDependencies()
+
+
 
 	/**
 	 * Displays dependency summaries for the given parent at a given status
@@ -122,8 +122,8 @@ class AdminSummaryDependency extends AdminDependency
 		}
 	}
 
-	// }}}
-	// {{{ public static function &querySummaries()
+
+
 
 	/**
 	 *
@@ -165,8 +165,8 @@ class AdminSummaryDependency extends AdminDependency
 		return $entry_array;
 	}
 
-	// }}}
-	// {{{ protected function getDependencyText()
+
+
 
 	/**
 	 * Gets the text for a dependency list summary for this dependency
@@ -189,7 +189,7 @@ class AdminSummaryDependency extends AdminDependency
 		return $message;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminSummaryDependency.php
+++ b/Admin/AdminSummaryDependency.php
@@ -162,7 +162,7 @@ class AdminSummaryDependency extends AdminDependency
         $entries = SwatDB::query(
             $db,
             $sql,
-            'AdminDependencySummaryWrapper',
+            AdminDependencySummaryWrapper::class,
             $types
         );
 

--- a/Admin/AdminTableViewOrderableColumn.php
+++ b/Admin/AdminTableViewOrderableColumn.php
@@ -1,24 +1,17 @@
 <?php
 
 /**
- * An orderable column
+ * An orderable column.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminTableViewOrderableColumn extends SwatTableViewOrderableColumn
 {
-
-
-	public function displayHeader()
-	{
-		$this->link = isset($_GET['source']) ? $_GET['source'] : '';
-		$this->unset_get_vars = array('source');
-		parent::displayHeader();
-	}
-
-
+    public function displayHeader()
+    {
+        $this->link = $_GET['source'] ?? '';
+        $this->unset_get_vars = ['source'];
+        parent::displayHeader();
+    }
 }
-
-?>

--- a/Admin/AdminTableViewOrderableColumn.php
+++ b/Admin/AdminTableViewOrderableColumn.php
@@ -9,7 +9,7 @@
  */
 class AdminTableViewOrderableColumn extends SwatTableViewOrderableColumn
 {
-	// {{{ public function displayHeader()
+
 
 	public function displayHeader()
 	{
@@ -18,7 +18,7 @@ class AdminTableViewOrderableColumn extends SwatTableViewOrderableColumn
 		parent::displayHeader();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminTitleLinkCellRenderer.php
+++ b/Admin/AdminTitleLinkCellRenderer.php
@@ -12,7 +12,7 @@
  */
 class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 {
-	// {{{ public properties
+
 
 	/**
 	 * The stock id of this AdminTitleCellRenderer
@@ -26,8 +26,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 	 */
 	public $stock_id = null;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * A CSS class set by the stock_id of this title link cell renderer
@@ -43,8 +43,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 	 */
 	protected $last_stock_id = null;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a title link cell renderer
@@ -57,8 +57,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		);
 	}
 
-	// }}}
-	// {{{ public function setFromStock()
+
+
 
 	/**
 	 * Sets the values of this title link cell renderer to a stock type
@@ -135,8 +135,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		$this->last_stock_id = $stock_id;
 	}
 
-	// }}}
-	// {{{ public function init()
+
+
 
 	/**
 	 * Initializes this admin title link cell renderer
@@ -151,8 +151,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 			$this->setFromStock($this->stock_id, false);
 	}
 
-	// }}}
-	// {{{ public function render()
+
+
 
 	/**
 	 * Renders the contents of this cell
@@ -169,8 +169,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		parent::render();
 	}
 
-	// }}}
-	// {{{ protected function setStockType()
+
+
 
 	/**
 	 * Applies the stock type specificed by the user
@@ -182,8 +182,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		}
 	}
 
-	// }}}
-	// {{{ protected function renderSensitive()
+
+
 
 	/**
 	 * Renders this link as sensitive
@@ -202,8 +202,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		$anchor->close();
 	}
 
-	// }}}
-	// {{{ protected function renderInsensitive()
+
+
 
 	/**
 	 * Renders this link as not sensitive
@@ -221,8 +221,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		$span_tag->close();
 	}
 
-	// }}}
-	// {{{ protected function renderContent()
+
+
 
 	/**
 	 * Renders this link as not sensitive
@@ -240,8 +240,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		$content_span->display();
 	}
 
-	// }}}
-	// {{{ protected function getCSSClassNames()
+
+
 
 	/**
 	 * Gets the array of CSS classes that are applied to this user-interface
@@ -264,8 +264,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		return $classes;
 	}
 
-	// }}}
-	// {{{ public function getDataSpecificCSSClassNames()
+
+
 
 	/**
 	 * Gets the data specific CSS class names for this cell renderer
@@ -285,8 +285,8 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		return $classes;
 	}
 
-	// }}}
-	// {{{ public function getBaseCSSClassNames()
+
+
 
 	/**
 	 * Gets the base CSS class names for this cell renderer
@@ -300,7 +300,7 @@ class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 		return $classes;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminTitleLinkCellRenderer.php
+++ b/Admin/AdminTitleLinkCellRenderer.php
@@ -1,306 +1,271 @@
 <?php
 
 /**
- * A title link cell renderer for Admin index pages
+ * A title link cell renderer for Admin index pages.
  *
  * Links in the cell renderer are styled as block-level elements,
  * so other cell renderers in the same table cell may cause layout issues.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminTitleLinkCellRenderer extends SwatLinkCellRenderer
 {
-
-
-	/**
-	 * The stock id of this AdminTitleCellRenderer
-	 *
-	 * Specifying a stock id initializes this title link renderer with a set of
-	 * stock values.
-	 *
-	 * @var string
-	 *
-	 * @see AdminTitleCellRenderer::setFromStock()
-	 */
-	public $stock_id = null;
-
-
-
-
-	/**
-	 * A CSS class set by the stock_id of this title link cell renderer
-	 *
-	 * @var string
-	 */
-	protected $stock_class = null;
-
-	/**
-	 * The last stock_id used in a render call
-	 *
-	 * @var string
-	 */
-	protected $last_stock_id = null;
-
-
-
-
-	/**
-	 * Creates a title link cell renderer
-	 */
-	public function __construct()
-	{
-		parent::__construct();
-		$this->addStyleSheet(
-			'packages/admin/styles/admin-title-link-cell-renderer.css'
-		);
-	}
-
-
-
-
-	/**
-	 * Sets the values of this title link cell renderer to a stock type
-	 *
-	 * Valid stock type ids are:
-	 *
-	 * - document (default)
-	 * - document-with-contents
-	 * - edit
-	 * - file-save-as
-	 * - folder
-	 * - folder-with-contents
-	 * - person
-	 * - product
-	 * - download
-	 *
-	 * @param string $stock_id the identifier of the stock type to use.
-	 * @param boolean $overwrite_properties whether to overwrite properties if
-	 *                                       they are already set.
-	 *
-	 * @throws SwatUndefinedStockTypeException
-	 */
-	public function setFromStock($stock_id, $overwrite_properties = true)
-	{
-		if ($stock_id === $this->last_stock_id)
-			return;
-
-		$class = null;
-
-		switch ($stock_id) {
-		case 'document':
-			$class = 'admin-title-link-cell-renderer-document';
-			break;
-
-		case 'document-with-contents':
-			$class = 'admin-title-link-cell-renderer-document-with-contents';
-			break;
-
-		case 'edit':
-			$class = 'admin-title-link-cell-renderer-edit';
-			break;
-
-		case 'file-save-as':
-			$class = 'admin-title-link-cell-renderer-file-save-as';
-			break;
-
-		case 'folder-with-contents':
-			$class = 'admin-title-link-cell-renderer-folder-with-contents';
-			break;
-
-		case 'folder':
-			$class = 'admin-title-link-cell-renderer-folder';
-			break;
-
-		case 'person':
-			$class = 'admin-title-link-cell-renderer-person';
-			break;
-
-		case 'product':
-			$class = 'admin-title-link-cell-renderer-product';
-			break;
-
-		case 'download':
-			$class = 'admin-title-link-cell-renderer-download';
-			break;
-
-		default:
-			throw new SwatUndefinedStockTypeException(
-				"Stock type with id of '{$stock_id}' not found.",
-				0, $stock_id);
-		}
-
-		$this->stock_class = $class;
-		$this->last_stock_id = $stock_id;
-	}
-
-
-
-
-	/**
-	 * Initializes this admin title link cell renderer
-	 */
-	public function init()
-	{
-		parent::init();
-
-		if ($this->stock_id === null)
-			$this->setFromStock('document', false);
-		else
-			$this->setFromStock($this->stock_id, false);
-	}
-
-
-
-
-	/**
-	 * Renders the contents of this cell
-	 *
-	 * @see SwatCellRenderer::render()
-	 */
-	public function render()
-	{
-		if (!$this->visible)
-			return;
-
-		$this->setStockType();
-
-		parent::render();
-	}
-
-
-
-
-	/**
-	 * Applies the stock type specificed by the user
-	 */
-	protected function setStockType()
-	{
-		if ($this->stock_id !== null) {
-			$this->setFromStock($this->stock_id, false);
-		}
-	}
-
-
-
-
-	/**
-	 * Renders this link as sensitive
-	 */
-	protected function renderSensitive()
-	{
-		$anchor = new SwatHtmlTag('a');
-		$anchor->href = $this->getLink();
-		$anchor->class = $this->getCSSClassString();
-		$anchor->title = $this->getTitle();
-
-		$anchor->open();
-
-		$this->renderContent();
-
-		$anchor->close();
-	}
-
-
-
-
-	/**
-	 * Renders this link as not sensitive
-	 */
-	protected function renderInsensitive()
-	{
-		$span_tag = new SwatHtmlTag('span');
-		$span_tag->class = $this->getCSSClassString();
-		$span_tag->title = $this->getTitle();
-
-		$span_tag->open();
-
-		$this->renderContent();
-
-		$span_tag->close();
-	}
-
-
-
-
-	/**
-	 * Renders this link as not sensitive
-	 */
-	protected function renderContent()
-	{
-		$icon_span = new SwatHtmlTag('span');
-		$icon_span->class = 'admin-title-link-cell-renderer-icon';
-		$icon_span->setContent('');
-		$icon_span->display();
-
-		$content_span = new SwatHtmlTag('span');
-		$content_span->class = 'admin-title-link-cell-renderer-contents';
-		$content_span->setContent($this->getText(), $this->content_type);
-		$content_span->display();
-	}
-
-
-
-
-	/**
-	 * Gets the array of CSS classes that are applied to this user-interface
-	 * object
-	 *
-	 * For AdminTitleLinkCellRenderer objects these classes are applied to the
-	 * anchor tag.
-	 *
-	 * @return array the array of CSS classes that are applied to this
-	 *                user-interface object
-	 */
-	protected function getCSSClassNames()
-	{
-		$classes = parent::getCSSClassNames();
-
-		$classes[] = 'admin-title-link-cell-renderer';
-		if ($this->stock_class !== null)
-			$classes[] = $this->stock_class;
-
-		return $classes;
-	}
-
-
-
-
-	/**
-	 * Gets the data specific CSS class names for this cell renderer
-	 *
-	 * @return array the array of base CSS class names for this cell renderer.
-	 */
-	public function getDataSpecificCSSClassNames()
-	{
-		$classes = array();
-
-		if ($this->stock_class !== null)
-			$classes[] = $this->stock_class;
-
-		$classes = array_merge($classes,
-			parent::getDataSpecificCSSClassNames());
-
-		return $classes;
-	}
-
-
-
-
-	/**
-	 * Gets the base CSS class names for this cell renderer
-	 *
-	 * @return array the array of base CSS class names for this cell renderer.
-	 */
-	public function getBaseCSSClassNames()
-	{
-		$classes = parent::getBaseCSSClassNames();
-		$classes[] = 'admin-title-link-cell-renderer';
-		return $classes;
-	}
-
-
+    /**
+     * The stock id of this AdminTitleCellRenderer.
+     *
+     * Specifying a stock id initializes this title link renderer with a set of
+     * stock values.
+     *
+     * @var string
+     *
+     * @see AdminTitleCellRenderer::setFromStock()
+     */
+    public $stock_id;
+
+    /**
+     * A CSS class set by the stock_id of this title link cell renderer.
+     *
+     * @var string
+     */
+    protected $stock_class;
+
+    /**
+     * The last stock_id used in a render call.
+     *
+     * @var string
+     */
+    protected $last_stock_id;
+
+    /**
+     * Creates a title link cell renderer.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+        $this->addStyleSheet(
+            'packages/admin/styles/admin-title-link-cell-renderer.css'
+        );
+    }
+
+    /**
+     * Sets the values of this title link cell renderer to a stock type.
+     *
+     * Valid stock type ids are:
+     *
+     * - document (default)
+     * - document-with-contents
+     * - edit
+     * - file-save-as
+     * - folder
+     * - folder-with-contents
+     * - person
+     * - product
+     * - download
+     *
+     * @param string $stock_id             the identifier of the stock type to use
+     * @param bool   $overwrite_properties whether to overwrite properties if
+     *                                     they are already set
+     *
+     * @throws SwatUndefinedStockTypeException
+     */
+    public function setFromStock($stock_id, $overwrite_properties = true)
+    {
+        if ($stock_id === $this->last_stock_id) {
+            return;
+        }
+
+        $class = null;
+
+        switch ($stock_id) {
+            case 'document':
+                $class = 'admin-title-link-cell-renderer-document';
+                break;
+
+            case 'document-with-contents':
+                $class = 'admin-title-link-cell-renderer-document-with-contents';
+                break;
+
+            case 'edit':
+                $class = 'admin-title-link-cell-renderer-edit';
+                break;
+
+            case 'file-save-as':
+                $class = 'admin-title-link-cell-renderer-file-save-as';
+                break;
+
+            case 'folder-with-contents':
+                $class = 'admin-title-link-cell-renderer-folder-with-contents';
+                break;
+
+            case 'folder':
+                $class = 'admin-title-link-cell-renderer-folder';
+                break;
+
+            case 'person':
+                $class = 'admin-title-link-cell-renderer-person';
+                break;
+
+            case 'product':
+                $class = 'admin-title-link-cell-renderer-product';
+                break;
+
+            case 'download':
+                $class = 'admin-title-link-cell-renderer-download';
+                break;
+
+            default:
+                throw new SwatUndefinedStockTypeException(
+                    "Stock type with id of '{$stock_id}' not found.",
+                    0,
+                    $stock_id
+                );
+        }
+
+        $this->stock_class = $class;
+        $this->last_stock_id = $stock_id;
+    }
+
+    /**
+     * Initializes this admin title link cell renderer.
+     */
+    public function init()
+    {
+        parent::init();
+
+        if ($this->stock_id === null) {
+            $this->setFromStock('document', false);
+        } else {
+            $this->setFromStock($this->stock_id, false);
+        }
+    }
+
+    /**
+     * Renders the contents of this cell.
+     *
+     * @see SwatCellRenderer::render()
+     */
+    public function render()
+    {
+        if (!$this->visible) {
+            return;
+        }
+
+        $this->setStockType();
+
+        parent::render();
+    }
+
+    /**
+     * Applies the stock type specificed by the user.
+     */
+    protected function setStockType()
+    {
+        if ($this->stock_id !== null) {
+            $this->setFromStock($this->stock_id, false);
+        }
+    }
+
+    /**
+     * Renders this link as sensitive.
+     */
+    protected function renderSensitive()
+    {
+        $anchor = new SwatHtmlTag('a');
+        $anchor->href = $this->getLink();
+        $anchor->class = $this->getCSSClassString();
+        $anchor->title = $this->getTitle();
+
+        $anchor->open();
+
+        $this->renderContent();
+
+        $anchor->close();
+    }
+
+    /**
+     * Renders this link as not sensitive.
+     */
+    protected function renderInsensitive()
+    {
+        $span_tag = new SwatHtmlTag('span');
+        $span_tag->class = $this->getCSSClassString();
+        $span_tag->title = $this->getTitle();
+
+        $span_tag->open();
+
+        $this->renderContent();
+
+        $span_tag->close();
+    }
+
+    /**
+     * Renders this link as not sensitive.
+     */
+    protected function renderContent()
+    {
+        $icon_span = new SwatHtmlTag('span');
+        $icon_span->class = 'admin-title-link-cell-renderer-icon';
+        $icon_span->setContent('');
+        $icon_span->display();
+
+        $content_span = new SwatHtmlTag('span');
+        $content_span->class = 'admin-title-link-cell-renderer-contents';
+        $content_span->setContent($this->getText(), $this->content_type);
+        $content_span->display();
+    }
+
+    /**
+     * Gets the array of CSS classes that are applied to this user-interface
+     * object.
+     *
+     * For AdminTitleLinkCellRenderer objects these classes are applied to the
+     * anchor tag.
+     *
+     * @return array the array of CSS classes that are applied to this
+     *               user-interface object
+     */
+    protected function getCSSClassNames()
+    {
+        $classes = parent::getCSSClassNames();
+
+        $classes[] = 'admin-title-link-cell-renderer';
+        if ($this->stock_class !== null) {
+            $classes[] = $this->stock_class;
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Gets the data specific CSS class names for this cell renderer.
+     *
+     * @return array the array of base CSS class names for this cell renderer
+     */
+    public function getDataSpecificCSSClassNames()
+    {
+        $classes = [];
+
+        if ($this->stock_class !== null) {
+            $classes[] = $this->stock_class;
+        }
+
+        return array_merge(
+            $classes,
+            parent::getDataSpecificCSSClassNames()
+        );
+    }
+
+    /**
+     * Gets the base CSS class names for this cell renderer.
+     *
+     * @return array the array of base CSS class names for this cell renderer
+     */
+    public function getBaseCSSClassNames()
+    {
+        $classes = parent::getBaseCSSClassNames();
+        $classes[] = 'admin-title-link-cell-renderer';
+
+        return $classes;
+    }
 }
-
-?>

--- a/Admin/AdminTreeControlCellRenderer.php
+++ b/Admin/AdminTreeControlCellRenderer.php
@@ -1,56 +1,51 @@
 <?php
 
 /**
- * Cell renderer for renderering tree details links
+ * Cell renderer for renderering tree details links.
  *
  * This cell renderer also displays a could of children in the details
  * link title attribute.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminTreeControlCellRenderer extends SwatImageLinkCellRenderer
 {
+    /**
+     * The number of children the item this renderer is rendering for has.
+     *
+     * @var int
+     */
+    public $childcount = 0;
 
+    public function render()
+    {
+        if (!$this->visible) {
+            return;
+        }
 
-	/**
-	 * The number of children the item this renderer is rendering for has
-	 *
-	 * @var integer
-	 */
-	public $childcount = 0;
+        $this->width = 22;
+        $this->height = 22;
 
+        if ($this->childcount == 0) {
+            $this->title = Admin::_('View Details');
+            $this->alt = Admin::_('Details');
+            $this->image = 'packages/admin/images/admin-generic-document.png';
+        } else {
+            $this->title = sprintf(
+                Admin::ngettext(
+                    'View Details (%s sub-item)',
+                    'View Details (%s sub-items)',
+                    $this->childcount
+                ),
+                SwatString::numberFormat($this->childcount)
+            );
 
+            $this->alt = Admin::_('Details');
+            $this->image =
+                'packages/admin/images/admin-document-with-contents.png';
+        }
 
-
-	public function render()
-	{
-		if (!$this->visible)
-			return;
-
-		$this->width = 22;
-		$this->height = 22;
-
-		if ($this->childcount == 0) {
-			$this->title = Admin::_('View Details');
-			$this->alt = Admin::_('Details');
-			$this->image = 'packages/admin/images/admin-generic-document.png';
-		} else {
-			$this->title = sprintf(Admin::ngettext(
-				'View Details (%s sub-item)',
-				'View Details (%s sub-items)', $this->childcount),
-				SwatString::numberFormat($this->childcount));
-
-			$this->alt = Admin::_('Details');
-			$this->image =
-				'packages/admin/images/admin-document-with-contents.png';
-		}
-
-		parent::render();
-	}
-
-
+        parent::render();
+    }
 }
-
-?>

--- a/Admin/AdminTreeControlCellRenderer.php
+++ b/Admin/AdminTreeControlCellRenderer.php
@@ -12,7 +12,7 @@
  */
 class AdminTreeControlCellRenderer extends SwatImageLinkCellRenderer
 {
-	// {{{ public properties
+
 
 	/**
 	 * The number of children the item this renderer is rendering for has
@@ -21,8 +21,8 @@ class AdminTreeControlCellRenderer extends SwatImageLinkCellRenderer
 	 */
 	public $childcount = 0;
 
-	// }}}
-	// {{{ public function render()
+
+
 
 	public function render()
 	{
@@ -50,7 +50,7 @@ class AdminTreeControlCellRenderer extends SwatImageLinkCellRenderer
 		parent::render();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminTreeTitleLinkCellRenderer.php
+++ b/Admin/AdminTreeTitleLinkCellRenderer.php
@@ -9,13 +9,13 @@
  */
 class AdminTreeTitleLinkCellRenderer extends AdminTitleLinkCellRenderer
 {
-	// {{{ public properties
+
 
 	public $child_count = 0;
 	public $base_stock_id = 'document';
 
-	// }}}
-	// {{{ protected function setStockType()
+
+
 
 	/**
 	 * Applies the stock type specificed by the user
@@ -31,8 +31,8 @@ class AdminTreeTitleLinkCellRenderer extends AdminTitleLinkCellRenderer
 		parent::setStockType();
 	}
 
-	// }}}
-	// {{{ protected function getTitle()
+
+
 
 	protected function getTitle()
 	{
@@ -49,7 +49,7 @@ class AdminTreeTitleLinkCellRenderer extends AdminTitleLinkCellRenderer
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminTreeTitleLinkCellRenderer.php
+++ b/Admin/AdminTreeTitleLinkCellRenderer.php
@@ -1,55 +1,44 @@
 <?php
 
 /**
- * A title link cell renderer for tree index pages
+ * A title link cell renderer for tree index pages.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminTreeTitleLinkCellRenderer extends AdminTitleLinkCellRenderer
 {
+    public $child_count = 0;
+    public $base_stock_id = 'document';
 
+    /**
+     * Applies the stock type specificed by the user.
+     */
+    protected function setStockType()
+    {
+        if (intval($this->child_count) > 0) {
+            $this->setFromStock($this->base_stock_id . '-with-contents');
+        } else {
+            $this->setFromStock($this->base_stock_id);
+        }
 
-	public $child_count = 0;
-	public $base_stock_id = 'document';
+        // setting stock_id overrides base_stock_id
+        parent::setStockType();
+    }
 
+    protected function getTitle()
+    {
+        if (intval($this->child_count) === 0) {
+            return Admin::_('no sub-items');
+        }
 
-
-
-	/**
-	 * Applies the stock type specificed by the user
-	 */
-	protected function setStockType()
-	{
-		if (intval($this->child_count) > 0)
-			$this->setFromStock($this->base_stock_id.'-with-contents');
-		else
-			$this->setFromStock($this->base_stock_id);
-
-		// setting stock_id overrides base_stock_id
-		parent::setStockType();
-	}
-
-
-
-
-	protected function getTitle()
-	{
-		if (intval($this->child_count) === 0)
-			return Admin::_('no sub-items');
-
-		return sprintf(
-			Admin::ngettext(
-				'%d sub-item',
-				'%d sub-items',
-				$this->child_count
-			),
-			$this->child_count
-		);
-	}
-
-
+        return sprintf(
+            Admin::ngettext(
+                '%d sub-item',
+                '%d sub-items',
+                $this->child_count
+            ),
+            $this->child_count
+        );
+    }
 }
-
-?>

--- a/Admin/AdminTwoFactorAuthentication.php
+++ b/Admin/AdminTwoFactorAuthentication.php
@@ -12,7 +12,7 @@ use RobThree\Auth\TwoFactorAuth;
  */
 class AdminTwoFactorAuthentication
 {
-	// {{{ public function getNewSecret()
+
 
 	public function getNewSecret()
 	{
@@ -20,8 +20,8 @@ class AdminTwoFactorAuthentication
 		return $two_fa->createSecret();
 	}
 
-	// }}}
-	// {{{ public function getQrCodeDataUri()
+
+
 
 	public function getQrCodeDataUri($title, $secret, $size = 400)
 	{
@@ -29,8 +29,8 @@ class AdminTwoFactorAuthentication
 		return $two_fa->getQRCodeImageAsDataUri($title, $secret, $size);
 	}
 
-	// }}}
-	// {{{ public function validateToken()
+
+
 
 	public function validateToken($secret, $token, &$timeslice)
 	{
@@ -46,7 +46,7 @@ class AdminTwoFactorAuthentication
 		return $success;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminTwoFactorAuthentication.php
+++ b/Admin/AdminTwoFactorAuthentication.php
@@ -4,49 +4,39 @@ use RobThree\Auth\Providers\Qr\BaconQrCodeProvider;
 use RobThree\Auth\TwoFactorAuth;
 
 /**
- * Admin 2FA
+ * Admin 2FA.
  *
- * @package   Admin
  * @copyright 2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminTwoFactorAuthentication
 {
+    public function getNewSecret()
+    {
+        $two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
 
+        return $two_fa->createSecret();
+    }
 
-	public function getNewSecret()
-	{
-		$two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
-		return $two_fa->createSecret();
-	}
+    public function getQrCodeDataUri($title, $secret, $size = 400)
+    {
+        $two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
 
+        return $two_fa->getQRCodeImageAsDataUri($title, $secret, $size);
+    }
 
+    public function validateToken($secret, $token, &$timeslice)
+    {
+        // strip all non numeric characters like spaces and dashes that people
+        // might enter (e.g. Authy adds spaces for readability)
+        $token = preg_replace('/[^0-9]/', '', $token);
 
+        // The timeslice is used to make sure tokens before this
+        // can't be used to authenticate again. There's a "window" of token
+        // use and without this, someone could capture the code, and re-use it.
+        $two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
+        $success = $two_fa->verifyCode($secret, $token, 1, null, $timeslice);
 
-	public function getQrCodeDataUri($title, $secret, $size = 400)
-	{
-		$two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
-		return $two_fa->getQRCodeImageAsDataUri($title, $secret, $size);
-	}
-
-
-
-
-	public function validateToken($secret, $token, &$timeslice)
-	{
-		// strip all non numeric characters like spaces and dashes that people
-		// might enter (e.g. Authy adds spaces for readability)
-		$token = preg_replace('/[^0-9]/', '', $token);
-
-		// The timeslice is used to make sure tokens before this
-		// can't be used to authenticate again. There's a "window" of token
-		// use and without this, someone could capture the code, and re-use it.
-		$two_fa = new TwoFactorAuth(new BaconQrCodeProvider());
-		$success = $two_fa->verifyCode($secret, $token, 1, null, $timeslice);
-		return $success;
-	}
-
-
+        return $success;
+    }
 }
-
-?>

--- a/Admin/AdminUI.php
+++ b/Admin/AdminUI.php
@@ -14,7 +14,7 @@
  */
 class AdminUI extends SwatUI
 {
-	// {{{ public function getValues()
+
 
 	/**
 	 * Gets values from widgets
@@ -39,8 +39,8 @@ class AdminUI extends SwatUI
 		return $values;
 	}
 
-	// }}}
-	// {{{ public function setValues()
+
+
 
 	/**
 	 * Sets values of widgets
@@ -67,7 +67,7 @@ class AdminUI extends SwatUI
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/AdminUI.php
+++ b/Admin/AdminUI.php
@@ -1,73 +1,64 @@
 <?php
 
 /**
- * UI manager for administrators
+ * UI manager for administrators.
  *
  * Subclass of {@link SwatUI} for use with the Admin package.  This can be used
  * as a central place to add {@link SwatUI::$classmap class maps} and
  * {@link SwatUI::registerHandler() UI handlers} that are specific to the Admin
  * package.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUI extends SwatUI
 {
+    /**
+     * Gets values from widgets.
+     *
+     * Convenience method to retrive values from multiple widgets at once.
+     * This method is useful when using {@link SwatDB::rowInsert()} and
+     * {@link SwatDB::rowUpdate} but only works if the widget id and
+     * field name are the same, if this is not the case you should manually get
+     * the values.
+     *
+     * @param array $ids an array of widget ids to retrieve values from
+     *
+     * @return array an array of widget values indexed by widget ids
+     */
+    public function getValues(array $ids)
+    {
+        $values = [];
 
+        foreach ($ids as $widget_id) {
+            $values[$widget_id] = $this->getWidget($widget_id)->value;
+        }
 
-	/**
-	 * Gets values from widgets
-	 *
-	 * Convenience method to retrive values from multiple widgets at once.
-	 * This method is useful when using {@link SwatDB::rowInsert()} and
-	 * {@link SwatDB::rowUpdate} but only works if the widget id and
-	 * field name are the same, if this is not the case you should manually get
-	 * the values.
-	 *
-	 * @param array $ids an array of widget ids to retrieve values from.
-	 *
-	 * @return array an array of widget values indexed by widget ids.
-	 */
-	public function getValues(array $ids)
-	{
-		$values = array();
+        return $values;
+    }
 
-		foreach ($ids as $widget_id)
-			$values[$widget_id] = $this->getWidget($widget_id)->value;
-
-		return $values;
-	}
-
-
-
-
-	/**
-	 * Sets values of widgets
-	 *
-	 * Convenience method to set values of multiple widgets at once.
-	 * This method is useful when using {@link SwatDB::rowQuery()}
-	 * but only works if the widget id and field name are the same, if this
-	 * is not the case you should manually set the values.
-	 *
-	 * If a widget id-value pair is passed for a widget that does not exist,
-	 * that value is ignored.
-	 *
-	 * @param array $values an array of widget values indexed by widget ids.
-	 */
-	public function setValues(array $values)
-	{
-		foreach ($values as $id => $value) {
-			try {
-				$widget = $this->getWidget($id);
-				$widget->value = $values[$id];
-			} catch (SwatWidgetNotFoundException $e) {
-				// ignore
-			}
-		}
-	}
-
-
+    /**
+     * Sets values of widgets.
+     *
+     * Convenience method to set values of multiple widgets at once.
+     * This method is useful when using {@link SwatDB::rowQuery()}
+     * but only works if the widget id and field name are the same, if this
+     * is not the case you should manually set the values.
+     *
+     * If a widget id-value pair is passed for a widget that does not exist,
+     * that value is ignored.
+     *
+     * @param array $values an array of widget values indexed by widget ids
+     */
+    public function setValues(array $values)
+    {
+        foreach ($values as $id => $value) {
+            try {
+                $widget = $this->getWidget($id);
+                $widget->value = $values[$id];
+            } catch (SwatWidgetNotFoundException $e) {
+                // ignore
+            }
+        }
+    }
 }
-
-?>

--- a/Admin/AdminUniqueEntry.php
+++ b/Admin/AdminUniqueEntry.php
@@ -1,59 +1,46 @@
 <?php
 
 /**
- * A unique text entry widget
+ * A unique text entry widget.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUniqueEntry extends SwatEntry
 {
+    /**
+     * Whether or not this entry is alphanumeric.
+     *
+     * This property affects the processing of this control.
+     *
+     * @var bool
+     *
+     * @see AdminUniqueEntry::process()
+     */
+    public $alphanum = true;
 
+    public function init()
+    {
+        parent::init();
+        $this->size = 20;
+    }
 
-	/**
-	 * Whether or not this entry is alphanumeric
-	 *
-	 * This property affects the processing of this control.
-	 *
-	 * @var boolean
-	 *
-	 * @see AdminUniqueEntry::process()
-	 */
-	public $alphanum = true;
+    /**
+     * Processes this unique entry.
+     *
+     * Ensures the value entered by the user is unique and if it is not unique
+     * attaches an error message to the control.
+     */
+    public function process()
+    {
+        parent::process();
 
+        if ($this->alphanum && preg_match('/[^[:alnum:]\-_]/u', $this->value)) {
+            $message = Admin::_('The %s field can only contain letters and ' .
+                'numbers. Spaces and other special characters are not ' .
+                'allowed.');
 
-
-
-	public function init()
-	{
-		parent::init();
-		$this->size = 20;
-	}
-
-
-
-
-	/**
-	 * Processes this unique entry
-	 *
-	 * Ensures the value entered by the user is unique and if it is not unique
-	 * attaches an error message to the control.
-	 */
-	public function process()
-	{
-		parent::process();
-
-		if ($this->alphanum && preg_match('/[^[:alnum:]\-_]/u', $this->value)) {
-			$message = Admin::_('The %s field can only contain letters and '.
-				'numbers. Spaces and other special characters are not '.
-				'allowed.');
-
-			$this->addMessage(new SwatMessage($message, 'error'));
-		}
-	}
-
-
+            $this->addMessage(new SwatMessage($message, 'error'));
+        }
+    }
 }
-
-?>

--- a/Admin/AdminUniqueEntry.php
+++ b/Admin/AdminUniqueEntry.php
@@ -9,7 +9,7 @@
  */
 class AdminUniqueEntry extends SwatEntry
 {
-	// {{{ public properties
+
 
 	/**
 	 * Whether or not this entry is alphanumeric
@@ -22,8 +22,8 @@ class AdminUniqueEntry extends SwatEntry
 	 */
 	public $alphanum = true;
 
-	// }}}
-	// {{{ public function init()
+
+
 
 	public function init()
 	{
@@ -31,8 +31,8 @@ class AdminUniqueEntry extends SwatEntry
 		$this->size = 20;
 	}
 
-	// }}}
-	// {{{ public function process()
+
+
 
 	/**
 	 * Processes this unique entry
@@ -53,7 +53,7 @@ class AdminUniqueEntry extends SwatEntry
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminComponent/Delete.php
+++ b/Admin/components/AdminComponent/Delete.php
@@ -1,72 +1,80 @@
 <?php
 
 /**
- * Delete confirmation page for AdminComponents
+ * Delete confirmation page for AdminComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminComponentDelete extends AdminDBDelete
 {
-	// process phase
+    // process phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
-	protected function processDBData(): void
-	{
-		parent::processDBData();
+        $sql = 'delete from AdminComponent where id in (%s)';
+        $item_list = $this->getItemList('integer');
+        $sql = sprintf($sql, $item_list);
+        $num = SwatDB::exec($this->app->db, $sql);
 
-		$sql = 'delete from AdminComponent where id in (%s)';
-		$item_list = $this->getItemList('integer');
-		$sql = sprintf($sql, $item_list);
-		$num = SwatDB::exec($this->app->db, $sql);
+        $message = new SwatMessage(sprintf(
+            Admin::ngettext(
+                'One component has been deleted.',
+                '%s components have been deleted.',
+                $num
+            ),
+            SwatString::numberFormat($num)
+        ));
 
-		$message = new SwatMessage(sprintf(Admin::ngettext(
-			'One component has been deleted.',
-			'%s components have been deleted.', $num),
-			SwatString::numberFormat($num)));
+        $this->app->messages->add($message);
+    }
 
-		$this->app->messages->add($message);
-	}
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
+        $item_list = $this->getItemList('integer');
 
-	// build phase
+        $dep = new AdminListDependency();
+        $dep->setTitle(Admin::_('component'), Admin::_('components'));
+        $dep->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminComponent',
+            'integer:id',
+            null,
+            'text:title',
+            'displayorder, title',
+            'id in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
+        $dep_subcomponents = new AdminSummaryDependency();
+        $dep_subcomponents->setTitle(
+            Admin::_('sub-component'),
+            Admin::_('sub-components')
+        );
 
-	protected function buildInternal()
-	{
-		parent::buildInternal();
+        $dep_subcomponents->summaries = AdminSummaryDependency::querySummaries(
+            $this->app->db,
+            'AdminSubComponent',
+            'integer:id',
+            'integer:component',
+            'component in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
-		$item_list = $this->getItemList('integer');
+        $dep->addDependency($dep_subcomponents);
 
-		$dep = new AdminListDependency();
-		$dep->setTitle(Admin::_('component'), Admin::_('components'));
-		$dep->entries = AdminListDependency::queryEntries($this->app->db,
-			'AdminComponent', 'integer:id', null, 'text:title',
-			'displayorder, title', 'id in ('.$item_list.')',
-			AdminDependency::DELETE);
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = $dep->getMessage();
+        $message->content_type = 'text/xml';
 
-		$dep_subcomponents = new AdminSummaryDependency();
-		$dep_subcomponents->setTitle(
-			Admin::_('sub-component'), Admin::_('sub-components'));
-
-		$dep_subcomponents->summaries = AdminSummaryDependency::querySummaries(
-			$this->app->db, 'AdminSubComponent', 'integer:id',
-			'integer:component', 'component in ('.$item_list.')',
-			AdminDependency::DELETE);
-
-		$dep->addDependency($dep_subcomponents);
-
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = $dep->getMessage();
-		$message->content_type = 'text/xml';
-
-		if ($dep->getStatusLevelCount(AdminDependency::DELETE) == 0)
-			$this->switchToCancelButton();
-	}
-
-
+        if ($dep->getStatusLevelCount(AdminDependency::DELETE) == 0) {
+            $this->switchToCancelButton();
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminComponent/Delete.php
+++ b/Admin/components/AdminComponent/Delete.php
@@ -10,7 +10,7 @@
 class AdminAdminComponentDelete extends AdminDBDelete
 {
 	// process phase
-	// {{{ protected function processDBData()
+
 
 	protected function processDBData(): void
 	{
@@ -29,10 +29,10 @@ class AdminAdminComponentDelete extends AdminDBDelete
 		$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -66,7 +66,7 @@ class AdminAdminComponentDelete extends AdminDBDelete
 			$this->switchToCancelButton();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminComponent/Details.php
+++ b/Admin/components/AdminComponent/Details.php
@@ -30,7 +30,7 @@ class AdminAdminComponentDetails extends AdminIndex
 
     protected function initComponent()
     {
-        $class_name = SwatDBClassMap::get('AdminComponent');
+        $class_name = SwatDBClassMap::get(AdminComponent::class);
         $this->details_component = new $class_name();
         $this->details_component->setDatabase($this->app->db);
 

--- a/Admin/components/AdminComponent/Details.php
+++ b/Admin/components/AdminComponent/Details.php
@@ -9,7 +9,7 @@
  */
 class AdminAdminComponentDetails extends AdminIndex
 {
-	// {{{ private properties
+
 
 	private $id;
 
@@ -18,10 +18,10 @@ class AdminAdminComponentDetails extends AdminIndex
 	 */
 	private $details_component;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -34,8 +34,8 @@ class AdminAdminComponentDetails extends AdminIndex
 		$this->initComponent();
 	}
 
-	// }}}
-	// {{{ protected function initComponent()
+
+
 
 	protected function initComponent()
 	{
@@ -50,10 +50,10 @@ class AdminAdminComponentDetails extends AdminIndex
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processActions()
+
 
 	protected function processActions(SwatView $view, SwatActions $actions)
 	{
@@ -94,10 +94,10 @@ class AdminAdminComponentDetails extends AdminIndex
 			$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -130,8 +130,8 @@ class AdminAdminComponentDetails extends AdminIndex
 		$frame->subtitle = $this->details_component->title;
 	}
 
-	// }}}
-	// {{{ protected function getTableModel()
+
+
 
 	protected function getTableModel(SwatView $view): ?SwatTableModel
 	{
@@ -143,8 +143,8 @@ class AdminAdminComponentDetails extends AdminIndex
 		return $sub_components;
 	}
 
-	// }}}
-	// {{{ private function displayGroups()
+
+
 
 	private function displayGroups()
 	{
@@ -162,7 +162,7 @@ class AdminAdminComponentDetails extends AdminIndex
 		echo '<ul>';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminComponent/Details.php
+++ b/Admin/components/AdminComponent/Details.php
@@ -1,168 +1,171 @@
 <?php
 
 /**
- * Details page for AdminComponents
+ * Details page for AdminComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminComponentDetails extends AdminIndex
 {
+    private $id;
 
+    /**
+     * @var AdminComponent
+     */
+    private $details_component;
 
-	private $id;
+    // init phase
 
-	/**
-	 * @var AdminComponent
-	 */
-	private $details_component;
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->ui->loadFromXML(__DIR__ . '/details.xml');
 
+        $this->id = intval(SiteApplication::initVar('id'));
 
-	// init phase
+        $this->initComponent();
+    }
 
+    protected function initComponent()
+    {
+        $class_name = SwatDBClassMap::get('AdminComponent');
+        $this->details_component = new $class_name();
+        $this->details_component->setDatabase($this->app->db);
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+        if (!$this->details_component->load($this->id)) {
+            throw new AdminNotFoundException(
+                sprintf(
+                    Admin::_('Component with id "%s" not found.'),
+                    $this->id
+                )
+            );
+        }
+    }
 
-		$this->ui->loadFromXML(__DIR__.'/details.xml');
+    // process phase
 
-		$this->id = intval(SiteApplication::initVar('id'));
+    protected function processActions(SwatView $view, SwatActions $actions)
+    {
+        $num = count($view->checked_items);
+        $message = null;
 
-		$this->initComponent();
-	}
+        switch ($actions->selected->id) {
+            case 'delete':
+                $this->app->replacePage('AdminSubComponent/Delete');
+                $this->app->getPage()->setItems($view->checked_items);
+                $this->app->getPage()->setParent($this->id);
+                break;
 
+            case 'show':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminSubComponent',
+                    'boolean:visible',
+                    true,
+                    'id',
+                    $view->checked_items
+                );
 
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One sub-component has been shown.',
+                        '%s sub-components have been shown.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
+                break;
 
-	protected function initComponent()
-	{
-		$class_name = SwatDBClassMap::get('AdminComponent');
-		$this->details_component = new $class_name();
-		$this->details_component->setDatabase($this->app->db);
+            case 'hide':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminSubComponent',
+                    'boolean:visible',
+                    false,
+                    'id',
+                    $view->checked_items
+                );
 
-		if (!$this->details_component->load($this->id)) {
-			throw new AdminNotFoundException(
-				sprintf(Admin::_('Component with id "%s" not found.'),
-					$this->id));
-		}
-	}
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One sub-component has been hidden.',
+                        '%s sub-components have been hidden.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
+                break;
+        }
 
+        if ($message !== null) {
+            $this->app->messages->add($message);
+        }
+    }
 
-	// process phase
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-		$num = count($view->checked_items);
-		$message = null;
+        $this->ui->getWidget('details_toolbar')->setToolLinkValues($this->id);
+        $this->ui->getWidget('sub_components_toolbar')->setToolLinkValues(
+            $this->id
+        );
 
-		switch ($actions->selected->id) {
-		case 'delete':
-			$this->app->replacePage('AdminSubComponent/Delete');
-			$this->app->getPage()->setItems($view->checked_items);
-			$this->app->getPage()->setParent($this->id);
-			break;
+        $form = $this->ui->getWidget('index_form');
+        $form->addHiddenField('id', $this->id);
 
-		case 'show':
-			SwatDB::updateColumn($this->app->db, 'AdminSubComponent',
-				'boolean:visible', true, 'id', $view->checked_items);
+        $this->navbar->createEntry(Admin::_('Details'));
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One sub-component has been shown.',
-				'%s sub-components have been shown.', $num),
-				SwatString::numberFormat($num)));
+        $ds = new SwatDetailsStore($this->details_component);
 
-			break;
+        ob_start();
+        $this->displayGroups();
+        $ds->groups_summary = ob_get_clean();
 
-		case 'hide':
-			SwatDB::updateColumn($this->app->db, 'AdminSubComponent',
-				'boolean:visible', false, 'id', $view->checked_items);
+        if ($this->details_component->description !== null) {
+            $ds->description = SwatString::condense(SwatString::toXHTML(
+                $this->details_component->description
+            ));
+        }
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One sub-component has been hidden.',
-				'%s sub-components have been hidden.', $num),
-				SwatString::numberFormat($num)));
+        $component_details = $this->ui->getWidget('component_details');
+        $component_details->data = $ds;
 
-			break;
-		}
+        $frame = $this->ui->getWidget('details_frame');
+        $frame->title = Admin::_('Component');
+        $frame->subtitle = $this->details_component->title;
+    }
 
-		if ($message !== null)
-			$this->app->messages->add($message);
-	}
+    protected function getTableModel(SwatView $view): ?SwatTableModel
+    {
+        $sub_components = $this->details_component->sub_components;
 
+        if (count($sub_components) < 2) {
+            $this->ui->getWidget('order_tool')->sensitive = false;
+        }
 
+        return $sub_components;
+    }
 
-	// build phase
+    private function displayGroups()
+    {
+        echo '<ul>';
 
+        foreach ($this->details_component->groups as $group) {
+            echo '<li>';
+            $anchor_tag = new SwatHtmlTag('a');
+            $anchor_tag->href = 'AdminGroup/Edit?id=' . $group->id;
+            $anchor_tag->setContent($group->title);
+            $anchor_tag->display();
+            echo '</li>';
+        }
 
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$this->ui->getWidget('details_toolbar')->setToolLinkValues($this->id);
-		$this->ui->getWidget('sub_components_toolbar')->setToolLinkValues(
-			$this->id);
-
-		$form = $this->ui->getWidget('index_form');
-		$form->addHiddenField('id', $this->id);
-
-		$this->navbar->createEntry(Admin::_('Details'));
-
-		$ds = new SwatDetailsStore($this->details_component);
-
-		ob_start();
-		$this->displayGroups();
-		$ds->groups_summary = ob_get_clean();
-
-		if ($this->details_component->description !== null)
-			$ds->description = SwatString::condense(SwatString::toXHTML(
-				$this->details_component->description));
-
-		$component_details = $this->ui->getWidget('component_details');
-		$component_details->data = $ds;
-
-		$frame = $this->ui->getWidget('details_frame');
-		$frame->title = Admin::_('Component');
-		$frame->subtitle = $this->details_component->title;
-	}
-
-
-
-
-	protected function getTableModel(SwatView $view): ?SwatTableModel
-	{
-		$sub_components = $this->details_component->sub_components;
-
-		if (count($sub_components) < 2)
-			$this->ui->getWidget('order_tool')->sensitive = false;
-
-		return $sub_components;
-	}
-
-
-
-
-	private function displayGroups()
-	{
-		echo '<ul>';
-
-		foreach ($this->details_component->groups as $group) {
-			echo '<li>';
-			$anchor_tag = new SwatHtmlTag('a');
-			$anchor_tag->href = 'AdminGroup/Edit?id='.$group->id;
-			$anchor_tag->setContent($group->title);
-			$anchor_tag->display();
-			echo '</li>';
-		}
-
-		echo '<ul>';
-	}
-
-
+        echo '<ul>';
+    }
 }
-
-?>

--- a/Admin/components/AdminComponent/Edit.php
+++ b/Admin/components/AdminComponent/Edit.php
@@ -9,23 +9,23 @@
  */
 class AdminAdminComponentEdit extends AdminObjectEdit
 {
-	// {{{ protected function getObjectClass()
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminComponent';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/edit.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -39,10 +39,10 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -52,8 +52,8 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		$this->initGroups();
 	}
 
-	// }}}
-	// {{{ protected function initSections()
+
+
 
 	protected function initSections()
 	{
@@ -69,8 +69,8 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		$section_flydown->addOptionsByArray($section_flydown_options);
 	}
 
-	// }}}
-	// {{{ protected function initGroups()
+
+
 
 	protected function initGroups()
 	{
@@ -86,10 +86,10 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		$group_list->addOptionsByArray($group_list_options);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function validate()
+
 
 	protected function validate(): void
 	{
@@ -108,16 +108,16 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function postSaveObject()
+
+
 
 	protected function postSaveObject()
 	{
 		$this->updateGroupBindings();
 	}
 
-	// }}}
-	// {{{ protected function updateGroupBindings()
+
+
 
 	protected function updateGroupBindings()
 	{
@@ -135,8 +135,8 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
@@ -146,10 +146,10 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function loadObject()
+
 
 	protected function loadObject()
 	{
@@ -160,8 +160,8 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function loadGroupBindings()
+
+
 
 	protected function loadGroupBindings()
 	{
@@ -175,7 +175,7 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminComponent/Edit.php
+++ b/Admin/components/AdminComponent/Edit.php
@@ -10,7 +10,7 @@ class AdminAdminComponentEdit extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'AdminComponent';
+        return AdminComponent::class;
     }
 
     protected function getUiXml()

--- a/Admin/components/AdminComponent/Edit.php
+++ b/Admin/components/AdminComponent/Edit.php
@@ -1,181 +1,141 @@
 <?php
 
 /**
- * Edit page for AdminComponents
+ * Edit page for AdminComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminComponentEdit extends AdminObjectEdit
 {
+    protected function getObjectClass()
+    {
+        return 'AdminComponent';
+    }
 
+    protected function getUiXml()
+    {
+        return __DIR__ . '/edit.xml';
+    }
 
-	protected function getObjectClass()
-	{
-		return 'AdminComponent';
-	}
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'title',
+            'shortname',
+            'section',
+            'visible',
+            'enabled',
+            'description',
+        ];
+    }
 
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->initSections();
+        $this->initGroups();
+    }
 
-	protected function getUiXml()
-	{
-		return __DIR__.'/edit.xml';
-	}
+    protected function initSections()
+    {
+        $section_flydown = $this->ui->getWidget('section');
+        $section_flydown_options = SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminSection',
+            'title',
+            'id',
+            'displayorder'
+        );
 
+        $section_flydown->addOptionsByArray($section_flydown_options);
+    }
 
+    protected function initGroups()
+    {
+        $group_list = $this->ui->getWidget('groups');
+        $group_list_options = SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminGroup',
+            'title',
+            'id',
+            'title'
+        );
 
+        $group_list->addOptionsByArray($group_list_options);
+    }
 
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'title',
-			'shortname',
-			'section',
-			'visible',
-			'enabled',
-			'description',
-		);
-	}
+    // process phase
 
+    protected function validate(): void
+    {
+        $shortname_widget = $this->ui->getWidget('shortname');
+        $shortname = $shortname_widget->value;
 
+        $should_validate_shortname = (!$this->isNew() || $shortname != '');
+        if ($should_validate_shortname
+            && !$this->validateShortname($shortname)) {
+            $message = new SwatMessage(
+                Admin::_('Shortname already exists and must be unique.'),
+                'error'
+            );
 
-	// init phase
+            $shortname_widget->addMessage($message);
+        }
+    }
 
+    protected function postSaveObject()
+    {
+        $this->updateGroupBindings();
+    }
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+    protected function updateGroupBindings()
+    {
+        $group_list = $this->ui->getWidget('groups');
 
-		$this->initSections();
-		$this->initGroups();
-	}
+        SwatDB::updateBinding(
+            $this->app->db,
+            'AdminComponentAdminGroupBinding',
+            'component',
+            $this->getObject()->id,
+            'groupnum',
+            $group_list->values,
+            'AdminGroup',
+            'id'
+        );
+    }
 
+    protected function getSavedMessagePrimaryContent()
+    {
+        return sprintf(
+            Admin::_('Component “%s” has been saved.'),
+            $this->getObject()->title
+        );
+    }
 
+    // build phase
 
+    protected function loadObject()
+    {
+        parent::loadObject();
 
-	protected function initSections()
-	{
-		$section_flydown = $this->ui->getWidget('section');
-		$section_flydown_options = SwatDB::getOptionArray(
-			$this->app->db,
-			'AdminSection',
-			'title',
-			'id',
-			'displayorder'
-		);
+        if (!$this->isNew()) {
+            $this->loadGroupBindings();
+        }
+    }
 
-		$section_flydown->addOptionsByArray($section_flydown_options);
-	}
-
-
-
-
-	protected function initGroups()
-	{
-		$group_list = $this->ui->getWidget('groups');
-		$group_list_options = SwatDB::getOptionArray(
-			$this->app->db,
-			'AdminGroup',
-			'title',
-			'id',
-			'title'
-		);
-
-		$group_list->addOptionsByArray($group_list_options);
-	}
-
-
-
-	// process phase
-
-
-	protected function validate(): void
-	{
-		$shortname_widget = $this->ui->getWidget('shortname');
-		$shortname = $shortname_widget->value;
-
-		$should_validate_shortname = (!$this->isNew() || $shortname != '');
-		if ($should_validate_shortname &&
-			!$this->validateShortname($shortname)) {
-			$message = new SwatMessage(
-				Admin::_('Shortname already exists and must be unique.'),
-				'error'
-			);
-
-			$shortname_widget->addMessage($message);
-		}
-	}
-
-
-
-
-	protected function postSaveObject()
-	{
-		$this->updateGroupBindings();
-	}
-
-
-
-
-	protected function updateGroupBindings()
-	{
-		$group_list = $this->ui->getWidget('groups');
-
-		SwatDB::updateBinding(
-			$this->app->db,
-			'AdminComponentAdminGroupBinding',
-			'component',
-			$this->getObject()->id,
-			'groupnum',
-			$group_list->values,
-			'AdminGroup',
-			'id'
-		);
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return sprintf(
-			Admin::_('Component “%s” has been saved.'),
-			$this->getObject()->title
-		);
-	}
-
-
-
-	// build phase
-
-
-	protected function loadObject()
-	{
-		parent::loadObject();
-
-		if (!$this->isNew()) {
-			$this->loadGroupBindings();
-		}
-	}
-
-
-
-
-	protected function loadGroupBindings()
-	{
-		$group_list = $this->ui->getWidget('groups');
-		$group_list->values = SwatDB::queryColumn(
-			$this->app->db,
-			'AdminComponentAdminGroupBinding',
-			'groupnum',
-			'component',
-			$this->getObject()->id
-		);
-	}
-
-
+    protected function loadGroupBindings()
+    {
+        $group_list = $this->ui->getWidget('groups');
+        $group_list->values = SwatDB::queryColumn(
+            $this->app->db,
+            'AdminComponentAdminGroupBinding',
+            'groupnum',
+            'component',
+            $this->getObject()->id
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminComponent/Index.php
+++ b/Admin/components/AdminComponent/Index.php
@@ -10,7 +10,7 @@
 class AdminAdminComponentIndex extends AdminIndex
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 	protected function initInternal()
 	{
 		$this->ui->loadFromXML(__DIR__.'/index.xml');
@@ -20,10 +20,10 @@ class AdminAdminComponentIndex extends AdminIndex
 			$this->app->db, 'AdminSection', 'title', 'id', 'displayorder'));
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processActions()
+
 
 	protected function processActions(SwatView $view, SwatActions $actions)
 	{
@@ -102,10 +102,10 @@ class AdminAdminComponentIndex extends AdminIndex
 			$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function getTableModel()
+
 
 	protected function getTableModel(SwatView $view): SwatTableStore
 	{
@@ -179,7 +179,7 @@ class AdminAdminComponentIndex extends AdminIndex
 		return $store;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminComponent/Index.php
+++ b/Admin/components/AdminComponent/Index.php
@@ -1,121 +1,175 @@
 <?php
 
 /**
- * Index page for AdminComponents
+ * Index page for AdminComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminComponentIndex extends AdminIndex
 {
-	// init phase
+    // init phase
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/index.xml');
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/index.xml');
 
-		$section_flydown = $this->ui->getWidget('section');
-		$section_flydown->addOptionsByArray(SwatDB::getOptionArray(
-			$this->app->db, 'AdminSection', 'title', 'id', 'displayorder'));
-	}
+        $section_flydown = $this->ui->getWidget('section');
+        $section_flydown->addOptionsByArray(SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminSection',
+            'title',
+            'id',
+            'displayorder'
+        ));
+    }
 
+    // process phase
 
+    protected function processActions(SwatView $view, SwatActions $actions)
+    {
+        $num = count($view->checked_items);
+        $message = null;
 
-	// process phase
+        switch ($actions->selected->id) {
+            case 'delete':
+                $this->app->replacePage('AdminComponent/Delete');
+                $this->app->getPage()->setItems($view->getSelection());
+                break;
 
+            case 'show':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminComponent',
+                    'boolean:visible',
+                    true,
+                    'id',
+                    $view->getSelection()
+                );
 
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-		$num = count($view->checked_items);
-		$message = null;
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One component has been shown.',
+                        '%s components have been shown.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-		switch ($actions->selected->id) {
-		case 'delete':
-			$this->app->replacePage('AdminComponent/Delete');
-			$this->app->getPage()->setItems($view->getSelection());
-			break;
+                break;
 
-		case 'show':
-			SwatDB::updateColumn($this->app->db, 'AdminComponent',
-				'boolean:visible', true, 'id', $view->getSelection());
+            case 'hide':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminComponent',
+                    'boolean:visible',
+                    false,
+                    'id',
+                    $view->getSelection()
+                );
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One component has been shown.',
-				'%s components have been shown.', $num),
-				SwatString::numberFormat($num)));
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One component has been hidden.',
+                        '%s components have been hidden.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-			break;
+                break;
 
-		case 'hide':
-			SwatDB::updateColumn($this->app->db, 'AdminComponent',
-				'boolean:visible', false, 'id', $view->getSelection());
+            case 'enable':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminComponent',
+                    'boolean:enabled',
+                    true,
+                    'id',
+                    $view->getSelection()
+                );
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One component has been hidden.',
-				'%s components have been hidden.', $num),
-				SwatString::numberFormat($num)));
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One component has been enabled.',
+                        '%s components have been enabled.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-			break;
+                break;
 
-		case 'enable':
-			SwatDB::updateColumn($this->app->db, 'AdminComponent',
-				'boolean:enabled', true, 'id', $view->getSelection());
+            case 'disable':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminComponent',
+                    'boolean:enabled',
+                    false,
+                    'id',
+                    $view->getSelection()
+                );
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One component has been enabled.',
-				'%s components have been enabled.', $num),
-				SwatString::numberFormat($num)));
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One component has been disabled.',
+                        '%s components have been disabled.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-			break;
+                break;
 
-		case 'disable':
-			SwatDB::updateColumn($this->app->db, 'AdminComponent',
-				'boolean:enabled', false, 'id', $view->getSelection());
+            case 'change_section':
+                $new_section = $actions->selected->widget->value;
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One component has been disabled.',
-				'%s components have been disabled.', $num),
-				SwatString::numberFormat($num)));
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminComponent',
+                    'integer:section',
+                    $new_section,
+                    'id',
+                    $view->getSelection()
+                );
 
-			break;
+                $title = SwatDB::queryOneFromTable(
+                    $this->app->db,
+                    'AdminSection',
+                    'text:title',
+                    'id',
+                    $new_section
+                );
 
-		case 'change_section':
-			$new_section = $actions->selected->widget->value;
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One component has been moved to section “%s”.',
+                        '%s components have been moved to section “%s”.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num),
+                    $title
+                ));
 
-			SwatDB::updateColumn($this->app->db, 'AdminComponent',
-				'integer:section', $new_section, 'id', $view->getSelection());
+                break;
+        }
 
-			$title = SwatDB::queryOneFromTable($this->app->db, 'AdminSection',
-				'text:title', 'id', $new_section);
+        if ($message !== null) {
+            $this->app->messages->add($message);
+        }
+    }
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One component has been moved to section “%s”.',
-				'%s components have been moved to section “%s”.', $num),
-				SwatString::numberFormat($num),
-				$title));
+    // build phase
 
-			break;
-		}
+    protected function getTableModel(SwatView $view): SwatTableStore
+    {
+        /*
+         * Build a custom table-view store here so we can set the sensitivity
+         * on group header change-order links.
+         */
 
-		if ($message !== null)
-			$this->app->messages->add($message);
-	}
-
-
-
-	// build phase
-
-
-	protected function getTableModel(SwatView $view): SwatTableStore
-	{
-		/*
-		 * Build a custom table-view store here so we can set the sensitivity
-		 * on group header change-order links.
-		 */
-
-		// get component information
-		$sql = 'select AdminComponent.id,
+        // get component information
+        $sql = 'select AdminComponent.id,
 					AdminComponent.title,
 					AdminComponent.shortname,
 					AdminComponent.section,
@@ -126,14 +180,16 @@ class AdminAdminComponentIndex extends AdminIndex
 					on AdminSection.id = AdminComponent.section
 				order by AdminSection.displayorder, AdminSection.id, %s';
 
-		$sql = sprintf($sql,
-			$this->getOrderByClause($view, 'AdminComponent.displayorder,
-				AdminComponent.title', 'AdminComponent'));
+        $sql = sprintf(
+            $sql,
+            $this->getOrderByClause($view, 'AdminComponent.displayorder,
+				AdminComponent.title', 'AdminComponent')
+        );
 
-		$components = SwatDB::query($this->app->db, $sql);
+        $components = SwatDB::query($this->app->db, $sql);
 
-		// get component-count and title for each section
-		$sql = 'select section as id, AdminSection.title as title,
+        // get component-count and title for each section
+        $sql = 'select section as id, AdminSection.title as title,
 			count(AdminComponent.id) as num_components
 			from AdminComponent
 			inner join AdminSection
@@ -142,44 +198,40 @@ class AdminAdminComponentIndex extends AdminIndex
 				AdminSection.displayorder
 			order by AdminSection.displayorder, AdminSection.id';
 
-		$section_info = SwatDB::query($this->app->db, $sql);
-		$current_section = null;
+        $section_info = SwatDB::query($this->app->db, $sql);
+        $current_section = null;
 
-		$store = new SwatTableStore();
+        $store = new SwatTableStore();
 
-		foreach ($components as $component) {
-			$ds = new SwatDetailsStore();
+        foreach ($components as $component) {
+            $ds = new SwatDetailsStore();
 
-			if ($current_section === null ||
-				$current_section->id !== $component->section) {
-				foreach ($section_info as $section) {
-					if ($section->id === $component->section) {
-						$current_section = $section;
-						break;
-					}
-				}
-			}
+            if ($current_section === null
+                || $current_section->id !== $component->section) {
+                foreach ($section_info as $section) {
+                    if ($section->id === $component->section) {
+                        $current_section = $section;
+                        break;
+                    }
+                }
+            }
 
-			// set component-specific info
-			$ds->id = $component->id;
-			$ds->title = $component->title;
-			$ds->shortname = $component->shortname;
-			$ds->visible = $component->visible;
-			$ds->enabled = $component->enabled;
+            // set component-specific info
+            $ds->id = $component->id;
+            $ds->title = $component->title;
+            $ds->shortname = $component->shortname;
+            $ds->visible = $component->visible;
+            $ds->enabled = $component->enabled;
 
-			// set section-specific info
-			$ds->section = $current_section->id;
-			$ds->section_title = $current_section->title;
-			$ds->section_order_sensitive =
-				($current_section->num_components > 1);
+            // set section-specific info
+            $ds->section = $current_section->id;
+            $ds->section_title = $current_section->title;
+            $ds->section_order_sensitive =
+                ($current_section->num_components > 1);
 
-			$store->add($ds);
-		}
+            $store->add($ds);
+        }
 
-		return $store;
-	}
-
-
+        return $store;
+    }
 }
-
-?>

--- a/Admin/components/AdminComponent/Order.php
+++ b/Admin/components/AdminComponent/Order.php
@@ -1,76 +1,71 @@
 <?php
 
 /**
- * Order page for AdminComponents
+ * Order page for AdminComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminComponentOrder extends AdminDBOrder
 {
+    private $parent;
 
+    // init phase
 
-	private $parent;
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->parent = SiteApplication::initVar('parent');
+        $form = $this->ui->getWidget('order_form');
+        $form->addHiddenField('parent', $this->parent);
+    }
 
+    // process phase
 
-	// init phase
+    protected function saveIndex($id, $index)
+    {
+        SwatDB::updateColumn(
+            $this->app->db,
+            'AdminComponent',
+            'integer:displayorder',
+            $index,
+            'integer:id',
+            [$id]
+        );
+    }
 
+    // build phase
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+    protected function buildInternal()
+    {
+        $frame = $this->ui->getWidget('order_frame');
+        $frame->title = Admin::_('Order Components');
+        parent::buildInternal();
+    }
 
-		$this->parent = SiteApplication::initVar('parent');
-		$form = $this->ui->getWidget('order_form');
-		$form->addHiddenField('parent', $this->parent);
-	}
+    protected function loadData()
+    {
+        $where_clause = sprintf(
+            'section = %s',
+            $this->app->db->quote($this->parent, 'integer')
+        );
 
+        $order_widget = $this->ui->getWidget('order');
+        $order_widget->addOptionsByArray(SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminComponent',
+            'title',
+            'id',
+            'displayorder, title',
+            $where_clause
+        ));
 
+        $sql = 'select sum(displayorder) from AdminComponent where ' .
+            $where_clause;
 
-	// process phase
-
-
-	protected function saveIndex($id, $index)
-	{
-		SwatDB::updateColumn($this->app->db, 'AdminComponent',
-			'integer:displayorder', $index, 'integer:id', array($id));
-	}
-
-
-
-	// build phase
-
-	protected function buildInternal()
-	{
-		$frame = $this->ui->getWidget('order_frame');
-		$frame->title = Admin::_('Order Components');
-		parent::buildInternal();
-	}
-
-
-
-
-	protected function loadData()
-	{
-		$where_clause = sprintf('section = %s',
-			$this->app->db->quote($this->parent, 'integer'));
-
-		$order_widget = $this->ui->getWidget('order');
-		$order_widget->addOptionsByArray(SwatDB::getOptionArray($this->app->db,
-			'AdminComponent', 'title', 'id', 'displayorder, title',
-			$where_clause));
-
-		$sql = 'select sum(displayorder) from AdminComponent where '.
-			$where_clause;
-
-		$sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
-		$options_list = $this->ui->getWidget('options');
-		$options_list->value = ($sum == 0) ? 'auto' : 'custom';
-	}
-
-
+        $sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
+        $options_list = $this->ui->getWidget('options');
+        $options_list->value = ($sum == 0) ? 'auto' : 'custom';
+    }
 }
-
-?>

--- a/Admin/components/AdminComponent/Order.php
+++ b/Admin/components/AdminComponent/Order.php
@@ -9,14 +9,14 @@
  */
 class AdminAdminComponentOrder extends AdminDBOrder
 {
-	// {{{ private properties
+
 
 	private $parent;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -27,10 +27,10 @@ class AdminAdminComponentOrder extends AdminDBOrder
 		$form->addHiddenField('parent', $this->parent);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function saveIndex()
+
 
 	protected function saveIndex($id, $index)
 	{
@@ -38,10 +38,10 @@ class AdminAdminComponentOrder extends AdminDBOrder
 			'integer:displayorder', $index, 'integer:id', array($id));
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 	protected function buildInternal()
 	{
 		$frame = $this->ui->getWidget('order_frame');
@@ -49,8 +49,8 @@ class AdminAdminComponentOrder extends AdminDBOrder
 		parent::buildInternal();
 	}
 
-	// }}}
-	// {{{ protected function loadData()
+
+
 
 	protected function loadData()
 	{
@@ -70,7 +70,7 @@ class AdminAdminComponentOrder extends AdminDBOrder
 		$options_list->value = ($sum == 0) ? 'auto' : 'custom';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminGroup/Delete.php
+++ b/Admin/components/AdminGroup/Delete.php
@@ -1,57 +1,59 @@
 <?php
 
 /**
- * Delete confirmation page for AdminGroups component
+ * Delete confirmation page for AdminGroups component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminGroupDelete extends AdminDBDelete
 {
-	// process phase
+    // process phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
-	protected function processDBData(): void
-	{
-		parent::processDBData();
+        $sql = 'delete from AdminGroup where id in (%s)';
+        $item_list = $this->getItemList('integer');
+        $sql = sprintf($sql, $item_list);
+        $num = SwatDB::exec($this->app->db, $sql);
 
-		$sql = 'delete from AdminGroup where id in (%s)';
-		$item_list = $this->getItemList('integer');
-		$sql = sprintf($sql, $item_list);
-		$num = SwatDB::exec($this->app->db, $sql);
+        $message = new SwatMessage(sprintf(
+            Admin::ngettext(
+                'One admin group has been deleted.',
+                '%s admin groups have been deleted.',
+                $num
+            ),
+            SwatString::numberFormat($num)
+        ));
 
-		$message = new SwatMessage(sprintf(Admin::ngettext(
-			'One admin group has been deleted.',
-			'%s admin groups have been deleted.', $num),
-			SwatString::numberFormat($num)));
+        $this->app->messages->add($message);
+    }
 
-		$this->app->messages->add($message);
-	}
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
+        $item_list = $this->getItemList('integer');
 
-	// build phase
+        $dep = new AdminListDependency();
+        $dep->setTitle(Admin::_('group'), Admin::_('groups'));
+        $dep->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminGroup',
+            'integer:id',
+            null,
+            'text:title',
+            'title',
+            'id in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$item_list = $this->getItemList('integer');
-
-		$dep = new AdminListDependency();
-		$dep->setTitle(Admin::_('group'), Admin::_('groups'));
-		$dep->entries = AdminListDependency::queryEntries($this->app->db,
-			'AdminGroup', 'integer:id', null, 'text:title', 'title',
-			'id in ('.$item_list.')', AdminDependency::DELETE);
-
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = $dep->getMessage();
-		$message->content_type = 'text/xml';
-	}
-
-
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = $dep->getMessage();
+        $message->content_type = 'text/xml';
+    }
 }
-
-?>

--- a/Admin/components/AdminGroup/Delete.php
+++ b/Admin/components/AdminGroup/Delete.php
@@ -10,7 +10,7 @@
 class AdminAdminGroupDelete extends AdminDBDelete
 {
 	// process phase
-	// {{{ protected function processDBData()
+
 
 	protected function processDBData(): void
 	{
@@ -29,10 +29,10 @@ class AdminAdminGroupDelete extends AdminDBDelete
 		$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -51,7 +51,7 @@ class AdminAdminGroupDelete extends AdminDBDelete
 		$message->content_type = 'text/xml';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminGroup/Edit.php
+++ b/Admin/components/AdminGroup/Edit.php
@@ -1,197 +1,154 @@
 <?php
 
 /**
- * Edit page for AdminGroups component
+ * Edit page for AdminGroups component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminGroupEdit extends AdminObjectEdit
 {
+    protected function getObjectClass()
+    {
+        return 'AdminGroup';
+    }
 
+    protected function getUiXml()
+    {
+        return __DIR__ . '/edit.xml';
+    }
 
-	protected function getObjectClass()
-	{
-		return 'AdminGroup';
-	}
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'title',
+        ];
+    }
 
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->initUsers();
+        $this->initComponents();
+    }
 
-	protected function getUiXml()
-	{
-		return __DIR__.'/edit.xml';
-	}
+    protected function initUsers()
+    {
+        $user_list = $this->ui->getWidget('users');
+        $user_list_options = SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminUser',
+            'name',
+            'id',
+            'name'
+        );
 
+        $user_list->addOptionsByArray($user_list_options);
+    }
 
+    protected function initComponents()
+    {
+        $component_list = $this->ui->getWidget('components');
+        $component_list_options = SwatDB::getGroupedOptionArray(
+            $this->app->db,
+            'AdminComponent',
+            'title',
+            'id',
+            'AdminSection',
+            'title',
+            'id',
+            'section',
+            'AdminSection.displayorder, AdminSection.title, ' .
+                'AdminComponent.displayorder,  AdminComponent.title'
+        );
 
+        $component_list->setTree($component_list_options);
+    }
 
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'title',
-		);
-	}
+    // process phase
 
+    protected function postSaveObject()
+    {
+        $this->updateUserBindings();
+        $this->updateComponentBindings();
+    }
 
+    protected function updateUserBindings()
+    {
+        $user_list = $this->ui->getWidget('users');
 
-	// init phase
+        SwatDB::updateBinding(
+            $this->app->db,
+            'AdminUserAdminGroupBinding',
+            'groupnum',
+            $this->getObject()->id,
+            'usernum',
+            $user_list->values,
+            'AdminUser',
+            'id'
+        );
+    }
 
+    protected function updateComponentBindings()
+    {
+        $component_list = $this->ui->getWidget('components');
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+        SwatDB::updateBinding(
+            $this->app->db,
+            'AdminComponentAdminGroupBinding',
+            'groupnum',
+            $this->getObject()->id,
+            'component',
+            $component_list->values,
+            'AdminComponent',
+            'id'
+        );
+    }
 
-		$this->initUsers();
-		$this->initComponents();
-	}
+    protected function getSavedMessagePrimaryContent()
+    {
+        return sprintf(
+            Admin::_('Group “%s” has been saved.'),
+            $this->getObject()->title
+        );
+    }
 
+    // build phase
 
+    protected function loadObject()
+    {
+        parent::loadObject();
 
+        if (!$this->isNew()) {
+            $this->loadUserBindings();
+            $this->loadComponentBindings();
+        }
+    }
 
-	protected function initUsers()
-	{
-		$user_list = $this->ui->getWidget('users');
-		$user_list_options = SwatDB::getOptionArray(
-			$this->app->db,
-			'AdminUser',
-			'name',
-			'id',
-			'name'
-		);
+    protected function loadUserBindings()
+    {
+        $user_list = $this->ui->getWidget('users');
+        $user_list->values = SwatDB::queryColumn(
+            $this->app->db,
+            'AdminUserAdminGroupBinding',
+            'usernum',
+            'groupnum',
+            $this->getObject()->id
+        );
+    }
 
-		$user_list->addOptionsByArray($user_list_options);
-	}
-
-
-
-
-	protected function initComponents()
-	{
-		$component_list = $this->ui->getWidget('components');
-		$component_list_options = SwatDB::getGroupedOptionArray(
-			$this->app->db,
-			'AdminComponent',
-			'title',
-			'id',
-			'AdminSection',
-			'title',
-			'id',
-			'section',
-			'AdminSection.displayorder, AdminSection.title, '.
-				'AdminComponent.displayorder,  AdminComponent.title'
-		);
-
-		$component_list->setTree($component_list_options);
-	}
-
-
-
-	// process phase
-
-
-	protected function postSaveObject()
-	{
-		$this->updateUserBindings();
-		$this->updateComponentBindings();
-	}
-
-
-
-
-	protected function updateUserBindings()
-	{
-		$user_list = $this->ui->getWidget('users');
-
-		SwatDB::updateBinding(
-			$this->app->db,
-			'AdminUserAdminGroupBinding',
-			'groupnum',
-			$this->getObject()->id,
-			'usernum',
-			$user_list->values,
-			'AdminUser',
-			'id'
-		);
-	}
-
-
-
-
-	protected function updateComponentBindings()
-	{
-		$component_list = $this->ui->getWidget('components');
-
-		SwatDB::updateBinding(
-			$this->app->db,
-			'AdminComponentAdminGroupBinding',
-			'groupnum',
-			$this->getObject()->id,
-			'component',
-			$component_list->values,
-			'AdminComponent',
-			'id'
-		);
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return sprintf(
-			Admin::_('Group “%s” has been saved.'),
-			$this->getObject()->title
-		);
-	}
-
-
-
-	// build phase
-
-
-	protected function loadObject()
-	{
-		parent::loadObject();
-
-		if (!$this->isNew()) {
-			$this->loadUserBindings();
-			$this->loadComponentBindings();
-		}
-	}
-
-
-
-
-	protected function loadUserBindings()
-	{
-		$user_list = $this->ui->getWidget('users');
-		$user_list->values = SwatDB::queryColumn(
-			$this->app->db,
-			'AdminUserAdminGroupBinding',
-			'usernum',
-			'groupnum',
-			$this->getObject()->id
-		);
-	}
-
-
-
-
-	protected function loadComponentBindings()
-	{
-		$component_list = $this->ui->getWidget('components');
-		$component_list->values = SwatDB::queryColumn(
-			$this->app->db,
-			'AdminComponentAdminGroupBinding',
-			'component',
-			'groupnum',
-			$this->getObject()->id
-		);
-	}
-
-
+    protected function loadComponentBindings()
+    {
+        $component_list = $this->ui->getWidget('components');
+        $component_list->values = SwatDB::queryColumn(
+            $this->app->db,
+            'AdminComponentAdminGroupBinding',
+            'component',
+            'groupnum',
+            $this->getObject()->id
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminGroup/Edit.php
+++ b/Admin/components/AdminGroup/Edit.php
@@ -10,7 +10,7 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'AdminGroup';
+        return AdminGroup::class;
     }
 
     protected function getUiXml()

--- a/Admin/components/AdminGroup/Edit.php
+++ b/Admin/components/AdminGroup/Edit.php
@@ -9,23 +9,23 @@
  */
 class AdminAdminGroupEdit extends AdminObjectEdit
 {
-	// {{{ protected function getObjectClass()
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminGroup';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/edit.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -34,10 +34,10 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -47,8 +47,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		$this->initComponents();
 	}
 
-	// }}}
-	// {{{ protected function initUsers()
+
+
 
 	protected function initUsers()
 	{
@@ -64,8 +64,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		$user_list->addOptionsByArray($user_list_options);
 	}
 
-	// }}}
-	// {{{ protected function initUsers()
+
+
 
 	protected function initComponents()
 	{
@@ -86,10 +86,10 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		$component_list->setTree($component_list_options);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function postSaveObject()
+
 
 	protected function postSaveObject()
 	{
@@ -97,8 +97,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		$this->updateComponentBindings();
 	}
 
-	// }}}
-	// {{{ protected function updateUserBindings()
+
+
 
 	protected function updateUserBindings()
 	{
@@ -116,8 +116,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function updateComponentBindings()
+
+
 
 	protected function updateComponentBindings()
 	{
@@ -135,8 +135,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
@@ -146,10 +146,10 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function loadObject()
+
 
 	protected function loadObject()
 	{
@@ -161,8 +161,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function loadUserBindings()
+
+
 
 	protected function loadUserBindings()
 	{
@@ -176,8 +176,8 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function loadComponentBindings()
+
+
 
 	protected function loadComponentBindings()
 	{
@@ -191,7 +191,7 @@ class AdminAdminGroupEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminGroup/Index.php
+++ b/Admin/components/AdminGroup/Index.php
@@ -10,17 +10,17 @@
 class AdminAdminGroupIndex extends AdminIndex
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
 		$this->ui->loadFromXML(__DIR__.'/index.xml');
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processActions()
+
 
 	protected function processActions(SwatView $view, SwatActions $actions)
 	{
@@ -32,10 +32,10 @@ class AdminAdminGroupIndex extends AdminIndex
 		}
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function getTableModel()
+
 
 	protected function getTableModel(SwatView $view): AdminGroupWrapper
 	{
@@ -45,7 +45,7 @@ class AdminAdminGroupIndex extends AdminIndex
 		return $groups;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminGroup/Index.php
+++ b/Admin/components/AdminGroup/Index.php
@@ -1,51 +1,38 @@
 <?php
 
 /**
- * Index page for AdminGroups component
+ * Index page for AdminGroups component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminGroupIndex extends AdminIndex
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/index.xml');
+    }
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/index.xml');
-	}
+    // process phase
 
+    protected function processActions(SwatView $view, SwatActions $actions)
+    {
+        switch ($actions->selected->id) {
+            case 'delete':
+                $this->app->replacePage('AdminGroup/Delete');
+                $this->app->getPage()->setItems($view->getSelection());
+                break;
+        }
+    }
 
+    // build phase
 
-	// process phase
+    protected function getTableModel(SwatView $view): AdminGroupWrapper
+    {
+        $sql = 'select id, title from AdminGroup order by title';
 
-
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-		switch ($actions->selected->id) {
-		case 'delete':
-			$this->app->replacePage('AdminGroup/Delete');
-			$this->app->getPage()->setItems($view->getSelection());
-			break;
-		}
-	}
-
-
-
-	// build phase
-
-
-	protected function getTableModel(SwatView $view): AdminGroupWrapper
-	{
-		$sql = 'select id, title from AdminGroup order by title';
-		$groups = SwatDB::query($this->app->db, $sql, AdminGroupWrapper::class);
-
-		return $groups;
-	}
-
-
+        return SwatDB::query($this->app->db, $sql, AdminGroupWrapper::class);
+    }
 }
-
-?>

--- a/Admin/components/AdminSection/Delete.php
+++ b/Admin/components/AdminSection/Delete.php
@@ -10,7 +10,7 @@
 class AdminAdminSectionDelete extends AdminDBDelete
 {
 	// init phase
-	// {{{ protected function processDBData()
+
 
 	protected function processDBData(): void
 	{
@@ -29,10 +29,10 @@ class AdminAdminSectionDelete extends AdminDBDelete
 		$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -74,7 +74,7 @@ class AdminAdminSectionDelete extends AdminDBDelete
 		$message->content_type = 'text/xml';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSection/Delete.php
+++ b/Admin/components/AdminSection/Delete.php
@@ -1,80 +1,96 @@
 <?php
 
 /**
- * Delete confirmation page for AdminSections component
+ * Delete confirmation page for AdminSections component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSectionDelete extends AdminDBDelete
 {
-	// init phase
+    // init phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
-	protected function processDBData(): void
-	{
-		parent::processDBData();
+        $sql = 'delete from AdminSection where id in (%s)';
+        $item_list = $this->getItemList('integer');
+        $sql = sprintf($sql, $item_list);
+        $num = SwatDB::exec($this->app->db, $sql);
 
-		$sql = 'delete from AdminSection where id in (%s)';
-		$item_list = $this->getItemList('integer');
-		$sql = sprintf($sql, $item_list);
-		$num = SwatDB::exec($this->app->db, $sql);
+        $message = new SwatMessage(sprintf(
+            Admin::ngettext(
+                'One admin section has been deleted.',
+                '%s admin sections have been deleted.',
+                $num
+            ),
+            SwatString::numberFormat($num)
+        ));
 
-		$message = new SwatMessage(sprintf(Admin::ngettext(
-			'One admin section has been deleted.',
-			'%s admin sections have been deleted.', $num),
-			SwatString::numberFormat($num)));
+        $this->app->messages->add($message);
+    }
 
-		$this->app->messages->add($message);
-	}
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
+        $item_list = $this->getItemList('integer');
 
-	// build phase
+        $dep = new AdminListDependency();
+        $dep->setTitle(Admin::_('section'), Admin::_('sections'));
+        $dep->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminSection',
+            'integer:id',
+            null,
+            'text:title',
+            'title',
+            'id in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
+        $dep_components = new AdminListDependency();
+        $dep_components->setTitle(
+            Admin::_('component'),
+            Admin::_('components')
+        );
 
-	protected function buildInternal()
-	{
-		parent::buildInternal();
+        $dep_components->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminComponent',
+            'integer:id',
+            'integer:section',
+            'text:title',
+            'title',
+            'section in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
-		$item_list = $this->getItemList('integer');
+        $dep->addDependency($dep_components);
 
-		$dep = new AdminListDependency();
-		$dep->setTitle(Admin::_('section'), Admin::_('sections'));
-		$dep->entries = AdminListDependency::queryEntries($this->app->db,
-			'AdminSection', 'integer:id', null, 'text:title', 'title',
-			'id in ('.$item_list.')', AdminDependency::DELETE);
+        $dep_subcomponents = new AdminSummaryDependency();
+        $dep_subcomponents->setTitle(
+            Admin::_('sub-component'),
+            Admin::_('sub-components')
+        );
 
-		$dep_components = new AdminListDependency();
-		$dep_components->setTitle(
-			Admin::_('component'), Admin::_('components'));
+        $dep_subcomponents->summaries = AdminSummaryDependency::querySummaries(
+            $this->app->db,
+            'AdminSubComponent',
+            'integer:id',
+            'integer:component',
+            'component in (select id from AdminComponent where section in (' .
+            $item_list . '))',
+            AdminDependency::DELETE
+        );
 
-		$dep_components->entries = AdminListDependency::queryEntries(
-			$this->app->db, 'AdminComponent', 'integer:id', 'integer:section',
-			'text:title', 'title', 'section in ('.$item_list.')',
-			AdminDependency::DELETE);
+        $dep_components->addDependency($dep_subcomponents);
 
-		$dep->addDependency($dep_components);
-
-		$dep_subcomponents = new AdminSummaryDependency();
-		$dep_subcomponents->setTitle(
-			Admin::_('sub-component'), Admin::_('sub-components'));
-
-		$dep_subcomponents->summaries = AdminSummaryDependency::querySummaries(
-			$this->app->db, 'AdminSubComponent', 'integer:id',
-			'integer:component',
-			'component in (select id from AdminComponent where section in ('.
-			$item_list.'))', AdminDependency::DELETE);
-
-		$dep_components->addDependency($dep_subcomponents);
-
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = $dep->getMessage();
-		$message->content_type = 'text/xml';
-	}
-
-
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = $dep->getMessage();
+        $message->content_type = 'text/xml';
+    }
 }
-
-?>

--- a/Admin/components/AdminSection/Edit.php
+++ b/Admin/components/AdminSection/Edit.php
@@ -9,23 +9,23 @@
  */
 class AdminAdminSectionEdit extends AdminObjectEdit
 {
-	// {{{ protected function getObjectClass()
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminSection';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/edit.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -36,10 +36,10 @@ class AdminAdminSectionEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function getSavedMessagePrimaryContent()
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
@@ -49,7 +49,7 @@ class AdminAdminSectionEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSection/Edit.php
+++ b/Admin/components/AdminSection/Edit.php
@@ -1,55 +1,39 @@
 <?php
 
 /**
- * Edit page for AdminSections
+ * Edit page for AdminSections.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSectionEdit extends AdminObjectEdit
 {
+    protected function getObjectClass()
+    {
+        return 'AdminSection';
+    }
 
+    protected function getUiXml()
+    {
+        return __DIR__ . '/edit.xml';
+    }
 
-	protected function getObjectClass()
-	{
-		return 'AdminSection';
-	}
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'title',
+            'visible',
+            'description',
+        ];
+    }
 
+    // process phase
 
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/edit.xml';
-	}
-
-
-
-
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'title',
-			'visible',
-			'description',
-		);
-	}
-
-
-
-	// process phase
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return sprintf(
-			Admin::_('Section “%s” has been saved.'),
-			$this->getObject()->title
-		);
-	}
-
-
+    protected function getSavedMessagePrimaryContent()
+    {
+        return sprintf(
+            Admin::_('Section “%s” has been saved.'),
+            $this->getObject()->title
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSection/Edit.php
+++ b/Admin/components/AdminSection/Edit.php
@@ -10,7 +10,7 @@ class AdminAdminSectionEdit extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'AdminSection';
+        return AdminSection::class;
     }
 
     protected function getUiXml()

--- a/Admin/components/AdminSection/Index.php
+++ b/Admin/components/AdminSection/Index.php
@@ -9,17 +9,17 @@
 class AdminAdminSectionIndex extends AdminIndex
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
 		$this->ui->loadFromXML(__DIR__.'/index.xml');
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processActions()
+
 
 	protected function processActions(SwatView $view, SwatActions $actions)
 	{
@@ -59,10 +59,10 @@ class AdminAdminSectionIndex extends AdminIndex
 			$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function getTableModel()
+
 
 	protected function getTableModel(SwatView $view): AdminSectionWrapper
 	{
@@ -78,7 +78,7 @@ class AdminAdminSectionIndex extends AdminIndex
 		return $sections;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSection/Index.php
+++ b/Admin/components/AdminSection/Index.php
@@ -1,84 +1,94 @@
 <?php
 
 /**
- * Index page for admin sections
+ * Index page for admin sections.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  */
 class AdminAdminSectionIndex extends AdminIndex
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/index.xml');
+    }
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/index.xml');
-	}
+    // process phase
 
+    protected function processActions(SwatView $view, SwatActions $actions)
+    {
+        $num = count($view->checked_items);
+        $message = null;
 
+        switch ($actions->selected->id) {
+            case 'delete':
+                $this->app->replacePage('AdminSection/Delete');
+                $this->app->getPage()->setItems($view->getSelection());
+                break;
 
-	// process phase
+            case 'show':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminSection',
+                    'boolean:visible',
+                    true,
+                    'id',
+                    $view->getSelection()
+                );
 
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One section has been shown.',
+                        '%s sections have been shown.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-		$num = count($view->checked_items);
-		$message = null;
+                break;
 
-		switch ($actions->selected->id) {
-		case 'delete':
-			$this->app->replacePage('AdminSection/Delete');
-			$this->app->getPage()->setItems($view->getSelection());
-			break;
+            case 'hide':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminSection',
+                    'boolean:visible',
+                    false,
+                    'id',
+                    $view->getSelection()
+                );
 
-		case 'show':
-			SwatDB::updateColumn($this->app->db, 'AdminSection',
-				'boolean:visible', true, 'id', $view->getSelection());
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One section has been hidden.',
+                        '%s sections have been hidden.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One section has been shown.',
-				'%s sections have been shown.', $num),
-				SwatString::numberFormat($num)));
+                break;
+        }
 
-			break;
+        if ($message !== null) {
+            $this->app->messages->add($message);
+        }
+    }
 
-		case 'hide':
-			SwatDB::updateColumn($this->app->db, 'AdminSection',
-				'boolean:visible', false, 'id', $view->getSelection());
+    // build phase
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One section has been hidden.',
-				'%s sections have been hidden.', $num),
-				SwatString::numberFormat($num)));
-
-			break;
-		}
-
-		if ($message !== null)
-			$this->app->messages->add($message);
-	}
-
-
-
-	// build phase
-
-
-	protected function getTableModel(SwatView $view): AdminSectionWrapper
-	{
-		$sql = 'select id, title, visible
+    protected function getTableModel(SwatView $view): AdminSectionWrapper
+    {
+        $sql = 'select id, title, visible
 			from AdminSection
 			order by displayorder';
 
-		$sections = SwatDB::query($this->app->db, $sql, AdminSectionWrapper::class);
+        $sections = SwatDB::query($this->app->db, $sql, AdminSectionWrapper::class);
 
-		if (count($sections) == 0)
-			$this->ui->getWidget('order_tool')->visible = false;
+        if (count($sections) == 0) {
+            $this->ui->getWidget('order_tool')->visible = false;
+        }
 
-		return $sections;
-	}
-
-
+        return $sections;
+    }
 }
-
-?>

--- a/Admin/components/AdminSection/Order.php
+++ b/Admin/components/AdminSection/Order.php
@@ -9,14 +9,14 @@
  */
 class AdminAdminSectionOrder extends AdminDBOrder
 {
-	// {{{ private properties
+
 
 	private $parent;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -27,10 +27,10 @@ class AdminAdminSectionOrder extends AdminDBOrder
 		$form->addHiddenField('parent', $this->parent);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function saveIndex()
+
 
 	protected function saveIndex($id, $index)
 	{
@@ -38,10 +38,10 @@ class AdminAdminSectionOrder extends AdminDBOrder
 			'integer:displayorder', $index, 'integer:id', array($id));
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 	protected function buildInternal()
 	{
 		$frame = $this->ui->getWidget('order_frame');
@@ -49,8 +49,8 @@ class AdminAdminSectionOrder extends AdminDBOrder
 		parent::buildInternal();
 	}
 
-	// }}}
-	// {{{ protected function loadData()
+
+
 
 	protected function loadData()
 	{
@@ -64,7 +64,7 @@ class AdminAdminSectionOrder extends AdminDBOrder
 		$options_list->value = ($sum == 0) ? 'auto' : 'custom';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSection/Order.php
+++ b/Admin/components/AdminSection/Order.php
@@ -1,70 +1,63 @@
 <?php
 
 /**
- * Order page for AdminSections component
+ * Order page for AdminSections component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSectionOrder extends AdminDBOrder
 {
+    private $parent;
 
+    // init phase
 
-	private $parent;
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->parent = SiteApplication::initVar('parent');
+        $form = $this->ui->getWidget('order_form');
+        $form->addHiddenField('parent', $this->parent);
+    }
 
+    // process phase
 
-	// init phase
+    protected function saveIndex($id, $index)
+    {
+        SwatDB::updateColumn(
+            $this->app->db,
+            'AdminSection',
+            'integer:displayorder',
+            $index,
+            'integer:id',
+            [$id]
+        );
+    }
 
+    // build phase
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+    protected function buildInternal()
+    {
+        $frame = $this->ui->getWidget('order_frame');
+        $frame->title = Admin::_('Order Sections');
+        parent::buildInternal();
+    }
 
-		$this->parent = SiteApplication::initVar('parent');
-		$form = $this->ui->getWidget('order_form');
-		$form->addHiddenField('parent', $this->parent);
-	}
+    protected function loadData()
+    {
+        $order_widget = $this->ui->getWidget('order');
+        $order_widget->addOptionsByArray(SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminSection',
+            'title',
+            'id',
+            'displayorder, title'
+        ));
 
-
-
-	// process phase
-
-
-	protected function saveIndex($id, $index)
-	{
-		SwatDB::updateColumn($this->app->db, 'AdminSection',
-			'integer:displayorder', $index, 'integer:id', array($id));
-	}
-
-
-
-	// build phase
-
-	protected function buildInternal()
-	{
-		$frame = $this->ui->getWidget('order_frame');
-		$frame->title = Admin::_('Order Sections');
-		parent::buildInternal();
-	}
-
-
-
-
-	protected function loadData()
-	{
-		$order_widget = $this->ui->getWidget('order');
-		$order_widget->addOptionsByArray(SwatDB::getOptionArray($this->app->db,
-			'AdminSection', 'title', 'id', 'displayorder, title'));
-
-		$sql = 'select sum(displayorder) from AdminSection';
-		$sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
-		$options_list = $this->ui->getWidget('options');
-		$options_list->value = ($sum == 0) ? 'auto' : 'custom';
-	}
-
-
+        $sql = 'select sum(displayorder) from AdminSection';
+        $sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
+        $options_list = $this->ui->getWidget('options');
+        $options_list->value = ($sum == 0) ? 'auto' : 'custom';
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/ChangePassword.php
+++ b/Admin/components/AdminSite/ChangePassword.php
@@ -9,15 +9,15 @@
 class AdminAdminSiteChangePassword extends AdminPage
 {
 	// init phase
-	// {{{ protected function createLayout()
+
 
 	protected function createLayout()
 	{
 		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
 	}
 
-	// }}}
-	// {{{ protected function initInternal()
+
+
 
 	protected function initInternal()
 	{
@@ -35,10 +35,10 @@ class AdminAdminSiteChangePassword extends AdminPage
 		$form->addHiddenField('relocate_uri', $this->app->getUri());
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -71,8 +71,8 @@ class AdminAdminSiteChangePassword extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function validatePasswords()
+
+
 
 	protected function validatePasswords()
 	{
@@ -113,10 +113,10 @@ class AdminAdminSiteChangePassword extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize
+
 
 	public function finalize()
 	{
@@ -127,7 +127,7 @@ class AdminAdminSiteChangePassword extends AdminPage
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/ChangePassword.php
+++ b/Admin/components/AdminSite/ChangePassword.php
@@ -1,133 +1,116 @@
 <?php
 
 /**
- * Force change password page after initial login
+ * Force change password page after initial login.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  */
 class AdminAdminSiteChangePassword extends AdminPage
 {
-	// init phase
+    // init phase
 
+    protected function createLayout()
+    {
+        return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
+    }
 
-	protected function createLayout()
-	{
-		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
-	}
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->ui->loadFromXML(__DIR__ . '/change-password.xml');
 
+        $confirm = $this->ui->getWidget('confirm_password');
+        $confirm->password_widget = $this->ui->getWidget('password');
 
+        $form = $this->ui->getWidget('change_password_form');
+        $form->action = 'AdminSite/ChangePassword';
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+        // remember where we came from
+        $form->addHiddenField('relocate_uri', $this->app->getUri());
+    }
 
-		$this->ui->loadFromXML(__DIR__.'/change-password.xml');
+    // process phase
 
-		$confirm = $this->ui->getWidget('confirm_password');
-		$confirm->password_widget = $this->ui->getWidget('password');
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-		$form = $this->ui->getWidget('change_password_form');
-		$form->action = 'AdminSite/ChangePassword';
+        $crypt = $this->app->getModule('SiteCryptModule');
 
-		// remember where we came from
-		$form->addHiddenField('relocate_uri', $this->app->getUri());
-	}
+        $form = $this->ui->getWidget('change_password_form');
+        if ($form->isProcessed()) {
+            $this->validatePasswords();
+            if (!$form->hasMessage()) {
+                $password = $this->ui->getWidget('password')->value;
 
+                $user = $this->app->session->user;
+                $user->setPasswordHash($crypt->generateHash($password));
+                $user->force_change_password = false;
+                $user->save();
 
+                $this->app->session->login($user->email, $password);
 
-	// process phase
+                $message = new SwatMessage(
+                    Admin::_('Your password has been updated.')
+                );
 
+                $this->app->messages->add($message);
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+                // go back where we came from
+                $uri = $form->getHiddenField('relocate_uri');
+                $this->app->relocate($uri);
+            }
+        }
+    }
 
-		$crypt = $this->app->getModule('SiteCryptModule');
+    protected function validatePasswords()
+    {
+        $user = $this->app->session->user;
 
-		$form = $this->ui->getWidget('change_password_form');
-		if ($form->isProcessed()) {
-			$this->validatePasswords();
-			if (!$form->hasMessage()) {
-				$password = $this->ui->getWidget('password')->value;
+        $old_password = $this->ui->getWidget('old_password')->value;
+        $new_password = $this->ui->getWidget('password')->value;
 
-				$user = $this->app->session->user;
-				$user->setPasswordHash($crypt->generateHash($password));
-				$user->force_change_password = false;
-				$user->save();
+        if ($old_password === null || $new_password === null) {
+            return;
+        }
 
-				$this->app->session->login($user->email, $password);
+        // make sure old password is not the same as new password
+        if ($old_password == $new_password) {
+            $message = new SwatMessage(Admin::_('Your new password can not be ' .
+                'the same as your old password'), 'error');
 
-				$message = new SwatMessage(
-					Admin::_('Your password has been updated.'));
+            $this->ui->getWidget('password')->addMessage($message);
+        }
 
-				$this->app->messages->add($message);
+        $crypt = $this->app->getModule('SiteCryptModule');
 
-				// go back where we came from
-				$uri = $form->getHiddenField('relocate_uri');
-				$this->app->relocate($uri);
-			}
-		}
-	}
+        $password_hash = $user->password;
+        $password_salt = $user->password_salt;
 
+        // make sure old password is correct
+        if (!$crypt->verifyHash(
+            $old_password,
+            $password_hash,
+            $password_salt
+        )) {
+            $this->ui->getWidget('old_password')->addMessage(
+                new SwatMessage(
+                    Admin::_('Your old password is not correct'),
+                    'error'
+                )
+            );
+        }
+    }
 
+    // finalize phase
 
+    public function finalize()
+    {
+        parent::finalize();
 
-	protected function validatePasswords()
-	{
-		$user = $this->app->session->user;
-
-		$old_password = $this->ui->getWidget('old_password')->value;
-		$new_password = $this->ui->getWidget('password')->value;
-
-		if ($old_password === null || $new_password === null)
-			return;
-
-		// make sure old password is not the same as new password
-		if ($old_password == $new_password) {
-			$message = new SwatMessage(Admin::_('Your new password can not be '.
-				'the same as your old password'), 'error');
-
-			$this->ui->getWidget('password')->addMessage($message);
-		}
-
-		$crypt = $this->app->getModule('SiteCryptModule');
-
-		$password_hash = $user->password;
-		$password_salt = $user->password_salt;
-
-		// make sure old password is correct
-		if (!$crypt->verifyHash(
-				$old_password,
-				$password_hash,
-				$password_salt
-			)) {
-
-			$this->ui->getWidget('old_password')->addMessage(
-				new SwatMessage(
-					Admin::_('Your old password is not correct'),
-					'error'
-				)
-			);
-		}
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-change-password-page.css'
-		);
-	}
-
-
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-change-password-page.css'
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Exception.php
+++ b/Admin/components/AdminSite/Exception.php
@@ -1,93 +1,71 @@
 <?php
 
 /**
- * Exception page in an admin application
+ * Exception page in an admin application.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  */
 class AdminAdminSiteException extends SiteXhtmlExceptionPage
 {
+    /**
+     * @var SwatContainer
+     */
+    protected $container;
 
+    protected function createLayout()
+    {
+        return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
+    }
 
-	/**
-	 * @var SwatContainer
-	 */
-	protected $container;
+    // init phase
 
+    public function init()
+    {
+        parent::init();
 
+        $this->container = new SwatFrame();
+        $this->container->classes[] = 'admin-exception-container';
+    }
 
+    // build phase
 
-	protected function createLayout()
-	{
-		return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
-	}
+    public function build()
+    {
+        parent::build();
+        if (isset($this->layout->navbar)) {
+            $this->layout->navbar->popEntry();
+            $this->layout->navbar->popEntry();
+            $this->layout->navbar->createEntry('Error');
+        }
+    }
 
+    protected function display()
+    {
+        ob_start();
 
+        printf('<p>%s</p>', $this->getSummary());
 
-	// init phase
+        echo '<p>This error has been reported.</p>';
 
+        if ($this->exception !== null) {
+            $this->exception->process(false);
+        }
 
-	public function init()
-	{
-		parent::init();
+        $content_block = new SwatContentBlock();
+        $content_block->content = ob_get_clean();
+        $content_block->content_type = 'text/xml';
 
-		$this->container = new SwatFrame();
-		$this->container->classes[] = 'admin-exception-container';
-	}
+        $this->container->add($content_block);
+        $this->container->display();
+    }
 
+    // finalize phase
 
-
-	// build phase
-
-
-	public function build()
-	{
-		parent::build();
-		if (isset($this->layout->navbar)) {
-			$this->layout->navbar->popEntry();
-			$this->layout->navbar->popEntry();
-			$this->layout->navbar->createEntry('Error');
-		}
-	}
-
-
-
-
-	protected function display()
-	{
-		ob_start();
-
-		printf('<p>%s</p>', $this->getSummary());
-
-		echo '<p>This error has been reported.</p>';
-
-		if ($this->exception !== null) {
-			$this->exception->process(false);
-		}
-
-		$content_block = new SwatContentBlock();
-		$content_block->content = ob_get_clean();
-		$content_block->content_type = 'text/xml';
-
-		$this->container->add($content_block);
-		$this->container->display();
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-		$this->layout->addHtmlHeadEntrySet(
-			$this->container->getHtmlHeadEntrySet()
-		);
-	}
-
-
+    public function finalize()
+    {
+        parent::finalize();
+        $this->layout->addHtmlHeadEntrySet(
+            $this->container->getHtmlHeadEntrySet()
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Exception.php
+++ b/Admin/components/AdminSite/Exception.php
@@ -8,25 +8,25 @@
  */
 class AdminAdminSiteException extends SiteXhtmlExceptionPage
 {
-	// {{{ protected properties
+
 
 	/**
 	 * @var SwatContainer
 	 */
 	protected $container;
 
-	// }}}
-	// {{{ protected function createLayout()
+
+
 
 	protected function createLayout()
 	{
 		return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ public function init()
+
 
 	public function init()
 	{
@@ -36,10 +36,10 @@ class AdminAdminSiteException extends SiteXhtmlExceptionPage
 		$this->container->classes[] = 'admin-exception-container';
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ public function build()
+
 
 	public function build()
 	{
@@ -51,8 +51,8 @@ class AdminAdminSiteException extends SiteXhtmlExceptionPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function display()
+
+
 
 	protected function display()
 	{
@@ -74,10 +74,10 @@ class AdminAdminSiteException extends SiteXhtmlExceptionPage
 		$this->container->display();
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize()
+
 
 	public function finalize()
 	{
@@ -87,7 +87,7 @@ class AdminAdminSiteException extends SiteXhtmlExceptionPage
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/ForgotPassword.php
+++ b/Admin/components/AdminSite/ForgotPassword.php
@@ -144,7 +144,7 @@ class AdminAdminSiteForgotPassword extends AdminPage
      */
     protected function getAccount($email)
     {
-        $class_name = SwatDBClassMap::get('AdminUser');
+        $class_name = SwatDBClassMap::get(AdminUser::class);
         $admin_user = new $class_name();
         $admin_user->setDatabase($this->app->db);
         $found = $admin_user->loadFromEmail($email);

--- a/Admin/components/AdminSite/ForgotPassword.php
+++ b/Admin/components/AdminSite/ForgotPassword.php
@@ -10,17 +10,17 @@
  */
 class AdminAdminSiteForgotPassword extends AdminPage
 {
-	// {{{ protected function createLayout()
+
 
 	protected function createLayout()
 	{
 		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -39,10 +39,10 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		$form->action = $this->app->getUri();
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -55,8 +55,8 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function generatePasswordLink()
+
+
 
 	protected function generatePasswordLink()
 	{
@@ -127,8 +127,8 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function getAccount()
+
+
 
 	/**
 	 * Gets the user to which to send the forgot password email
@@ -150,8 +150,8 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		return $admin_user;
 	}
 
-	// }}}
-	// {{{ protected function sendResetPasswordMailMessage()
+
+
 
 	protected function sendResetPasswordMailMessage(AdminUser $admin_user)
 	{
@@ -179,7 +179,7 @@ class AdminAdminSiteForgotPassword extends AdminPage
 		$mail_message->send();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/ForgotPassword.php
+++ b/Admin/components/AdminSite/ForgotPassword.php
@@ -1,185 +1,188 @@
 <?php
 
 /**
- * Administrator forgot password page
+ * Administrator forgot password page.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminUser
  */
 class AdminAdminSiteForgotPassword extends AdminPage
 {
+    protected function createLayout()
+    {
+        return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
+    }
 
+    // init phase
 
-	protected function createLayout()
-	{
-		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
-	}
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/forgot-password.xml');
 
+        $email = $this->ui->getWidget('email');
 
+        try {
+            if (isset($this->app->cookie->email)) {
+                $email->value = $this->app->cookie->email;
+            }
+        } catch (SiteCookieException $e) {
+            $this->app->cookie->removeCookie('email', '/');
+        }
 
-	// init phase
+        $form = $this->ui->getWidget('forgot_password_form');
+        $form->action = $this->app->getUri();
+    }
 
+    // process phase
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/forgot-password.xml');
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-		$email = $this->ui->getWidget('email');
-		try {
-			if (isset($this->app->cookie->email))
-				$email->value = $this->app->cookie->email;
+        $form = $this->ui->getWidget('forgot_password_form');
 
-		} catch (SiteCookieException $e) {
-			$this->app->cookie->removeCookie('email', '/');
-		}
+        if ($form->isProcessed() && !$form->hasMessage()) {
+            $this->generatePasswordLink();
+        }
+    }
 
-		$form = $this->ui->getWidget('forgot_password_form');
-		$form->action = $this->app->getUri();
-	}
+    protected function generatePasswordLink()
+    {
+        $email = $this->ui->getWidget('email')->value;
 
+        $admin_user = $this->getAccount($email);
 
+        if ($admin_user === null) {
+            $message = new SwatMessage(
+                Admin::_(
+                    'There is no account with the specified email address'
+                ),
+                'error'
+            );
 
-	// process phase
+            $message->secondary_content = Admin::_(
+                'Make sure you entered the email address correctly.'
+            );
 
+            $message->content_type = 'text/xml';
+            $this->ui->getWidget('email')->addMessage($message);
+        } else {
+            try {
+                $this->sendResetPasswordMailMessage($admin_user);
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+                $primary_text = Admin::_('Email has been sent');
+                $anchor_tag = new SwatHtmlTag('a');
+                $anchor_tag->href = 'mailto:' . $email;
+                $anchor_tag->setContent($email);
 
-		$form = $this->ui->getWidget('forgot_password_form');
+                /*
+                 * Don't show other site instances here as it could violate the
+                 * user's privacy. Another user is resetting the password and may
+                 * have no knowledge of other instances the user belongs to.
+                 */
+                $strong_tag = new SwatHtmlTag('strong');
+                $strong_tag->setContent(sprintf(
+                    Admin::_('Reset Your %s Admin Password'),
+                    $this->app->config->site->title
+                ));
 
-		if ($form->isProcessed() && !$form->hasMessage()) {
-			$this->generatePasswordLink();
-		}
-	}
+                $secondary_text = sprintf(
+                    Admin::_(
+                        '%sAn email has been sent to %s containing a link to ' .
+                        'create a new password for the %s admin.%s%sPlease check  ' .
+                        'your mail for a new message with the subject: %s.%s'
+                    ),
+                    '<p>',
+                    $anchor_tag,
+                    $this->app->config->site->title,
+                    '</p>',
+                    '<p>',
+                    $strong_tag,
+                    '</p>'
+                );
 
+                $message_type = 'notice';
+            } catch (SiteException $exception) {
+                $exception->process(false);
 
-
-
-	protected function generatePasswordLink()
-	{
-		$email = $this->ui->getWidget('email')->value;
-
-		$admin_user = $this->getAccount($email);
-
-		if ($admin_user === null) {
-			$message = new SwatMessage(Admin::_(
-				'There is no account with the specified email address'),
-				'error');
-
-			$message->secondary_content = Admin::_(
-				'Make sure you entered the email address correctly.');
-
-			$message->content_type = 'text/xml';
-			$this->ui->getWidget('email')->addMessage($message);
-		} else {
-			try {
-				$this->sendResetPasswordMailMessage($admin_user);
-
-				$primary_text = Admin::_('Email has been sent');
-				$anchor_tag = new SwatHtmlTag('a');
-				$anchor_tag->href = 'mailto:'.$email;
-				$anchor_tag->setContent($email);
-
-				/*
-				 * Don't show other site instances here as it could violate the
-				 * user's privacy. Another user is resetting the password and may
-				 * have no knowledge of other instances the user belongs to.
-				 */
-				$strong_tag = new SwatHtmlTag('strong');
-				$strong_tag->setContent(sprintf(
-					Admin::_('Reset Your %s Admin Password'),
-					$this->app->config->site->title));
-
-				$secondary_text = sprintf(Admin::_(
-					'%sAn email has been sent to %s containing a link to '.
-					'create a new password for the %s admin.%s%sPlease check  '.
-					'your mail for a new message with the subject: %s.%s'),
-					'<p>', $anchor_tag, $this->app->config->site->title,
-					'</p>', '<p>', $strong_tag, '</p>');
-
-				$message_type = 'notice';
-			} catch (SiteException $exception) {
-				$exception->process(false);
-
-				$primary_text = Admin::_('Unable to send email');
-				$secondary_text = sprintf(Admin::_('%1$s
+                $primary_text = Admin::_('Unable to send email');
+                $secondary_text = sprintf(
+                    Admin::_('%1$s
 					%3$sThis problem has been reported.%4$s
 					%3$sPlease contact the site administrator if this problem
 						continues.%4$s
 					%2$s'),
-					'<ul>', '</ul>', '<li>', '</li>');
+                    '<ul>',
+                    '</ul>',
+                    '<li>',
+                    '</li>'
+                );
 
-				$message_type = 'error';
-			}
+                $message_type = 'error';
+            }
 
-			$message = new SwatMessage($primary_text, $message_type);
-			$message->content_type = 'text/xml';
-			$message->secondary_content = $secondary_text;
+            $message = new SwatMessage($primary_text, $message_type);
+            $message->content_type = 'text/xml';
+            $message->secondary_content = $secondary_text;
 
-			$message_display = $this->ui->getWidget('message_display');
-			$message_display->add($message, SwatMessageDisplay::DISMISS_OFF);
+            $message_display = $this->ui->getWidget('message_display');
+            $message_display->add($message, SwatMessageDisplay::DISMISS_OFF);
 
-			$container = $this->ui->getWidget('field_container');
-			$container->visible = false;
-		}
-	}
+            $container = $this->ui->getWidget('field_container');
+            $container->visible = false;
+        }
+    }
 
+    /**
+     * Gets the user to which to send the forgot password email.
+     *
+     * @param string $email the email address of the admin user
+     *
+     * @return AdminUser the user or null if no such user exists
+     */
+    protected function getAccount($email)
+    {
+        $class_name = SwatDBClassMap::get('AdminUser');
+        $admin_user = new $class_name();
+        $admin_user->setDatabase($this->app->db);
+        $found = $admin_user->loadFromEmail($email);
 
+        if ($found === false) {
+            $admin_user = null;
+        }
 
+        return $admin_user;
+    }
 
-	/**
-	 * Gets the user to which to send the forgot password email
-	 *
-	 * @param string $email the email address of the admin user.
-	 *
-	 * @return AdminUser the user or null if no such user exists.
-	 */
-	protected function getAccount($email)
-	{
-		$class_name = SwatDBClassMap::get('AdminUser');
-		$admin_user = new $class_name();
-		$admin_user->setDatabase($this->app->db);
-		$found = $admin_user->loadFromEmail($email);
+    protected function sendResetPasswordMailMessage(AdminUser $admin_user)
+    {
+        $password_tag = $admin_user->resetPassword();
+        $password_link = $this->app->getBaseHref() .
+            'AdminSite/ResetPassword?password_tag=' . $password_tag;
 
-		if ($found === false)
-			$admin_user = null;
+        $mail_message = new AdminResetPasswordMailMessage(
+            $this->app,
+            $admin_user,
+            $password_link
+        );
 
-		return $admin_user;
-	}
+        $mail_message->smtp_server = $this->app->config->email->smtp_server;
+        $mail_message->smtp_port = $this->app->config->email->smtp_port;
+        $mail_message->smtp_username = $this->app->config->email->smtp_username;
+        $mail_message->smtp_password = $this->app->config->email->smtp_password;
 
+        $mail_message->from_address =
+            $this->app->config->email->service_address;
 
+        $mail_message->from_name = $this->app->config->site->title;
 
+        $mail_message->subject = sprintf(
+            Admin::_('Reset Your %s Admin Password'),
+            $this->app->config->site->title
+        );
 
-	protected function sendResetPasswordMailMessage(AdminUser $admin_user)
-	{
-		$password_tag = $admin_user->resetPassword();
-		$password_link = $this->app->getBaseHref().
-			'AdminSite/ResetPassword?password_tag='.$password_tag;
-
-		$mail_message = new AdminResetPasswordMailMessage($this->app,
-			$admin_user, $password_link);
-
-		$mail_message->smtp_server   = $this->app->config->email->smtp_server;
-		$mail_message->smtp_port     = $this->app->config->email->smtp_port;
-		$mail_message->smtp_username = $this->app->config->email->smtp_username;
-		$mail_message->smtp_password = $this->app->config->email->smtp_password;
-
-		$mail_message->from_address =
-			$this->app->config->email->service_address;
-
-		$mail_message->from_name = $this->app->config->site->title;
-
-		$mail_message->subject = sprintf(
-			Admin::_('Reset Your %s Admin Password'),
-			$this->app->config->site->title);
-
-		$mail_message->send();
-	}
-
-
+        $mail_message->send();
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Front.php
+++ b/Admin/components/AdminSite/Front.php
@@ -9,7 +9,7 @@
 class AdminAdminSiteFront extends AdminPage
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -17,10 +17,10 @@ class AdminAdminSiteFront extends AdminPage
 		$this->navbar->popEntry();
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -32,7 +32,7 @@ class AdminAdminSiteFront extends AdminPage
 		$this->buildMessages();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/Front.php
+++ b/Admin/components/AdminSite/Front.php
@@ -1,38 +1,29 @@
 <?php
 
 /**
- * Administrator Not Found page
+ * Administrator Not Found page.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  */
 class AdminAdminSiteFront extends AdminPage
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/front.xml');
+        $this->navbar->popEntry();
+    }
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/front.xml');
-		$this->navbar->popEntry();
-	}
+    // build phase
 
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		$note = $this->ui->getWidget('note');
-		$note->title = sprintf(
-			Admin::_('Welcome to the %s Admin!'),
-			$this->app->config->site->title
-		);
-		$this->buildMessages();
-	}
-
-
+    protected function buildInternal()
+    {
+        $note = $this->ui->getWidget('note');
+        $note->title = sprintf(
+            Admin::_('Welcome to the %s Admin!'),
+            $this->app->config->site->title
+        );
+        $this->buildMessages();
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Login.php
+++ b/Admin/components/AdminSite/Login.php
@@ -1,175 +1,153 @@
 <?php
 
 /**
- * Administrator login page
+ * Administrator login page.
  *
- * @package   Admin
  * @copyright 2005-2022 silverorange
  */
 class AdminAdminSiteLogin extends AdminPage
 {
+    /**
+     * Whether or not there was an error in the login information entered by
+     * the user.
+     *
+     * @var bool
+     */
+    protected $login_error = false;
 
+    protected function createLayout()
+    {
+        return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
+    }
 
-	/**
-	 * Whether or not there was an error in the login information entered by
-	 * the user
-	 *
-	 * @var boolean
-	 */
-	protected $login_error = false;
+    // init phase
 
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/login.xml');
+        $this->ui->getWidget('login_form')->addJavaScript(
+            'packages/admin/javascript/admin-login.js'
+        );
 
+        $frame = $this->ui->getWidget('login_frame');
+        $frame->title = $this->app->title;
 
+        $email = $this->ui->getWidget('email');
 
-	protected function createLayout()
-	{
-		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
-	}
+        try {
+            if (isset($this->app->cookie->email)) {
+                $email->value = $this->app->cookie->email;
+            }
+        } catch (SiteCookieException $e) {
+            $this->app->cookie->removeCookie('email', '/');
+        }
 
+        $form = $this->ui->getWidget('login_form');
+        $form->action = $this->app->getUri();
 
+        if (!$this->app->config->admin->allow_reset_password) {
+            $this->ui->getWidget('forgot_container')->visible = false;
+        }
+    }
 
-	// init phase
+    // process phase
 
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/login.xml');
-		$this->ui->getWidget('login_form')->addJavaScript(
-			'packages/admin/javascript/admin-login.js'
-		);
+        $form = $this->ui->getWidget('login_form');
 
-		$frame = $this->ui->getWidget('login_frame');
-		$frame->title = $this->app->title;
+        if ($form->isProcessed() && !$form->hasMessage()) {
+            $email = $this->ui->getWidget('email')->value;
+            $password = $this->ui->getWidget('password')->value;
+            $logged_in = $this->app->session->login($email, $password);
 
-		$email = $this->ui->getWidget('email');
-		try {
-			if (isset($this->app->cookie->email))
-				$email->value = $this->app->cookie->email;
+            if ($logged_in) {
+                $this->app->relocate($this->app->getUri());
+            } else {
+                if (isset($this->app->session->user)
+                    && $this->app->session->user->force_change_password) {
+                    $this->app->replacePage('AdminSite/ChangePassword');
+                } elseif (
+                    isset($this->app->session->user)
+                    && !$this->app->session->user->isActive()
+                ) {
+                    $message_display = $this->ui->getWidget('message_display');
+                    $message = new SwatMessage(
+                        Admin::_('Your account is inactive'),
+                        'error'
+                    );
 
-		} catch (SiteCookieException $e) {
-			$this->app->cookie->removeCookie('email', '/');
-		}
+                    $message->secondary_content = Admin::_(
+                        'Please contact another administrator to reactivate ' .
+                        'your account.'
+                    );
 
-		$form = $this->ui->getWidget('login_form');
-		$form->action = $this->app->getUri();
+                    $message_display->add($message);
+                    $this->login_error = true;
+                } elseif (isset($this->app->session->user)
+                    && $this->app->is2FaEnabled()
+                    && $this->app->session->user->two_fa_enabled
+                    && !$this->app->session->user->is2FaAuthenticated()) {
+                    $this->app->replacePage(
+                        'AdminSite/TwoFactorAuthentication'
+                    );
+                } else {
+                    $message_display = $this->ui->getWidget('message_display');
+                    $message = new SwatMessage(
+                        Admin::_('Login failed'),
+                        'error'
+                    );
 
-		if (!$this->app->config->admin->allow_reset_password) {
-			$this->ui->getWidget('forgot_container')->visible = false;
-		}
-	}
+                    $message->secondary_content =
+                        Admin::_('Check your password and try again.');
 
+                    $message_display->add($message);
+                    $this->login_error = true;
+                }
+            }
+        }
+    }
 
+    // build phase
 
-	// process phase
+    protected function display()
+    {
+        parent::display();
+        $this->displayJavaScript();
+    }
 
+    private function displayJavaScript()
+    {
+        try {
+            $email = (isset($this->app->cookie->email)) ?
+                $this->app->cookie->email : '';
+        } catch (SiteCookieException $e) {
+            $this->app->cookie->removeCookie('email', '/');
+            $email = '';
+        }
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+        $email = str_replace("'", "\\'", $email);
+        $email = str_ireplace('</script>', "</script' + '>", $email);
 
-		$form = $this->ui->getWidget('login_form');
+        $login_error = ($this->login_error) ? 'true' : 'false';
 
-		if ($form->isProcessed() && !$form->hasMessage()) {
-			$email = $this->ui->getWidget('email')->value;
-			$password = $this->ui->getWidget('password')->value;
-			$logged_in = $this->app->session->login($email, $password);
+        echo '<script type="text/javascript">';
+        echo "\nAdminLogin('email', 'password', 'login_button', " .
+            "'{$email}', {$login_error});";
 
-			if ($logged_in) {
-				$this->app->relocate($this->app->getUri());
-			} else {
-				if (isset($this->app->session->user) &&
-					$this->app->session->user->force_change_password) {
-					$this->app->replacePage('AdminSite/ChangePassword');
-				} elseif (
-					isset($this->app->session->user) &&
-					!$this->app->session->user->isActive()
-				) {
-					$message_display = $this->ui->getWidget('message_display');
-					$message = new SwatMessage(
-						Admin::_('Your account is inactive'),
-						'error'
-					);
+        echo '</script>';
+    }
 
-					$message->secondary_content = Admin::_(
-						'Please contact another administrator to reactivate '.
-						'your account.'
-					);
+    // finalize phase
 
-					$message_display->add($message);
-					$this->login_error = true;
-				} elseif (isset($this->app->session->user) &&
-					$this->app->is2FaEnabled() &&
-					$this->app->session->user->two_fa_enabled &&
-					!$this->app->session->user->is2FaAuthenticated()) {
-					$this->app->replacePage(
-						'AdminSite/TwoFactorAuthentication'
-					);
-				} else {
-					$message_display = $this->ui->getWidget('message_display');
-					$message = new SwatMessage(Admin::_('Login failed'),
-						'error');
+    public function finalize()
+    {
+        parent::finalize();
 
-					$message->secondary_content =
-						Admin::_('Check your password and try again.');
-
-					$message_display->add($message);
-					$this->login_error = true;
-				}
-			}
-		}
-	}
-
-
-
-	// build phase
-
-
-	protected function display()
-	{
-		parent::display();
-		$this->displayJavaScript();
-	}
-
-
-
-
-	private function displayJavaScript()
-	{
-		try {
-			$email = (isset($this->app->cookie->email)) ?
-				$this->app->cookie->email : '';
-		} catch (SiteCookieException $e) {
-			$this->app->cookie->removeCookie('email', '/');
-			$email = '';
-		}
-
-		$email = str_replace("'", "\\'", $email);
-		$email = str_ireplace('</script>', "</script' + '>", $email);
-
-		$login_error = ($this->login_error) ? 'true' : 'false';
-
-		echo '<script type="text/javascript">';
-		echo "\nAdminLogin('email', 'password', 'login_button', ".
-			"'{$email}', {$login_error});";
-
-		echo '</script>';
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-login-page.css'
-		);
-	}
-
-
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-login-page.css'
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Login.php
+++ b/Admin/components/AdminSite/Login.php
@@ -8,7 +8,7 @@
  */
 class AdminAdminSiteLogin extends AdminPage
 {
-	// {{{ protected properties
+
 
 	/**
 	 * Whether or not there was an error in the login information entered by
@@ -18,18 +18,18 @@ class AdminAdminSiteLogin extends AdminPage
 	 */
 	protected $login_error = false;
 
-	// }}}
-	// {{{ protected function createLayout()
+
+
 
 	protected function createLayout()
 	{
 		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -58,10 +58,10 @@ class AdminAdminSiteLogin extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -119,10 +119,10 @@ class AdminAdminSiteLogin extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function display()
+
 
 	protected function display()
 	{
@@ -130,8 +130,8 @@ class AdminAdminSiteLogin extends AdminPage
 		$this->displayJavaScript();
 	}
 
-	// }}}
-	// {{{ private function displayJavaScript()
+
+
 
 	private function displayJavaScript()
 	{
@@ -155,10 +155,10 @@ class AdminAdminSiteLogin extends AdminPage
 		echo '</script>';
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize
+
 
 	public function finalize()
 	{
@@ -169,7 +169,7 @@ class AdminAdminSiteLogin extends AdminPage
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/Logout.php
+++ b/Admin/components/AdminSite/Logout.php
@@ -1,45 +1,41 @@
 <?php
 
 /**
- * Very simple administrator logout page
+ * Very simple administrator logout page.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  */
 class AdminAdminSiteLogout extends AdminPage
 {
-	// process phase
+    // process phase
 
+    protected function processInternal()
+    {
+        $form = $this->layout->logout_form;
+        $form->process();
 
-	protected function processInternal()
-	{
-		$form = $this->layout->logout_form;
-		$form->process();
+        if ($form->isProcessed() && $form->isAuthenticated()) {
+            // log out
+            $this->app->session->logout();
+            $this->app->relocate($this->app->getBaseHref());
+        } else {
+            // add error message
+            $message = new SwatMessage(
+                Admin::_('Unable to log out.'),
+                'warning'
+            );
 
-		if ($form->isProcessed() && $form->isAuthenticated()) {
-			// log out
-			$this->app->session->logout();
-			$this->app->relocate($this->app->getBaseHref());
-		} else {
-			// add error message
-			$message = new SwatMessage(Admin::_('Unable to log out.'),
-				'warning');
+            $message->secondary_content =
+                Admin::_('In order to ensure your security, we were ' .
+                'unable to process your logout request. Please try again.');
 
-			$message->secondary_content =
-				Admin::_('In order to ensure your security, we were '.
-				'unable to process your logout request. Please try again.');
+            $this->app->messages->add($message);
 
-			$this->app->messages->add($message);
+            // go back where we came from
+            $url = (isset($_SERVER['HTTP_REFERER'])) ?
+                $_SERVER['HTTP_REFERER'] : 'Front';
 
-			// go back where we came from
-			$url = (isset($_SERVER['HTTP_REFERER'])) ?
-				$_SERVER['HTTP_REFERER'] : 'Front';
-
-			$this->app->relocate($url);
-		}
-	}
-
-
+            $this->app->relocate($url);
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Logout.php
+++ b/Admin/components/AdminSite/Logout.php
@@ -9,7 +9,7 @@
 class AdminAdminSiteLogout extends AdminPage
 {
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -39,7 +39,7 @@ class AdminAdminSiteLogout extends AdminPage
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/Profile.php
+++ b/Admin/components/AdminSite/Profile.php
@@ -1,290 +1,234 @@
 <?php
 
 /**
- * Edit page for the current admin user profile
+ * Edit page for the current admin user profile.
  *
- * @package   Admin
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  * @copyright 2005-2022 silverorange
  */
 class AdminAdminSiteProfile extends AdminObjectEdit
 {
-
-
-	protected function getObjectClass()
-	{
-		return 'AdminUser';
-	}
-
-
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/profile.xml';
-	}
-
-
-
-
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'email',
-			'name',
-		);
-	}
-
-
-
-	// init phase
-
-
-	protected function initObject()
-	{
-		// Set the id so the edit page knows it's an edit.
-		$this->id = $this->app->session->getUserId();
-
-		// Bypass all AdminObjectEdit loading.
-		$this->data_object = $this->app->session->user;
-	}
-
-
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->initPasswordWidgets();
-	}
-
-
-
-
-	protected function initPasswordWidgets()
-	{
-		$confirm = $this->ui->getWidget('confirm_password');
-		$confirm->password_widget = $this->ui->getWidget('new_password');
-	}
-
-
-
-	// process phase
-
-
-	protected function validate(): void
-	{
-		parent::validate();
-
-		$new_password = $this->ui->getWidget('new_password')->value;
-		$old_password = $this->ui->getWidget('old_password')->value;
-
-		if ($new_password != '') {
-			$crypt = $this->app->getModule('SiteCryptModule');
-
-			$password_hash = $this->data_object->password;
-			$password_salt = $this->data_object->password_salt;
-
-			if (!$crypt->verifyHash(
-					$old_password,
-					$password_hash,
-					$password_salt
-				)) {
-
-				$this->ui->getWidget('old_password')->addMessage(
-					new SwatMessage(
-						Admin::_(
-							'%1$s is incorrrect. Please check your %1$s and '.
-							'try again. Passwords are case sensitive.'
-						),
-						'error'
-					)
-				);
-			}
-		}
-
-		if ($this->ui->getWidget('two_fa_token')->value !== null) {
-			$this->validate2Fa();
-		}
-	}
-
-
-
-
-	protected function validate2Fa()
-	{
-		$two_factor_authentication = new AdminTwoFactorAuthentication();
-		$success = $two_factor_authentication->validateToken(
-			$this->data_object->two_fa_secret,
-			$this->ui->getWidget('two_fa_token')->value,
-			$this->data_object->two_fa_timeslice
-		);
-
-		if ($success) {
-			// save the new timestamp
-			$this->data_object->save();
-		} else {
-			$this->ui->getWidget('two_fa_token')->addMessage(
-				new SwatMessage(
-					Admin::_(
-						'Your two factor authentication token doesn’t '.
-						'match. Try again, or contact support for help.'
-					),
-					'error'
-				)
-			);
-		}
-	}
-
-
-
-
-	protected function updateObject()
-	{
-		parent::updateObject();
-
-		$this->updatePassword();
-
-		if ($this->ui->getWidget('two_fa_token')->value !== null) {
-			$this->data_object->two_fa_enabled = true;
-			$this->data_object->set2FaAuthenticated();
-		}
-	}
-
-
-
-
-	protected function updatePassword()
-	{
-		$new_password = $this->ui->getWidget('new_password')->value;
-
-		if ($new_password != '') {
-			$crypt = $this->app->getModule('SiteCryptModule');
-			$this->getObject()->setPasswordHash(
-				$crypt->generateHash($new_password)
-			);
-		}
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return Admin::_('Your user profile has been updated.');
-	}
-
-
-
-
-	protected function relocate()
-	{
-		$this->app->relocate('.');
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$old_password     = $this->ui->getWidget('old_password');
-		$new_password     = $this->ui->getWidget('new_password');
-		$confirm_password = $this->ui->getWidget('confirm_password');
-
-		if ($old_password->hasMessage() ||
-			$new_password->hasMessage() ||
-			$confirm_password->hasMessage()) {
-			$this->ui->getWidget('change_password')->open = true;
-		}
-
-		$this->build2fa();
-	}
-
-
-
-
-	protected function build2Fa()
-	{
-		if ($this->app->is2FaEnabled()) {
-			if ($this->data_object->two_fa_enabled) {
-				$this->ui->getWidget('two_fa_enabled_note')->visible = true;
-			} else {
-				$two_factor_authentication = new AdminTwoFactorAuthentication();
-
-				$form = $this->ui->getWidget('edit_form');
-				if (!$form->isSubmitted()) {
-					// Generate a new secret key each time the page loads so
-					// that someone doesn't steal the secret code, then later
-					// this user turns on 2FA, and  then the intruder would
-					// have the secret key from before.
-					$secret = $two_factor_authentication->getNewSecret();
-					$this->data_object->two_fa_secret = $secret;
-					$this->data_object->save();
-				}
-
-				$qr_code_url = $two_factor_authentication->getQrCodeDataUri(
-					sprintf(
-						'%s (%s)',
-						$this->app->config->site->title,
-						$this->data_object->email
-					),
-					$this->data_object->two_fa_secret
-				);
-
-				$img_tag = new SwatHtmlTag('img');
-				$img_tag->alt = Admin::_('Two Factor Authentication QR Code');
-				$img_tag->src = $qr_code_url;
-
-				$p_tag = new SwatHtmlTag('p');
-				$p_tag->class = 'admin-two-factor-secret';
-				$p_tag->setContent($this->data_object->two_fa_secret);
-
-				ob_start();
-				$img_tag->display();
-				$p_tag->display();
-				$this->ui->getWidget('two_fa_image')->content = ob_get_clean();
-				$this->ui->getWidget('two_fa')->visible = true;
-			}
-		}
-	}
-
-
-
-
-	protected function buildFrame()
-	{
-		// skip the parent buildFrame()
-	}
-
-
-
-
-	protected function buildNavBar()
-	{
-		$this->navbar->popEntry();
-		$this->navbar->createEntry(Admin::_('Login Settings'));
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-profile.css'
-		);
-	}
-
-
+    protected function getObjectClass()
+    {
+        return 'AdminUser';
+    }
+
+    protected function getUiXml()
+    {
+        return __DIR__ . '/profile.xml';
+    }
+
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'email',
+            'name',
+        ];
+    }
+
+    // init phase
+
+    protected function initObject()
+    {
+        // Set the id so the edit page knows it's an edit.
+        $this->id = $this->app->session->getUserId();
+
+        // Bypass all AdminObjectEdit loading.
+        $this->data_object = $this->app->session->user;
+    }
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->initPasswordWidgets();
+    }
+
+    protected function initPasswordWidgets()
+    {
+        $confirm = $this->ui->getWidget('confirm_password');
+        $confirm->password_widget = $this->ui->getWidget('new_password');
+    }
+
+    // process phase
+
+    protected function validate(): void
+    {
+        parent::validate();
+
+        $new_password = $this->ui->getWidget('new_password')->value;
+        $old_password = $this->ui->getWidget('old_password')->value;
+
+        if ($new_password != '') {
+            $crypt = $this->app->getModule('SiteCryptModule');
+
+            $password_hash = $this->data_object->password;
+            $password_salt = $this->data_object->password_salt;
+
+            if (!$crypt->verifyHash(
+                $old_password,
+                $password_hash,
+                $password_salt
+            )) {
+                $this->ui->getWidget('old_password')->addMessage(
+                    new SwatMessage(
+                        Admin::_(
+                            '%1$s is incorrrect. Please check your %1$s and ' .
+                            'try again. Passwords are case sensitive.'
+                        ),
+                        'error'
+                    )
+                );
+            }
+        }
+
+        if ($this->ui->getWidget('two_fa_token')->value !== null) {
+            $this->validate2Fa();
+        }
+    }
+
+    protected function validate2Fa()
+    {
+        $two_factor_authentication = new AdminTwoFactorAuthentication();
+        $success = $two_factor_authentication->validateToken(
+            $this->data_object->two_fa_secret,
+            $this->ui->getWidget('two_fa_token')->value,
+            $this->data_object->two_fa_timeslice
+        );
+
+        if ($success) {
+            // save the new timestamp
+            $this->data_object->save();
+        } else {
+            $this->ui->getWidget('two_fa_token')->addMessage(
+                new SwatMessage(
+                    Admin::_(
+                        'Your two factor authentication token doesn’t ' .
+                        'match. Try again, or contact support for help.'
+                    ),
+                    'error'
+                )
+            );
+        }
+    }
+
+    protected function updateObject()
+    {
+        parent::updateObject();
+
+        $this->updatePassword();
+
+        if ($this->ui->getWidget('two_fa_token')->value !== null) {
+            $this->data_object->two_fa_enabled = true;
+            $this->data_object->set2FaAuthenticated();
+        }
+    }
+
+    protected function updatePassword()
+    {
+        $new_password = $this->ui->getWidget('new_password')->value;
+
+        if ($new_password != '') {
+            $crypt = $this->app->getModule('SiteCryptModule');
+            $this->getObject()->setPasswordHash(
+                $crypt->generateHash($new_password)
+            );
+        }
+    }
+
+    protected function getSavedMessagePrimaryContent()
+    {
+        return Admin::_('Your user profile has been updated.');
+    }
+
+    protected function relocate()
+    {
+        $this->app->relocate('.');
+    }
+
+    // build phase
+
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+
+        $old_password = $this->ui->getWidget('old_password');
+        $new_password = $this->ui->getWidget('new_password');
+        $confirm_password = $this->ui->getWidget('confirm_password');
+
+        if ($old_password->hasMessage()
+            || $new_password->hasMessage()
+            || $confirm_password->hasMessage()) {
+            $this->ui->getWidget('change_password')->open = true;
+        }
+
+        $this->build2fa();
+    }
+
+    protected function build2Fa()
+    {
+        if ($this->app->is2FaEnabled()) {
+            if ($this->data_object->two_fa_enabled) {
+                $this->ui->getWidget('two_fa_enabled_note')->visible = true;
+            } else {
+                $two_factor_authentication = new AdminTwoFactorAuthentication();
+
+                $form = $this->ui->getWidget('edit_form');
+                if (!$form->isSubmitted()) {
+                    // Generate a new secret key each time the page loads so
+                    // that someone doesn't steal the secret code, then later
+                    // this user turns on 2FA, and  then the intruder would
+                    // have the secret key from before.
+                    $secret = $two_factor_authentication->getNewSecret();
+                    $this->data_object->two_fa_secret = $secret;
+                    $this->data_object->save();
+                }
+
+                $qr_code_url = $two_factor_authentication->getQrCodeDataUri(
+                    sprintf(
+                        '%s (%s)',
+                        $this->app->config->site->title,
+                        $this->data_object->email
+                    ),
+                    $this->data_object->two_fa_secret
+                );
+
+                $img_tag = new SwatHtmlTag('img');
+                $img_tag->alt = Admin::_('Two Factor Authentication QR Code');
+                $img_tag->src = $qr_code_url;
+
+                $p_tag = new SwatHtmlTag('p');
+                $p_tag->class = 'admin-two-factor-secret';
+                $p_tag->setContent($this->data_object->two_fa_secret);
+
+                ob_start();
+                $img_tag->display();
+                $p_tag->display();
+                $this->ui->getWidget('two_fa_image')->content = ob_get_clean();
+                $this->ui->getWidget('two_fa')->visible = true;
+            }
+        }
+    }
+
+    protected function buildFrame()
+    {
+        // skip the parent buildFrame()
+    }
+
+    protected function buildNavBar()
+    {
+        $this->navbar->popEntry();
+        $this->navbar->createEntry(Admin::_('Login Settings'));
+    }
+
+    // finalize phase
+
+    public function finalize()
+    {
+        parent::finalize();
+
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-profile.css'
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/Profile.php
+++ b/Admin/components/AdminSite/Profile.php
@@ -9,23 +9,23 @@
  */
 class AdminAdminSiteProfile extends AdminObjectEdit
 {
-	// {{{ protected function getObjectClass()
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminUser';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/profile.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -35,10 +35,10 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initObject()
+
 
 	protected function initObject()
 	{
@@ -49,8 +49,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		$this->data_object = $this->app->session->user;
 	}
 
-	// }}}
-	// {{{ protected function initInternal()
+
+
 
 	protected function initInternal()
 	{
@@ -59,8 +59,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		$this->initPasswordWidgets();
 	}
 
-	// }}}
-	// {{{ protected function initPasswordWidgets()
+
+
 
 	protected function initPasswordWidgets()
 	{
@@ -68,10 +68,10 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		$confirm->password_widget = $this->ui->getWidget('new_password');
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function validate()
+
 
 	protected function validate(): void
 	{
@@ -109,8 +109,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function validate2Fa()
+
+
 
 	protected function validate2Fa()
 	{
@@ -137,8 +137,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function updateObject()
+
+
 
 	protected function updateObject()
 	{
@@ -152,8 +152,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function updatePassword()
+
+
 
 	protected function updatePassword()
 	{
@@ -167,26 +167,26 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
 		return Admin::_('Your user profile has been updated.');
 	}
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	protected function relocate()
 	{
 		$this->app->relocate('.');
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -205,8 +205,8 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		$this->build2fa();
 	}
 
-	// }}}
-	// {{{ protected function build2Fa()
+
+
 
 	protected function build2Fa()
 	{
@@ -253,16 +253,16 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildFrame()
+
+
 
 	protected function buildFrame()
 	{
 		// skip the parent buildFrame()
 	}
 
-	// }}}
-	// {{{ protected function buildNavBar()
+
+
 
 	protected function buildNavBar()
 	{
@@ -270,10 +270,10 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		$this->navbar->createEntry(Admin::_('Login Settings'));
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize
+
 
 	public function finalize()
 	{
@@ -284,7 +284,7 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/Profile.php
+++ b/Admin/components/AdminSite/Profile.php
@@ -10,7 +10,7 @@ class AdminAdminSiteProfile extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'AdminUser';
+        return AdminUser::class;
     }
 
     protected function getUiXml()

--- a/Admin/components/AdminSite/ResetPassword.php
+++ b/Admin/components/AdminSite/ResetPassword.php
@@ -1,191 +1,182 @@
 <?php
 
 /**
- * Page to reset the password for an admin user
+ * Page to reset the password for an admin user.
  *
  * Users are required to enter a new password.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminUser
  */
 class AdminAdminSiteResetPassword extends AdminPage
 {
+    /**
+     * @var string
+     */
+    private $password_tag;
 
+    /**
+     * @var AdminUser
+     */
+    private $user;
 
-	/**
-	 * @var string
-	 */
-	private $password_tag;
+    protected function createLayout()
+    {
+        return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
+    }
 
-	/**
-	 * @var AdminUser
-	 */
-	private $user;
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->ui->loadFromXML(__DIR__ . '/reset-password.xml');
 
+        $this->password_tag = AdminApplication::initVar('password_tag');
 
-	protected function createLayout()
-	{
-		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
-	}
+        $this->initUser();
 
+        $form = $this->ui->getWidget('edit_form');
+        $form->addHiddenField('password_tag', $this->password_tag);
+        $form->action = $this->source;
 
+        $frame = $this->ui->getWidget('reset_password_frame');
 
-	// init phase
+        if ($this->user === null) {
+            $frame->title = Admin::_('Update Password');
+        } else {
+            $frame->title = sprintf(
+                Admin::_('Update Password for %s'),
+                $this->user->name
+            );
+        }
 
+        $confirm = $this->ui->getWidget('confirm_password');
+        $confirm->password_widget = $this->ui->getWidget('password');
+    }
 
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->ui->loadFromXML(__DIR__.'/reset-password.xml');
-
-		$this->password_tag = AdminApplication::initVar('password_tag');
-
-		$this->initUser();
-
-		$form = $this->ui->getWidget('edit_form');
-		$form->addHiddenField('password_tag', $this->password_tag);
-		$form->action = $this->source;
-
-		$frame = $this->ui->getWidget('reset_password_frame');
-
-		if ($this->user === null) {
-			$frame->title = Admin::_('Update Password');
-		} else {
-			$frame->title = sprintf(Admin::_('Update Password for %s'),
-				$this->user->name);
-		}
-
-		$confirm = $this->ui->getWidget('confirm_password');
-		$confirm->password_widget = $this->ui->getWidget('password');
-	}
-
-
-
-
-	/**
-	 * Initializes the admin user object associated with the password tag
-	 */
-	protected function initUser()
-	{
-		if ($this->password_tag !== null) {
-
-			$sql = sprintf('select id from AdminUser
+    /**
+     * Initializes the admin user object associated with the password tag.
+     */
+    protected function initUser()
+    {
+        if ($this->password_tag !== null) {
+            $sql = sprintf(
+                'select id from AdminUser
 				where password_tag = %s and
 					age(password_tag_date) < \'1 hour ago\'',
-				$this->app->db->quote($this->password_tag, 'text'));
+                $this->app->db->quote($this->password_tag, 'text')
+            );
 
-			$user_id = SwatDB::queryOne($this->app->db, $sql);
-			if ($user_id !== null) {
-				$class_name = SwatDBClassMap::get('AdminUser');
-				$user = new $class_name();
-				$user->setDatabase($this->app->db);
-				if ($user->load($user_id)) {
-					$this->user = $user;
-				}
-			}
-		}
-	}
+            $user_id = SwatDB::queryOne($this->app->db, $sql);
+            if ($user_id !== null) {
+                $class_name = SwatDBClassMap::get('AdminUser');
+                $user = new $class_name();
+                $user->setDatabase($this->app->db);
+                if ($user->load($user_id)) {
+                    $this->user = $user;
+                }
+            }
+        }
+    }
 
+    // process phase
 
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-	// process phase
+        if ($this->user === null) {
+            return;
+        }
 
+        $crypt = $this->app->getModule('SiteCryptModule');
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+        $form = $this->ui->getWidget('edit_form');
 
-		if ($this->user === null)
-			return;
+        if ($form->isProcessed()) {
+            if (!$form->hasMessage()) {
+                $password = $this->ui->getWidget('password')->value;
 
-		$crypt = $this->app->getModule('SiteCryptModule');
+                $this->user->setPasswordHash($crypt->generateHash($password));
+                $this->user->password_tag = null;
+                $this->user->password_tag_date = null;
+                $this->user->save();
 
-		$form = $this->ui->getWidget('edit_form');
+                $this->app->session->login($this->user->email, $password);
 
-		if ($form->isProcessed()) {
-			if (!$form->hasMessage()) {
-				$password = $this->ui->getWidget('password')->value;
+                $message = new SwatMessage(
+                    Admin::_('Your password has been updated.')
+                );
 
-				$this->user->setPasswordHash($crypt->generateHash($password));
-				$this->user->password_tag      = null;
-				$this->user->password_tag_date = null;
-				$this->user->save();
+                $this->app->messages->add($message);
+                $this->sendResetPasswordSuccessMailMessage();
+                $this->app->relocate($this->app->getBaseHref());
+            }
+        }
+    }
 
-				$this->app->session->login($this->user->email, $password);
+    protected function sendResetPasswordSuccessMailMessage()
+    {
+        $mail_message = new AdminResetPasswordSuccessMailMessage(
+            $this->app,
+            $this->user
+        );
 
-				$message = new SwatMessage(
-					Admin::_('Your password has been updated.'));
+        $mail_message->smtp_server = $this->app->config->email->smtp_server;
+        $mail_message->smtp_port = $this->app->config->email->smtp_port;
+        $mail_message->smtp_username = $this->app->config->email->smtp_username;
+        $mail_message->smtp_password = $this->app->config->email->smtp_password;
 
-				$this->app->messages->add($message);
-				$this->sendResetPasswordSuccessMailMessage();
-				$this->app->relocate($this->app->getBaseHref());
-			}
-		}
-	}
+        $mail_message->from_address =
+            $this->app->config->email->service_address;
 
+        $mail_message->from_name = $this->app->config->site->title;
 
+        $mail_message->subject = sprintf(
+            Admin::_('Your %s Admin Password was Successfully Updated'),
+            $this->app->config->site->title
+        );
 
+        $mail_message->send();
+    }
 
-	protected function sendResetPasswordSuccessMailMessage()
-	{
-		$mail_message = new AdminResetPasswordSuccessMailMessage($this->app,
-			$this->user);
+    // build phase
 
-		$mail_message->smtp_server   = $this->app->config->email->smtp_server;
-		$mail_message->smtp_port     = $this->app->config->email->smtp_port;
-		$mail_message->smtp_username = $this->app->config->email->smtp_username;
-		$mail_message->smtp_password = $this->app->config->email->smtp_password;
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-		$mail_message->from_address =
-			$this->app->config->email->service_address;
+        if ($this->user === null) {
+            $text = sprintf(
+                '<p>%s</p><ul><li>%s</li><li>%s</li><li>%s</li></ul>',
+                Admin::_('Please verify that the link is exactly the same as ' .
+                    'the one emailed to you.'),
+                Admin::_('If you requested an email more than once, only the ' .
+                    'most recent link will work.'),
+                sprintf(
+                    Admin::_('The emailed link expires after one hour. ' .
+                    'If the link has expired, %shave the email sent again%s.'),
+                    '<a href="AdminSite/ForgotPassword">',
+                    '</a>'
+                ),
+                sprintf(
+                    Admin::_('If you have lost the link sent in the ' .
+                    'email, you may %shave the email sent again%s.'),
+                    '<a href="AdminSite/ForgotPassword">',
+                    '</a>'
+                )
+            );
 
-		$mail_message->from_name = $this->app->config->site->title;
+            $message = new SwatMessage(Admin::_('Link Incorrect'), 'warning');
+            $message->secondary_content = $text;
+            $message->content_type = 'text/xml';
+            $this->ui->getWidget('message_display')->add($message);
 
-		$mail_message->subject = sprintf(
-			Admin::_('Your %s Admin Password was Successfully Updated'),
-			$this->app->config->site->title);
-
-		$mail_message->send();
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		if ($this->user === null) {
-			$text = sprintf(
-				'<p>%s</p><ul><li>%s</li><li>%s</li><li>%s</li></ul>',
-				Admin::_('Please verify that the link is exactly the same as '.
-					'the one emailed to you.'),
-				Admin::_('If you requested an email more than once, only the '.
-					'most recent link will work.'),
-				sprintf(Admin::_('The emailed link expires after one hour. '.
-					'If the link has expired, %shave the email sent again%s.'),
-					'<a href="AdminSite/ForgotPassword">', '</a>'),
-				sprintf(Admin::_('If you have lost the link sent in the '.
-					'email, you may %shave the email sent again%s.'),
-					'<a href="AdminSite/ForgotPassword">', '</a>'));
-
-			$message = new SwatMessage(Admin::_('Link Incorrect'), 'warning');
-			$message->secondary_content = $text;
-			$message->content_type = 'text/xml';
-			$this->ui->getWidget('message_display')->add($message);
-
-			$this->ui->getWidget('field_container')->visible = false;
-		}
-	}
-
-
+            $this->ui->getWidget('field_container')->visible = false;
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminSite/ResetPassword.php
+++ b/Admin/components/AdminSite/ResetPassword.php
@@ -73,7 +73,7 @@ class AdminAdminSiteResetPassword extends AdminPage
 
             $user_id = SwatDB::queryOne($this->app->db, $sql);
             if ($user_id !== null) {
-                $class_name = SwatDBClassMap::get('AdminUser');
+                $class_name = SwatDBClassMap::get(AdminUser::class);
                 $user = new $class_name();
                 $user->setDatabase($this->app->db);
                 if ($user->load($user_id)) {

--- a/Admin/components/AdminSite/ResetPassword.php
+++ b/Admin/components/AdminSite/ResetPassword.php
@@ -12,7 +12,7 @@
  */
 class AdminAdminSiteResetPassword extends AdminPage
 {
-	// {{{ private properties
+
 
 	/**
 	 * @var string
@@ -24,18 +24,18 @@ class AdminAdminSiteResetPassword extends AdminPage
 	 */
 	private $user;
 
-	// }}}
-	// {{{ protected function createLayout()
+
+
 
 	protected function createLayout()
 	{
 		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -64,8 +64,8 @@ class AdminAdminSiteResetPassword extends AdminPage
 		$confirm->password_widget = $this->ui->getWidget('password');
 	}
 
-	// }}}
-	// {{{ protected function initUser()
+
+
 
 	/**
 	 * Initializes the admin user object associated with the password tag
@@ -91,10 +91,10 @@ class AdminAdminSiteResetPassword extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -128,8 +128,8 @@ class AdminAdminSiteResetPassword extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function sendResetPasswordSuccessMailMessage()
+
+
 
 	protected function sendResetPasswordSuccessMailMessage()
 	{
@@ -153,10 +153,10 @@ class AdminAdminSiteResetPassword extends AdminPage
 		$mail_message->send();
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -185,7 +185,7 @@ class AdminAdminSiteResetPassword extends AdminPage
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/TwoFactorAuthentication.php
+++ b/Admin/components/AdminSite/TwoFactorAuthentication.php
@@ -9,15 +9,15 @@
 class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 {
 	// init phase
-	// {{{ protected function createLayout()
+
 
 	protected function createLayout()
 	{
 		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
 	}
 
-	// }}}
-	// {{{ protected function initInternal()
+
+
 
 	protected function initInternal()
 	{
@@ -37,10 +37,10 @@ class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -62,8 +62,8 @@ class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function validate2Fa()
+
+
 
 	protected function validate2Fa()
 	{
@@ -84,10 +84,10 @@ class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize
+
 
 	public function finalize()
 	{
@@ -98,7 +98,7 @@ class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSite/TwoFactorAuthentication.php
+++ b/Admin/components/AdminSite/TwoFactorAuthentication.php
@@ -1,104 +1,86 @@
 <?php
 
 /**
- * Authenticate 2FA Token
+ * Authenticate 2FA Token.
  *
- * @package   Admin
  * @copyright 2022 silverorange
  */
 class AdminAdminSiteTwoFactorAuthentication extends AdminPage
 {
-	// init phase
+    // init phase
 
+    protected function createLayout()
+    {
+        return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
+    }
 
-	protected function createLayout()
-	{
-		return new AdminLoginLayout($this->app, AdminLoginTemplate::class);
-	}
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->ui->loadFromXML(__DIR__ . '/two_factor_authentication.xml');
 
+        $form = $this->ui->getWidget('two_fa_form');
+        $form->action = 'AdminSite/TwoFactorAuthentication';
 
+        // remember where we came from
+        $form->addHiddenField('relocate_uri', $this->app->getUri());
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+        $user = $this->app->session->user;
+        if ($user->is2FaAuthenticated() || !$user->two_fa_enabled) {
+            $this->app->relocate('./');
+        }
+    }
 
-		$this->ui->loadFromXML(__DIR__.'/two_factor_authentication.xml');
+    // process phase
 
-		$form = $this->ui->getWidget('two_fa_form');
-		$form->action = 'AdminSite/TwoFactorAuthentication';
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-		// remember where we came from
-		$form->addHiddenField('relocate_uri', $this->app->getUri());
+        $form = $this->ui->getWidget('two_fa_form');
+        if ($form->isProcessed()) {
+            if (!$form->hasMessage()) {
+                $this->validate2Fa();
+            }
 
-		$user = $this->app->session->user;
-		if ($user->is2FaAuthenticated() || !$user->two_fa_enabled) {
-			$this->app->relocate('./');
-		}
-	}
+            if (!$form->hasMessage()) {
+                $this->app->session->user->set2FaAuthenticated();
 
+                // go back where we came from
+                $uri = $form->getHiddenField('relocate_uri');
+                $this->app->relocate($uri);
+            }
+        }
+    }
 
+    protected function validate2Fa()
+    {
+        $success = $this->app->session->loginWithTwoFactorAuthentication(
+            $this->ui->getWidget('two_fa_token')->value
+        );
 
-	// process phase
+        if (!$success) {
+            $this->ui->getWidget('two_fa_token')->addMessage(
+                new SwatMessage(
+                    Admin::_(
+                        'Your two factor authentication token doesn’t ' .
+                        'match. Try again, or contact support for help.'
+                    ),
+                    'error'
+                )
+            );
+        }
+    }
 
+    // finalize phase
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+    public function finalize()
+    {
+        parent::finalize();
 
-		$form = $this->ui->getWidget('two_fa_form');
-		if ($form->isProcessed()) {
-			if (!$form->hasMessage()) {
-				$this->validate2Fa();
-			}
-
-			if (!$form->hasMessage()) {
-				$this->app->session->user->set2FaAuthenticated();
-
-				// go back where we came from
-				$uri = $form->getHiddenField('relocate_uri');
-				$this->app->relocate($uri);
-			}
-		}
-	}
-
-
-
-
-	protected function validate2Fa()
-	{
-		$success = $this->app->session->loginWithTwoFactorAuthentication(
-			$this->ui->getWidget('two_fa_token')->value
-		);
-
-		if (!$success) {
-			$this->ui->getWidget('two_fa_token')->addMessage(
-				new SwatMessage(
-					Admin::_(
-						'Your two factor authentication token doesn’t '.
-						'match. Try again, or contact support for help.'
-					),
-					'error'
-				)
-			);
-		}
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-two-factor-authentication-page.css'
-		);
-	}
-
-
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-two-factor-authentication-page.css'
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSubComponent/Delete.php
+++ b/Admin/components/AdminSubComponent/Delete.php
@@ -1,90 +1,95 @@
 <?php
 
 /**
- * Delete confirmation page for AdminSubComponents
- * @package   Admin
+ * Delete confirmation page for AdminSubComponents.
+ *
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSubComponentDelete extends AdminDBDelete
 {
+    private $parent;
 
+    public function setParent($parent)
+    {
+        $this->parent = $parent;
+    }
 
-	private $parent;
+    // process phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
+        $item_list = $this->getItemList('integer');
 
+        $sql = 'delete from AdminSubComponent where id in (%s)';
 
-	public function setParent($parent)
-	{
-		$this->parent = $parent;
-	}
+        $sql = sprintf($sql, $item_list);
+        $num = SwatDB::exec($this->app->db, $sql);
 
+        $message = new SwatMessage(sprintf(
+            Admin::ngettext(
+                'One sub-component has been deleted.',
+                '%s sub-components have been deleted.',
+                $num
+            ),
+            SwatString::numberFormat($num)
+        ));
 
+        $this->app->messages->add($message);
+    }
 
-	// process phase
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-	protected function processDBData(): void
-	{
-		parent::processDBData();
+        $item_list = $this->getItemList('integer');
 
-		$item_list = $this->getItemList('integer');
+        $dep = new AdminListDependency();
+        $dep->setTitle(Admin::_('sub-component'), Admin::_('sub-components'));
+        $dep->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminSubComponent',
+            'integer:id',
+            null,
+            'text:title',
+            'displayorder, title',
+            'id in (' . $item_list . ')',
+            AdminDependency::DELETE
+        );
 
-		$sql = 'delete from AdminSubComponent where id in (%s)';
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = $dep->getMessage();
+        $message->content_type = 'text/xml';
 
-		$sql = sprintf($sql, $item_list);
-		$num = SwatDB::exec($this->app->db, $sql);
+        if ($dep->getStatusLevelCount(AdminDependency::DELETE) == 0) {
+            $this->switchToCancelButton();
+        }
 
-		$message = new SwatMessage(sprintf(Admin::ngettext(
-			'One sub-component has been deleted.',
-			'%s sub-components have been deleted.', $num),
-			SwatString::numberFormat($num)));
+        // rebuild the navbar
+        $component_title = SwatDB::queryOneFromTable(
+            $this->app->db,
+            'AdminComponent',
+            'text:title',
+            'id',
+            $this->parent
+        );
 
-		$this->app->messages->add($message);
-	}
+        // pop two entries because the AdminDBOrder base class adds an entry
+        $this->navbar->popEntries(2);
+        $this->navbar->createEntry(
+            Admin::_('Admin Components'),
+            'AdminComponent'
+        );
 
+        $this->navbar->createEntry(
+            $component_title,
+            'AdminComponent/Details?id=' . $this->parent
+        );
 
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$item_list = $this->getItemList('integer');
-
-		$dep = new AdminListDependency();
-		$dep->setTitle(Admin::_('sub-component'), Admin::_('sub-components'));
-		$dep->entries = AdminListDependency::queryEntries($this->app->db,
-			'AdminSubComponent', 'integer:id', null, 'text:title',
-			'displayorder, title', 'id in ('.$item_list.')',
-			AdminDependency::DELETE);
-
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = $dep->getMessage();
-		$message->content_type = 'text/xml';
-
-		if ($dep->getStatusLevelCount(AdminDependency::DELETE) == 0)
-			$this->switchToCancelButton();
-
-		// rebuild the navbar
-		$component_title = SwatDB::queryOneFromTable($this->app->db,
-			'AdminComponent', 'text:title', 'id', $this->parent);
-
-		// pop two entries because the AdminDBOrder base class adds an entry
-		$this->navbar->popEntries(2);
-		$this->navbar->createEntry(Admin::_('Admin Components'),
-			'AdminComponent');
-
-		$this->navbar->createEntry($component_title,
-			'AdminComponent/Details?id='.$this->parent);
-
-		$this->navbar->createEntry(Admin::_('Delete Sub-Component(s)'));
-	}
-
-
+        $this->navbar->createEntry(Admin::_('Delete Sub-Component(s)'));
+    }
 }
-
-?>

--- a/Admin/components/AdminSubComponent/Delete.php
+++ b/Admin/components/AdminSubComponent/Delete.php
@@ -8,22 +8,22 @@
  */
 class AdminAdminSubComponentDelete extends AdminDBDelete
 {
-	// {{{ private properties
+
 
 	private $parent;
 
-	// }}}
-	// {{{ public function setParent()
+
+
 
 	public function setParent($parent)
 	{
 		$this->parent = $parent;
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processDBData()
+
 
 	protected function processDBData(): void
 	{
@@ -44,10 +44,10 @@ class AdminAdminSubComponentDelete extends AdminDBDelete
 		$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -84,7 +84,7 @@ class AdminAdminSubComponentDelete extends AdminDBDelete
 		$this->navbar->createEntry(Admin::_('Delete Sub-Component(s)'));
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSubComponent/Edit.php
+++ b/Admin/components/AdminSubComponent/Edit.php
@@ -9,28 +9,28 @@
  */
 class AdminAdminSubComponentEdit extends AdminObjectEdit
 {
-	// {{{ protected properties
+
 
 	protected $admin_component;
 
-	// }}}
-	// {{{ protected function getObjectClass()
+
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminSubComponent';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/edit.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -41,10 +41,10 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -53,8 +53,8 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		$this->initAdminComponent();
 	}
 
-	// }}}
-	// {{{ protected function initAdminComponent()
+
+
 
 	protected function initAdminComponent()
 	{
@@ -85,10 +85,10 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function validate()
+
 
 	protected function validate(): void
 	{
@@ -107,8 +107,8 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function updateObject()
+
+
 
 	protected function updateObject()
 	{
@@ -119,8 +119,8 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
@@ -130,10 +130,10 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildForm()
+
 
 	protected function buildForm()
 	{
@@ -143,8 +143,8 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		$form->addHiddenField('parent', $this->admin_component->id);
 	}
 
-	// }}}
-	// {{{ protected function buildNavBar()
+
+
 
 	protected function buildNavBar()
 	{
@@ -170,7 +170,7 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSubComponent/Edit.php
+++ b/Admin/components/AdminSubComponent/Edit.php
@@ -1,176 +1,139 @@
 <?php
 
 /**
- * Edit page for AdminSubComponents
+ * Edit page for AdminSubComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSubComponentEdit extends AdminObjectEdit
 {
+    protected $admin_component;
 
+    protected function getObjectClass()
+    {
+        return 'AdminSubComponent';
+    }
 
-	protected $admin_component;
+    protected function getUiXml()
+    {
+        return __DIR__ . '/edit.xml';
+    }
 
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'title',
+            'shortname',
+            'visible',
+        ];
+    }
 
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
 
-	protected function getObjectClass()
-	{
-		return 'AdminSubComponent';
-	}
+        $this->initAdminComponent();
+    }
 
+    protected function initAdminComponent()
+    {
+        if ($this->isNew()) {
+            $parent_id = SiteApplication::initVar('parent');
 
+            if ($parent_id === null) {
+                throw new AdminNotFoundException(
+                    'Must supply a Component ID for newly created ' .
+                    'Sub-Compoenets.'
+                );
+            }
 
+            $class_name = SwatDBClassMap::get('AdminComponent');
+            $this->admin_component = new $class_name();
+            $this->admin_component->setDatabase($this->app->db);
 
-	protected function getUiXml()
-	{
-		return __DIR__.'/edit.xml';
-	}
+            if (!$this->admin_component->load($parent_id)) {
+                throw new AdminNotFoundException(
+                    sprintf(
+                        'Component with id "%s" not found.',
+                        $parent_id
+                    )
+                );
+            }
+        } else {
+            $this->admin_component = $this->getObject()->component;
+        }
+    }
 
+    // process phase
 
+    protected function validate(): void
+    {
+        $shortname_widget = $this->ui->getWidget('shortname');
+        $shortname = $shortname_widget->value;
 
+        $should_validate_shortname = (!$this->isNew() || $shortname != '');
+        if ($should_validate_shortname
+            && !$this->validateShortname($shortname)) {
+            $message = new SwatMessage(
+                Admin::_('Shortname already exists and must be unique.'),
+                'error'
+            );
 
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'title',
-			'shortname',
-			'visible',
-		);
-	}
+            $shortname_widget->addMessage($message);
+        }
+    }
 
+    protected function updateObject()
+    {
+        parent::updateObject();
 
+        if ($this->isNew()) {
+            $this->getObject()->component = $this->admin_component;
+        }
+    }
 
-	// init phase
+    protected function getSavedMessagePrimaryContent()
+    {
+        return sprintf(
+            Admin::_('Sub-Component “%s” has been saved.'),
+            $this->getObject()->title
+        );
+    }
 
+    // build phase
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+    protected function buildForm()
+    {
+        parent::buildForm();
 
-		$this->initAdminComponent();
-	}
+        $form = $this->ui->getWidget('edit_form');
+        $form->addHiddenField('parent', $this->admin_component->id);
+    }
 
+    protected function buildNavBar()
+    {
+        $this->navbar->popEntry();
 
+        $this->navbar->createEntry(
+            Admin::_('Admin Components'),
+            'AdminComponent'
+        );
 
+        $this->navbar->createEntry(
+            $this->admin_component->title,
+            sprintf(
+                'AdminComponent/Details?id=%s',
+                $this->admin_component->id
+            )
+        );
 
-	protected function initAdminComponent()
-	{
-		if ($this->isNew()) {
-			$parent_id = SiteApplication::initVar('parent');
-
-			if ($parent_id === null) {
-				throw new AdminNotFoundException(
-					'Must supply a Component ID for newly created '.
-					'Sub-Compoenets.'
-				);
-			}
-
-			$class_name = SwatDBClassMap::get('AdminComponent');
-			$this->admin_component = new $class_name();
-			$this->admin_component->setDatabase($this->app->db);
-
-			if (!$this->admin_component->load($parent_id)) {
-				throw new AdminNotFoundException(
-					sprintf(
-						'Component with id "%s" not found.',
-						$parent_id
-					)
-				);
-			}
-		} else {
-			$this->admin_component = $this->getObject()->component;
-		}
-	}
-
-
-
-	// process phase
-
-
-	protected function validate(): void
-	{
-		$shortname_widget = $this->ui->getWidget('shortname');
-		$shortname = $shortname_widget->value;
-
-		$should_validate_shortname = (!$this->isNew() || $shortname != '');
-		if ($should_validate_shortname &&
-			!$this->validateShortname($shortname)) {
-			$message = new SwatMessage(
-				Admin::_('Shortname already exists and must be unique.'),
-				'error'
-			);
-
-			$shortname_widget->addMessage($message);
-		}
-	}
-
-
-
-
-	protected function updateObject()
-	{
-		parent::updateObject();
-
-		if ($this->isNew()) {
-			$this->getObject()->component = $this->admin_component;
-		}
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return sprintf(
-			Admin::_('Sub-Component “%s” has been saved.'),
-			$this->getObject()->title
-		);
-	}
-
-
-
-	// build phase
-
-
-	protected function buildForm()
-	{
-		parent::buildForm();
-
-		$form = $this->ui->getWidget('edit_form');
-		$form->addHiddenField('parent', $this->admin_component->id);
-	}
-
-
-
-
-	protected function buildNavBar()
-	{
-		$this->navbar->popEntry();
-
-		$this->navbar->createEntry(
-			Admin::_('Admin Components'),
-			'AdminComponent'
-		);
-
-		$this->navbar->createEntry(
-			$this->admin_component->title,
-			sprintf(
-				'AdminComponent/Details?id=%s',
-				$this->admin_component->id
-			)
-		);
-
-		$this->navbar->createEntry(
-			($this->isNew())
-				? Admin::_('Add Sub-Component')
-				: Admin::_('Edit Sub-Component')
-		);
-	}
-
-
+        $this->navbar->createEntry(
+            ($this->isNew())
+                ? Admin::_('Add Sub-Component')
+                : Admin::_('Edit Sub-Component')
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminSubComponent/Edit.php
+++ b/Admin/components/AdminSubComponent/Edit.php
@@ -12,7 +12,7 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
 
     protected function getObjectClass()
     {
-        return 'AdminSubComponent';
+        return AdminSubComponent::class;
     }
 
     protected function getUiXml()
@@ -50,7 +50,7 @@ class AdminAdminSubComponentEdit extends AdminObjectEdit
                 );
             }
 
-            $class_name = SwatDBClassMap::get('AdminComponent');
+            $class_name = SwatDBClassMap::get(AdminComponent::class);
             $this->admin_component = new $class_name();
             $this->admin_component->setDatabase($this->app->db);
 

--- a/Admin/components/AdminSubComponent/Order.php
+++ b/Admin/components/AdminSubComponent/Order.php
@@ -9,14 +9,14 @@
  */
 class AdminAdminSubComponentOrder extends AdminDBOrder
 {
-	// {{{ private properties
+
 
 	private $parent;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -27,10 +27,10 @@ class AdminAdminSubComponentOrder extends AdminDBOrder
 		$form->addHiddenField('parent', $this->parent);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function saveIndex()
+
 
 	protected function saveIndex($id, $index)
 	{
@@ -38,10 +38,10 @@ class AdminAdminSubComponentOrder extends AdminDBOrder
 			'integer:displayorder', $index, 'integer:id', array($id));
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -63,8 +63,8 @@ class AdminAdminSubComponentOrder extends AdminDBOrder
 		$this->navbar->createEntry('Order Sub-Components');
 	}
 
-	// }}}
-	// {{{ protected function loadData()
+
+
 
 	protected function loadData()
 	{
@@ -86,7 +86,7 @@ class AdminAdminSubComponentOrder extends AdminDBOrder
 		$radio_list->value = ($sum == 0) ? 'auto' : 'custom';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminSubComponent/Order.php
+++ b/Admin/components/AdminSubComponent/Order.php
@@ -1,92 +1,93 @@
 <?php
 
 /**
- * Order page for AdminSubComponents
+ * Order page for AdminSubComponents.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminSubComponentOrder extends AdminDBOrder
 {
+    private $parent;
 
+    // init phase
 
-	private $parent;
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->parent = SiteApplication::initVar('parent');
+        $form = $this->ui->getWidget('order_form');
+        $form->addHiddenField('parent', $this->parent);
+    }
 
+    // process phase
 
-	// init phase
+    protected function saveIndex($id, $index)
+    {
+        SwatDB::updateColumn(
+            $this->app->db,
+            'AdminSubComponent',
+            'integer:displayorder',
+            $index,
+            'integer:id',
+            [$id]
+        );
+    }
 
+    // build phase
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-		$this->parent = SiteApplication::initVar('parent');
-		$form = $this->ui->getWidget('order_form');
-		$form->addHiddenField('parent', $this->parent);
-	}
+        $frame = $this->ui->getWidget('order_frame');
+        $frame->title = Admin::_('Order Sub-Components');
 
+        // rebuild the navbar
+        $parent_title = SwatDB::queryOneFromTable(
+            $this->app->db,
+            'AdminComponent',
+            'text:title',
+            'id',
+            $this->parent
+        );
 
+        // pop two entries because the AdminDBOrder base class adds an entry
+        $this->navbar->popEntries(2);
+        $this->navbar->createEntry('Admin Components', 'AdminComponent');
+        $this->navbar->createEntry(
+            $parent_title,
+            'AdminComponent/Details?id=' . $this->parent
+        );
 
-	// process phase
+        $this->navbar->createEntry('Order Sub-Components');
+    }
 
+    protected function loadData()
+    {
+        $where_clause = sprintf(
+            'component = %s',
+            $this->app->db->quote($this->parent, 'integer')
+        );
 
-	protected function saveIndex($id, $index)
-	{
-		SwatDB::updateColumn($this->app->db, 'AdminSubComponent',
-			'integer:displayorder', $index, 'integer:id', array($id));
-	}
+        $order_list = $this->ui->getWidget('order');
+        $order_list_options = SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminSubComponent',
+            'title',
+            'id',
+            'displayorder, title',
+            $where_clause
+        );
 
+        $order_list->addOptionsByArray($order_list_options);
 
+        $sql = 'select sum(displayorder) from AdminSubComponent
+			where ' . $where_clause;
 
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$frame = $this->ui->getWidget('order_frame');
-		$frame->title = Admin::_('Order Sub-Components');
-
-		// rebuild the navbar
-		$parent_title = SwatDB::queryOneFromTable($this->app->db,
-			'AdminComponent', 'text:title', 'id', $this->parent);
-
-		// pop two entries because the AdminDBOrder base class adds an entry
-		$this->navbar->popEntries(2);
-		$this->navbar->createEntry('Admin Components', 'AdminComponent');
-		$this->navbar->createEntry($parent_title,
-			'AdminComponent/Details?id='.$this->parent);
-
-		$this->navbar->createEntry('Order Sub-Components');
-	}
-
-
-
-
-	protected function loadData()
-	{
-		$where_clause = sprintf('component = %s',
-			$this->app->db->quote($this->parent, 'integer'));
-
-		$order_list = $this->ui->getWidget('order');
-		$order_list_options = SwatDB::getOptionArray($this->app->db,
-			'AdminSubComponent', 'title', 'id', 'displayorder, title',
-			$where_clause);
-
-		$order_list->addOptionsByArray($order_list_options);
-
-		$sql = 'select sum(displayorder) from AdminSubComponent
-			where '.$where_clause;
-
-		$sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
-		$radio_list = $this->ui->getWidget('options');
-		$radio_list->value = ($sum == 0) ? 'auto' : 'custom';
-	}
-
-
+        $sum = SwatDB::queryOne($this->app->db, $sql, 'integer');
+        $radio_list = $this->ui->getWidget('options');
+        $radio_list->value = ($sum == 0) ? 'auto' : 'custom';
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/Delete.php
+++ b/Admin/components/AdminUser/Delete.php
@@ -10,7 +10,7 @@
 class AdminAdminUserDelete extends AdminDBDelete
 {
 	// process phase
-	// {{{ protected function processDBData
+
 
 	protected function processDBData(): void
 	{
@@ -31,10 +31,10 @@ class AdminAdminUserDelete extends AdminDBDelete
 		$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	public function buildInternal()
 	{
@@ -70,7 +70,7 @@ class AdminAdminUserDelete extends AdminDBDelete
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/Delete.php
+++ b/Admin/components/AdminUser/Delete.php
@@ -1,76 +1,83 @@
 <?php
 
 /**
- * Delete confirmation page for AdminUsers component
+ * Delete confirmation page for AdminUsers component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminUserDelete extends AdminDBDelete
 {
-	// process phase
+    // process phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
-	protected function processDBData(): void
-	{
-		parent::processDBData();
+        $item_list = $this->getItemList('integer');
+        $sql = sprintf(
+            'delete from AdminUser where id in (%s) and id != %s',
+            $item_list,
+            $this->app->db->quote($this->app->session->getUserId(), 'integer')
+        );
 
-		$item_list = $this->getItemList('integer');
-		$sql = sprintf('delete from AdminUser where id in (%s) and id != %s',
-			$item_list,
-			$this->app->db->quote($this->app->session->getUserId(), 'integer'));
+        $num = SwatDB::exec($this->app->db, $sql);
 
-		$num = SwatDB::exec($this->app->db, $sql);
+        $message = new SwatMessage(sprintf(
+            Admin::ngettext(
+                'One admin user has been deleted.',
+                '%s admin users have been deleted.',
+                $num
+            ),
+            SwatString::numberFormat($num)
+        ));
 
-		$message = new SwatMessage(sprintf(Admin::ngettext(
-			'One admin user has been deleted.',
-			'%s admin users have been deleted.', $num),
-			SwatString::numberFormat($num)));
+        $this->app->messages->add($message);
+    }
 
-		$this->app->messages->add($message);
-	}
+    // build phase
 
+    public function buildInternal()
+    {
+        parent::buildInternal();
 
+        $item_list = $this->getItemList('integer');
 
-	// build phase
+        $where_clause = sprintf(
+            'id in (%s) and id != %s',
+            $item_list,
+            $this->app->db->quote($this->app->session->getUserId(), 'integer')
+        );
 
+        $dep = new AdminListDependency();
+        $dep->setTitle(Admin::_('admin user'), Admin::_('admin users'));
+        $dep->entries = AdminListDependency::queryEntries(
+            $this->app->db,
+            'AdminUser',
+            'integer:id',
+            null,
+            'text:name',
+            'name',
+            $where_clause,
+            AdminDependency::DELETE
+        );
 
-	public function buildInternal()
-	{
-		parent::buildInternal();
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = $dep->getMessage();
+        $message->content_type = 'text/xml';
 
-		$item_list = $this->getItemList('integer');
+        if ($dep->getItemCount() == 0) {
+            $this->switchToCancelButton();
+        }
 
-		$where_clause = sprintf('id in (%s) and id != %s',
-			$item_list,
-			$this->app->db->quote($this->app->session->getUserId(), 'integer'));
+        // display can't delete self message if current account is in selection
+        if ($this->items->contains($this->app->session->getUserId())) {
+            $header = new SwatHtmlTag('h3');
+            $header->setContent(
+                Admin::_('You cannot delete your own account.')
+            );
 
-		$dep = new AdminListDependency();
-		$dep->setTitle(Admin::_('admin user'), Admin::_('admin users'));
-		$dep->entries = AdminListDependency::queryEntries($this->app->db,
-			'AdminUser', 'integer:id', null, 'text:name', 'name',
-			$where_clause, AdminDependency::DELETE);
-
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = $dep->getMessage();
-		$message->content_type = 'text/xml';
-
-		if ($dep->getItemCount() == 0) {
-			$this->switchToCancelButton();
-		}
-
-		// display can't delete self message if current account is in selection
-		if ($this->items->contains($this->app->session->getUserId())) {
-			$header = new SwatHtmlTag('h3');
-			$header->setContent(
-				Admin::_('You cannot delete your own account.'));
-
-			$message->content.= $header;
-		}
-	}
-
-
+            $message->content .= $header;
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/Details.php
+++ b/Admin/components/AdminUser/Details.php
@@ -1,100 +1,87 @@
 <?php
 
 /**
- * Details page for AdminUsers component
+ * Details page for AdminUsers component.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminUserDetails extends AdminIndex
 {
+    private $id;
 
+    private AdminUser $user;
 
-	private $id;
+    // init phase
 
-	private AdminUser $user;
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/details.xml');
 
+        $this->id = intval(SiteApplication::initVar('id'));
 
+        $this->initUser();
 
-	// init phase
+        // set a default order on the table view
+        $index_view = $this->ui->getWidget('index_view');
+        $index_view->setDefaultOrderbyColumn(
+            $index_view->getColumn('login_date')
+        );
+    }
 
+    protected function initUser()
+    {
+        $class_name = SwatDBClassMap::get(AdminUser::class);
+        $this->user = new $class_name();
+        $this->user->setDatabase($this->app->db);
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/details.xml');
+        if (!$this->user->load($this->id)) {
+            throw new AdminNotFoundException(
+                sprintf(
+                    Admin::_('User with id "%s" not found.'),
+                    $this->id
+                )
+            );
+        }
+    }
 
-		$this->id = intval(SiteApplication::initVar('id'));
+    // build phase
 
-		$this->initUser();
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-		// set a default order on the table view
-		$index_view = $this->ui->getWidget('index_view');
-		$index_view->setDefaultOrderbyColumn(
-			$index_view->getColumn('login_date'));
-	}
+        $frame = $this->ui->getWidget('index_frame');
+        $frame->subtitle = sprintf($this->user->name);
 
+        // rebuild the navbar
+        $this->navbar->createEntry('Login History', 'AdminUser/LoginHistory');
+        $this->navbar->createEntry($this->user->name);
 
+        // set default time zone
+        $date_column =
+            $this->ui->getWidget('index_view')->getColumn('login_date');
 
+        $date_renderer = $date_column->getRendererByPosition();
+        $date_renderer->display_time_zone = $this->app->default_time_zone;
+    }
 
-	protected function initUser()
-	{
-		$class_name = SwatDBClassMap::get(AdminUser::class);
-		$this->user = new $class_name();
-		$this->user->setDatabase($this->app->db);
+    protected function getTableModel(SwatView $view): AdminUserHistoryWrapper
+    {
+        $instance_id = $this->app->getInstanceId();
 
-		if (!$this->user->load($this->id)) {
-			throw new AdminNotFoundException(
-				sprintf(Admin::_('User with id "%s" not found.'),
-					$this->id));
-		}
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$frame = $this->ui->getWidget('index_frame');
-		$frame->subtitle = sprintf($this->user->name);
-
-		// rebuild the navbar
-		$this->navbar->createEntry('Login History', 'AdminUser/LoginHistory');
-		$this->navbar->createEntry($this->user->name);
-
-		// set default time zone
-		$date_column =
-			$this->ui->getWidget('index_view')->getColumn('login_date');
-
-		$date_renderer = $date_column->getRendererByPosition();
-		$date_renderer->display_time_zone = $this->app->default_time_zone;
-	}
-
-
-
-
-	protected function getTableModel(SwatView $view): AdminUserHistoryWrapper
-	{
-		$instance_id = $this->app->getInstanceId();
-
-		$sql = 'select * from AdminUserHistory
+        $sql = 'select * from AdminUserHistory
 				where usernum = %s and instance %s %s
 				order by %s';
 
-		$sql = sprintf($sql,
-			$this->app->db->quote($this->user->id, 'integer'),
-			SwatDB::equalityOperator($instance_id),
-			$this->app->db->quote($instance_id, 'integer'),
-			$this->getOrderByClause($view, 'login_date desc'));
+        $sql = sprintf(
+            $sql,
+            $this->app->db->quote($this->user->id, 'integer'),
+            SwatDB::equalityOperator($instance_id),
+            $this->app->db->quote($instance_id, 'integer'),
+            $this->getOrderByClause($view, 'login_date desc')
+        );
 
-		return SwatDB::query($this->app->db, $sql, AdminUserHistoryWrapper::class);
-	}
-
-
+        return SwatDB::query($this->app->db, $sql, AdminUserHistoryWrapper::class);
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/Details.php
+++ b/Admin/components/AdminUser/Details.php
@@ -9,16 +9,16 @@
  */
 class AdminAdminUserDetails extends AdminIndex
 {
-	// {{{ private properties
+
 
 	private $id;
 
 	private AdminUser $user;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -34,8 +34,8 @@ class AdminAdminUserDetails extends AdminIndex
 			$index_view->getColumn('login_date'));
 	}
 
-	// }}}
-	// {{{ protected function initUser()
+
+
 
 	protected function initUser()
 	{
@@ -50,10 +50,10 @@ class AdminAdminUserDetails extends AdminIndex
 		}
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -74,8 +74,8 @@ class AdminAdminUserDetails extends AdminIndex
 		$date_renderer->display_time_zone = $this->app->default_time_zone;
 	}
 
-	// }}}
-	// {{{ protected function getTableModel()
+
+
 
 	protected function getTableModel(SwatView $view): AdminUserHistoryWrapper
 	{
@@ -94,7 +94,7 @@ class AdminAdminUserDetails extends AdminIndex
 		return SwatDB::query($this->app->db, $sql, AdminUserHistoryWrapper::class);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/Edit.php
+++ b/Admin/components/AdminUser/Edit.php
@@ -1,278 +1,223 @@
 <?php
 
 /**
- * Edit page for AdminUsers component
+ * Edit page for AdminUsers component.
  *
- * @package   Admin
  * @copyright 2005-2022 silverorange
  */
 class AdminAdminUserEdit extends AdminObjectEdit
 {
-
-
-	protected function getObjectClass()
-	{
-		return 'AdminUser';
-	}
-
-
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/edit.xml';
-	}
-
-
-
-
-	protected function getObjectUiValueNames()
-	{
-		return array(
-			'email',
-			'name',
-			'enabled',
-			'force_change_password',
-			'two_fa_enabled',
-		);
-	}
-
-
-
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->initPasswordWidgets();
-		$this->initGroups();
-		$this->initInstances();
-
-		$this->ui->getWidget('two_fa_enabled')->parent->visible =
-			$this->app->is2FaEnabled();
-	}
-
-
-
-
-	protected function initPasswordWidgets()
-	{
-		$confirm_widget = $this->ui->getWidget('confirm_password');
-		$confirm_widget->password_widget = $this->ui->getWidget('password');
-
-		if ($this->isNew()) {
-			$confirm_widget->required = true;
-			$this->ui->getWidget('password')->required = true;
-			$this->ui->getWidget('confirm_password_field')->note = null;
-			$this->ui->getWidget('password_disclosure')->open = true;
-			$this->ui->getWidget('password_disclosure')->title =
-				Admin::_('Set Password');
-		}
-	}
-
-
-
-
-	protected function initGroups()
-	{
-		$group_list = $this->ui->getWidget('groups');
-		$group_list_options = SwatDB::getOptionArray(
-			$this->app->db,
-			'AdminGroup',
-			'title',
-			'id',
-			'title'
-		);
-
-		$group_list->addOptionsByArray($group_list_options);
-	}
-
-
-
-
-	protected function initInstances()
-	{
-		if ($this->app->isMultipleInstanceAdmin()) {
-			$this->ui->getWidget('instances')->parent->visible = true;
-
-			$instance_list = $this->ui->getWidget('instances');
-			$instance_list_options = SwatDB::getOptionArray(
-				$this->app->db,
-				'Instance',
-				'title',
-				'id',
-				'shortname'
-			);
-
-			$instance_list->addOptionsByArray($instance_list_options);
-		}
-	}
-
-
-
-	// process phase
-
-
-	protected function validate(): void
-	{
-		$email = $this->ui->getWidget('email');
-
-		$class_name = SwatDBClassMap::get('AdminUser');
-		$user = new $class_name();
-		$user->setDatabase($this->app->db);
-
-		if ($user->loadFromEmail($email->value)) {
-			if ($user->id !== $this->getObject()->id) {
-				$message = new SwatMessage(
-					Admin::_(
-						'An account with this email address already exists.'
-					)
-				);
-
-				$email->addMessage($message);
-			}
-		}
-
-		if ($this->ui->getWidget('confirm_password_field')->hasMessage() ||
-			$this->ui->getWidget('password')->hasMessage()) {
-			$this->ui->getWidget('password_disclosure')->open = true;
-		}
-	}
-
-
-
-
-	protected function updateObject()
-	{
-		parent::updateObject();
-
-		$this->updatePassword();
-	}
-
-
-
-
-	protected function updatePassword()
-	{
-		$password = $this->ui->getWidget('password')->value;
-
-		if ($password != '') {
-			$crypt = $this->app->getModule('SiteCryptModule');
-			$this->getObject()->setPasswordHash(
-				$crypt->generateHash($password)
-			);
-		}
-	}
-
-
-
-
-	protected function postSaveObject()
-	{
-		$this->updateGroupBindings();
-		$this->updateInstanceBindings();
-	}
-
-
-
-
-	protected function updateGroupBindings()
-	{
-		$group_list = $this->ui->getWidget('groups');
-
-		SwatDB::updateBinding(
-			$this->app->db,
-			'AdminUserAdminGroupBinding',
-			'usernum',
-			$this->getObject()->id,
-			'groupnum',
-			$group_list->values,
-			'AdminGroup',
-			'id'
-		);
-	}
-
-
-
-
-	protected function updateInstanceBindings()
-	{
-		if ($this->app->isMultipleInstanceAdmin()) {
-			$instance_list = $this->ui->getWidget('instances');
-			SwatDB::updateBinding(
-				$this->app->db,
-				'AdminUserInstanceBinding',
-				'usernum',
-				$this->getObject()->id,
-				'instance',
-				$instance_list->values,
-				'Instance',
-				'id'
-			);
-		}
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return sprintf(
-			Admin::_('User “%s” has been saved.'),
-			$this->getObject()->email
-		);
-	}
-
-
-
-	// build phase
-
-
-	protected function loadObject()
-	{
-		parent::loadObject();
-
-		if (!$this->isNew()) {
-			$this->loadGroupBindings();
-			$this->loadInstanceBindings();
-		}
-	}
-
-
-
-
-	protected function loadGroupBindings()
-	{
-		$group_list = $this->ui->getWidget('groups');
-		$group_list->values = SwatDB::queryColumn(
-			$this->app->db,
-			'AdminUserAdminGroupBinding',
-			'groupnum',
-			'usernum',
-			$this->getObject()->id
-		);
-	}
-
-
-
-
-	protected function loadInstanceBindings()
-	{
-		if ($this->app->isMultipleInstanceAdmin()) {
-			$instance_list = $this->ui->getWidget('instances');
-			$instance_list->values = SwatDB::queryColumn(
-				$this->app->db,
-				'AdminUserInstanceBinding',
-				'instance',
-				'usernum',
-				$this->getObject()->id
-			);
-		}
-	}
-
-
+    protected function getObjectClass()
+    {
+        return 'AdminUser';
+    }
+
+    protected function getUiXml()
+    {
+        return __DIR__ . '/edit.xml';
+    }
+
+    protected function getObjectUiValueNames()
+    {
+        return [
+            'email',
+            'name',
+            'enabled',
+            'force_change_password',
+            'two_fa_enabled',
+        ];
+    }
+
+    // init phase
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->initPasswordWidgets();
+        $this->initGroups();
+        $this->initInstances();
+
+        $this->ui->getWidget('two_fa_enabled')->parent->visible =
+            $this->app->is2FaEnabled();
+    }
+
+    protected function initPasswordWidgets()
+    {
+        $confirm_widget = $this->ui->getWidget('confirm_password');
+        $confirm_widget->password_widget = $this->ui->getWidget('password');
+
+        if ($this->isNew()) {
+            $confirm_widget->required = true;
+            $this->ui->getWidget('password')->required = true;
+            $this->ui->getWidget('confirm_password_field')->note = null;
+            $this->ui->getWidget('password_disclosure')->open = true;
+            $this->ui->getWidget('password_disclosure')->title =
+                Admin::_('Set Password');
+        }
+    }
+
+    protected function initGroups()
+    {
+        $group_list = $this->ui->getWidget('groups');
+        $group_list_options = SwatDB::getOptionArray(
+            $this->app->db,
+            'AdminGroup',
+            'title',
+            'id',
+            'title'
+        );
+
+        $group_list->addOptionsByArray($group_list_options);
+    }
+
+    protected function initInstances()
+    {
+        if ($this->app->isMultipleInstanceAdmin()) {
+            $this->ui->getWidget('instances')->parent->visible = true;
+
+            $instance_list = $this->ui->getWidget('instances');
+            $instance_list_options = SwatDB::getOptionArray(
+                $this->app->db,
+                'Instance',
+                'title',
+                'id',
+                'shortname'
+            );
+
+            $instance_list->addOptionsByArray($instance_list_options);
+        }
+    }
+
+    // process phase
+
+    protected function validate(): void
+    {
+        $email = $this->ui->getWidget('email');
+
+        $class_name = SwatDBClassMap::get('AdminUser');
+        $user = new $class_name();
+        $user->setDatabase($this->app->db);
+
+        if ($user->loadFromEmail($email->value)) {
+            if ($user->id !== $this->getObject()->id) {
+                $message = new SwatMessage(
+                    Admin::_(
+                        'An account with this email address already exists.'
+                    )
+                );
+
+                $email->addMessage($message);
+            }
+        }
+
+        if ($this->ui->getWidget('confirm_password_field')->hasMessage()
+            || $this->ui->getWidget('password')->hasMessage()) {
+            $this->ui->getWidget('password_disclosure')->open = true;
+        }
+    }
+
+    protected function updateObject()
+    {
+        parent::updateObject();
+
+        $this->updatePassword();
+    }
+
+    protected function updatePassword()
+    {
+        $password = $this->ui->getWidget('password')->value;
+
+        if ($password != '') {
+            $crypt = $this->app->getModule('SiteCryptModule');
+            $this->getObject()->setPasswordHash(
+                $crypt->generateHash($password)
+            );
+        }
+    }
+
+    protected function postSaveObject()
+    {
+        $this->updateGroupBindings();
+        $this->updateInstanceBindings();
+    }
+
+    protected function updateGroupBindings()
+    {
+        $group_list = $this->ui->getWidget('groups');
+
+        SwatDB::updateBinding(
+            $this->app->db,
+            'AdminUserAdminGroupBinding',
+            'usernum',
+            $this->getObject()->id,
+            'groupnum',
+            $group_list->values,
+            'AdminGroup',
+            'id'
+        );
+    }
+
+    protected function updateInstanceBindings()
+    {
+        if ($this->app->isMultipleInstanceAdmin()) {
+            $instance_list = $this->ui->getWidget('instances');
+            SwatDB::updateBinding(
+                $this->app->db,
+                'AdminUserInstanceBinding',
+                'usernum',
+                $this->getObject()->id,
+                'instance',
+                $instance_list->values,
+                'Instance',
+                'id'
+            );
+        }
+    }
+
+    protected function getSavedMessagePrimaryContent()
+    {
+        return sprintf(
+            Admin::_('User “%s” has been saved.'),
+            $this->getObject()->email
+        );
+    }
+
+    // build phase
+
+    protected function loadObject()
+    {
+        parent::loadObject();
+
+        if (!$this->isNew()) {
+            $this->loadGroupBindings();
+            $this->loadInstanceBindings();
+        }
+    }
+
+    protected function loadGroupBindings()
+    {
+        $group_list = $this->ui->getWidget('groups');
+        $group_list->values = SwatDB::queryColumn(
+            $this->app->db,
+            'AdminUserAdminGroupBinding',
+            'groupnum',
+            'usernum',
+            $this->getObject()->id
+        );
+    }
+
+    protected function loadInstanceBindings()
+    {
+        if ($this->app->isMultipleInstanceAdmin()) {
+            $instance_list = $this->ui->getWidget('instances');
+            $instance_list->values = SwatDB::queryColumn(
+                $this->app->db,
+                'AdminUserInstanceBinding',
+                'instance',
+                'usernum',
+                $this->getObject()->id
+            );
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/Edit.php
+++ b/Admin/components/AdminUser/Edit.php
@@ -8,23 +8,23 @@
  */
 class AdminAdminUserEdit extends AdminObjectEdit
 {
-	// {{{ protected function getObjectClass()
+
 
 	protected function getObjectClass()
 	{
 		return 'AdminUser';
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/edit.xml';
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
@@ -37,10 +37,10 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -54,8 +54,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 			$this->app->is2FaEnabled();
 	}
 
-	// }}}
-	// {{{ protected function initPasswordWidgets()
+
+
 
 	protected function initPasswordWidgets()
 	{
@@ -72,8 +72,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function initGroups()
+
+
 
 	protected function initGroups()
 	{
@@ -89,8 +89,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		$group_list->addOptionsByArray($group_list_options);
 	}
 
-	// }}}
-	// {{{ protected function initInstances()
+
+
 
 	protected function initInstances()
 	{
@@ -110,10 +110,10 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function validate()
+
 
 	protected function validate(): void
 	{
@@ -141,8 +141,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function updateObject()
+
+
 
 	protected function updateObject()
 	{
@@ -151,8 +151,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		$this->updatePassword();
 	}
 
-	// }}}
-	// {{{ protected function updatePassword()
+
+
 
 	protected function updatePassword()
 	{
@@ -166,8 +166,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function postSaveObject()
+
+
 
 	protected function postSaveObject()
 	{
@@ -175,8 +175,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		$this->updateInstanceBindings();
 	}
 
-	// }}}
-	// {{{ protected function updateGroupBindings()
+
+
 
 	protected function updateGroupBindings()
 	{
@@ -194,8 +194,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function updateInstanceBindings()
+
+
 
 	protected function updateInstanceBindings()
 	{
@@ -214,8 +214,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
@@ -225,10 +225,10 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function loadObject()
+
 
 	protected function loadObject()
 	{
@@ -240,8 +240,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function loadGroupBindings()
+
+
 
 	protected function loadGroupBindings()
 	{
@@ -255,8 +255,8 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		);
 	}
 
-	// }}}
-	// {{{ protected function loadInstanceBindings()
+
+
 
 	protected function loadInstanceBindings()
 	{
@@ -272,7 +272,7 @@ class AdminAdminUserEdit extends AdminObjectEdit
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/Edit.php
+++ b/Admin/components/AdminUser/Edit.php
@@ -9,7 +9,7 @@ class AdminAdminUserEdit extends AdminObjectEdit
 {
     protected function getObjectClass()
     {
-        return 'AdminUser';
+        return AdminUser::class;
     }
 
     protected function getUiXml()
@@ -95,7 +95,7 @@ class AdminAdminUserEdit extends AdminObjectEdit
     {
         $email = $this->ui->getWidget('email');
 
-        $class_name = SwatDBClassMap::get('AdminUser');
+        $class_name = SwatDBClassMap::get(AdminUser::class);
         $user = new $class_name();
         $user->setDatabase($this->app->db);
 

--- a/Admin/components/AdminUser/Index.php
+++ b/Admin/components/AdminUser/Index.php
@@ -109,7 +109,7 @@ class AdminAdminUserIndex extends AdminIndex
     {
         $locale = SwatI18NLocale::get();
 
-        $class_name = SwatDBClassMap::get('AdminUser');
+        $class_name = SwatDBClassMap::get(AdminUser::class);
 
         $note = $this->ui->getWidget('active_note');
         $note->visible = true;
@@ -156,7 +156,7 @@ class AdminAdminUserIndex extends AdminIndex
                 $row->last_login = new SwatDate($row->last_login);
             }
 
-            $class_name = SwatDBClassMap::get('AdminUser');
+            $class_name = SwatDBClassMap::get(AdminUser::class);
 
             $ds = new SwatDetailsStore($row);
             $user = new $class_name($row);

--- a/Admin/components/AdminUser/Index.php
+++ b/Admin/components/AdminUser/Index.php
@@ -10,7 +10,7 @@
 class AdminAdminUserIndex extends AdminIndex
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -23,10 +23,10 @@ class AdminAdminUserIndex extends AdminIndex
 			SwatTableViewOrderableColumn::ORDER_BY_DIR_ASCENDING);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processActions()
+
 
 	protected function processActions(SwatView $view, SwatActions $actions)
 	{
@@ -72,10 +72,10 @@ class AdminAdminUserIndex extends AdminIndex
 			$this->app->messages->add($message);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -92,8 +92,8 @@ class AdminAdminUserIndex extends AdminIndex
 			$this->app->is2FaEnabled();
 	}
 
-	// }}}
-	// {{{ protected function buildActiveNote()
+
+
 
 	protected function buildActiveNote()
 	{
@@ -113,8 +113,8 @@ class AdminAdminUserIndex extends AdminIndex
 		);
 	}
 
-	// }}}
-	// {{{ protected function getTableModel()
+
+
 
 	protected function getTableModel(SwatView $view): SwatTableStore
 	{
@@ -188,10 +188,10 @@ class AdminAdminUserIndex extends AdminIndex
 		return $store;
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize()
+
 
 	public function finalize()
 	{
@@ -201,7 +201,7 @@ class AdminAdminUserIndex extends AdminIndex
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/Index.php
+++ b/Admin/components/AdminUser/Index.php
@@ -1,127 +1,134 @@
 <?php
 
 /**
- * Index page for AdminUsers component
+ * Index page for AdminUsers component.
  *
- * @package   Admin
  * @copyright 2005-2022 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminUserIndex extends AdminIndex
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        $this->ui->loadFromXML(__DIR__ . '/index.xml');
 
-	protected function initInternal()
-	{
-		$this->ui->loadFromXML(__DIR__.'/index.xml');
+        // set a default order on the table view
+        $index_view = $this->ui->getWidget('index_view');
+        $index_view->setDefaultOrderbyColumn(
+            $index_view->getColumn('email'),
+            SwatTableViewOrderableColumn::ORDER_BY_DIR_ASCENDING
+        );
+    }
 
-		// set a default order on the table view
-		$index_view = $this->ui->getWidget('index_view');
-		$index_view->setDefaultOrderbyColumn(
-			$index_view->getColumn('email'),
-			SwatTableViewOrderableColumn::ORDER_BY_DIR_ASCENDING);
-	}
+    // process phase
 
+    protected function processActions(SwatView $view, SwatActions $actions)
+    {
+        $num = count($view->checked_items);
+        $message = null;
 
+        switch ($actions->selected->id) {
+            case 'reactivate':
+                $this->app->replacePage('AdminUser/Reactivate');
+                $this->app->getPage()->setItems($view->getSelection());
+                break;
 
-	// process phase
+            case 'delete':
+                $this->app->replacePage('AdminUser/Delete');
+                $this->app->getPage()->setItems($view->getSelection());
+                break;
 
+            case 'enable':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminUser',
+                    'boolean:enabled',
+                    true,
+                    'id',
+                    $view->getSelection()
+                );
 
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-		$num = count($view->checked_items);
-		$message = null;
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One user has been enabled.',
+                        '%s users have been enabled.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-		switch ($actions->selected->id) {
-		case 'reactivate':
-			$this->app->replacePage('AdminUser/Reactivate');
-			$this->app->getPage()->setItems($view->getSelection());
-			break;
+                break;
 
-		case 'delete':
-			$this->app->replacePage('AdminUser/Delete');
-			$this->app->getPage()->setItems($view->getSelection());
-			break;
+            case 'disable':
+                SwatDB::updateColumn(
+                    $this->app->db,
+                    'AdminUser',
+                    'boolean:enabled',
+                    false,
+                    'id',
+                    $view->getSelection()
+                );
 
-		case 'enable':
-			SwatDB::updateColumn($this->app->db, 'AdminUser',
-				'boolean:enabled', true, 'id', $view->getSelection());
+                $message = new SwatMessage(sprintf(
+                    Admin::ngettext(
+                        'One user has been disabled.',
+                        '%s users have been disabled.',
+                        $num
+                    ),
+                    SwatString::numberFormat($num)
+                ));
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One user has been enabled.',
-				'%s users have been enabled.', $num),
-				SwatString::numberFormat($num)));
+                break;
+        }
 
-			break;
+        if ($message !== null) {
+            $this->app->messages->add($message);
+        }
+    }
 
-		case 'disable':
-			SwatDB::updateColumn($this->app->db, 'AdminUser',
-				'boolean:enabled', false, 'id',
-				$view->getSelection());
+    // build phase
 
-			$message = new SwatMessage(sprintf(Admin::ngettext(
-				'One user has been disabled.',
-				'%s users have been disabled.', $num),
-				SwatString::numberFormat($num)));
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-			break;
-		}
+        // set default time zone
+        $date_column =
+            $this->ui->getWidget('index_view')->getColumn('last_login');
 
-		if ($message !== null)
-			$this->app->messages->add($message);
-	}
+        $date_renderer = $date_column->getRendererByPosition();
+        $date_renderer->display_time_zone = $this->app->default_time_zone;
 
+        $this->ui->getWidget('index_view')->getColumn('two_fa')->visible =
+            $this->app->is2FaEnabled();
+    }
 
+    protected function buildActiveNote()
+    {
+        $locale = SwatI18NLocale::get();
 
-	// build phase
+        $class_name = SwatDBClassMap::get('AdminUser');
 
+        $note = $this->ui->getWidget('active_note');
+        $note->visible = true;
+        $note->content = sprintf(
+            Admin::_(
+                'Users become inactive after %s days of inactivity. To ' .
+                'reactivate a user, select the user and choose ' .
+                '“reactivate…” from the menu below.'
+            ),
+            $locale->formatNumber($class_name::EXPIRY_DAYS)
+        );
+    }
 
-	protected function buildInternal()
-	{
-		parent::buildInternal();
+    protected function getTableModel(SwatView $view): SwatTableStore
+    {
+        $instance_id = $this->app->getInstanceId();
 
-		// set default time zone
-		$date_column =
-			$this->ui->getWidget('index_view')->getColumn('last_login');
-
-		$date_renderer = $date_column->getRendererByPosition();
-		$date_renderer->display_time_zone = $this->app->default_time_zone;
-
-		$this->ui->getWidget('index_view')->getColumn('two_fa')->visible =
-			$this->app->is2FaEnabled();
-	}
-
-
-
-
-	protected function buildActiveNote()
-	{
-		$locale = SwatI18NLocale::get();
-
-		$class_name = SwatDBClassMap::get('AdminUser');
-
-		$note = $this->ui->getWidget('active_note');
-		$note->visible = true;
-		$note->content = sprintf(
-			Admin::_(
-				'Users become inactive after %s days of inactivity. To '.
-				'reactivate a user, select the user and choose '.
-				'“reactivate…” from the menu below.'
-			),
-			$locale->formatNumber($class_name::EXPIRY_DAYS)
-		);
-	}
-
-
-
-
-	protected function getTableModel(SwatView $view): SwatTableStore
-	{
-		$instance_id = $this->app->getInstanceId();
-
-		$sql = sprintf(
-			'select AdminUser.id, AdminUser.email, AdminUser.name,
+        $sql = sprintf(
+            'select AdminUser.id, AdminUser.email, AdminUser.name,
 					AdminUser.activation_date, AdminUser.enabled,
 					AdminUserLastLoginView.last_login,
 					AdminUser.two_fa_enabled
@@ -130,78 +137,71 @@ class AdminAdminUserIndex extends AdminIndex
 					AdminUserLastLoginView.usernum = AdminUser.id and
 					AdminUserLastLoginView.instance %s %s
 				order by %s',
-			SwatDB::equalityOperator($instance_id),
-			$this->app->db->quote($instance_id, 'integer'),
-			$this->getOrderByClause($view, 'AdminUser.email')
-		);
+            SwatDB::equalityOperator($instance_id),
+            $this->app->db->quote($instance_id, 'integer'),
+            $this->getOrderByClause($view, 'AdminUser.email')
+        );
 
-		$rows = SwatDB::query($this->app->db, $sql);
-		$active_users = array();
-		$inactive_users = array();
+        $rows = SwatDB::query($this->app->db, $sql);
+        $active_users = [];
+        $inactive_users = [];
 
-		// Build row objects and separate based on active/inactive status.
-		foreach ($rows as $row) {
-			if ($row->activation_date !== null) {
-				$row->activation_date = new SwatDate($row->activation_date);
-			}
+        // Build row objects and separate based on active/inactive status.
+        foreach ($rows as $row) {
+            if ($row->activation_date !== null) {
+                $row->activation_date = new SwatDate($row->activation_date);
+            }
 
-			if ($row->last_login !== null) {
-				$row->last_login = new SwatDate($row->last_login);
-			}
+            if ($row->last_login !== null) {
+                $row->last_login = new SwatDate($row->last_login);
+            }
 
-			$class_name = SwatDBClassMap::get('AdminUser');
+            $class_name = SwatDBClassMap::get('AdminUser');
 
-			$ds = new SwatDetailsStore($row);
-			$user = new $class_name($row);
-			$user->setDatabase($this->app->db);
-			if ($row->last_login instanceof SwatDate) {
-				$user->most_recent_history = new AdminUserHistory();
-				$user->most_recent_history->login_date = $row->last_login;
-			}
+            $ds = new SwatDetailsStore($row);
+            $user = new $class_name($row);
+            $user->setDatabase($this->app->db);
+            if ($row->last_login instanceof SwatDate) {
+                $user->most_recent_history = new AdminUserHistory();
+                $user->most_recent_history->login_date = $row->last_login;
+            }
 
-			$ds->is_active = $user->isActive();
-			if ($ds->is_active) {
-				$ds->active_title = Admin::_('Active');
-				$active_users[] = $ds;
-			} else {
-				$ds->active_title = Admin::_('Inactive');
-				$inactive_users[] = $ds;
-			}
-		}
+            $ds->is_active = $user->isActive();
+            if ($ds->is_active) {
+                $ds->active_title = Admin::_('Active');
+                $active_users[] = $ds;
+            } else {
+                $ds->active_title = Admin::_('Inactive');
+                $inactive_users[] = $ds;
+            }
+        }
 
-		// Build the resulting table store sorted by active/inactive.
-		$store = new SwatTableStore();
+        // Build the resulting table store sorted by active/inactive.
+        $store = new SwatTableStore();
 
-		foreach ($active_users as $ds) {
-			$store->add($ds);
-		}
+        foreach ($active_users as $ds) {
+            $store->add($ds);
+        }
 
-		foreach ($inactive_users as $ds) {
-			$store->add($ds);
-		}
+        foreach ($inactive_users as $ds) {
+            $store->add($ds);
+        }
 
-		// If there are inactive users, show a note with help text.
-		if (count($inactive_users) > 0) {
-			$this->buildActiveNote();
-		}
+        // If there are inactive users, show a note with help text.
+        if (count($inactive_users) > 0) {
+            $this->buildActiveNote();
+        }
 
-		return $store;
-	}
+        return $store;
+    }
 
+    // finalize phase
 
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-user-index-page.css'
-		);
-	}
-
-
+    public function finalize()
+    {
+        parent::finalize();
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-user-index-page.css'
+        );
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/LoginHistory.php
+++ b/Admin/components/AdminUser/LoginHistory.php
@@ -10,7 +10,7 @@
 class AdminAdminUserLoginHistory extends AdminIndex
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -24,10 +24,10 @@ class AdminAdminUserLoginHistory extends AdminIndex
 		$this->navbar->createEntry(Admin::_('Login History'));
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -45,10 +45,10 @@ class AdminAdminUserLoginHistory extends AdminIndex
 		$pager->process();
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -62,8 +62,8 @@ class AdminAdminUserLoginHistory extends AdminIndex
 		$date_renderer->display_time_zone = $this->app->default_time_zone;
 	}
 
-	// }}}
-	// {{{ protected function getTableModel()
+
+
 
 	protected function getTableModel(SwatView $view): ?SwatTableModel
 	{
@@ -89,7 +89,7 @@ class AdminAdminUserLoginHistory extends AdminIndex
 		return $rs;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/Reactivate.php
+++ b/Admin/components/AdminUser/Reactivate.php
@@ -1,114 +1,101 @@
 <?php
 
 /**
- * Reactivate confirmation page for AdminUsers component
+ * Reactivate confirmation page for AdminUsers component.
  *
- * @package   Admin
  * @copyright 2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminAdminUserReactivate extends AdminDBConfirmation
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
+        $this->navbar->popEntry();
+        $this->navbar->createEntry(Admin::_('Reactivate'));
+    }
 
-	protected function initInternal()
-	{
-		parent::initInternal();
-		$this->navbar->popEntry();
-		$this->navbar->createEntry(Admin::_('Reactivate'));
-	}
+    // process phase
 
+    protected function processDBData(): void
+    {
+        parent::processDBData();
 
+        $locale = SwatI18NLocale::get();
 
-	// process phase
+        $now = new SwatDate();
+        $now->toUTC();
 
-
-	protected function processDBData(): void
-	{
-		parent::processDBData();
-
-		$locale = SwatI18NLocale::get();
-
-		$now = new SwatDate();
-		$now->toUTC();
-
-		$sql = sprintf(
-			'update AdminUser set activation_date = %s
+        $sql = sprintf(
+            'update AdminUser set activation_date = %s
 			where id in (%s)',
-			$this->app->db->quote($now->getDate(), 'date'),
-			$this->getItemList('integer')
-		);
+            $this->app->db->quote($now->getDate(), 'date'),
+            $this->getItemList('integer')
+        );
 
-		$num = SwatDB::exec($this->app->db, $sql);
+        $num = SwatDB::exec($this->app->db, $sql);
 
-		$this->app->messages->add(
-			new SwatMessage(
-				sprintf(
-					Admin::ngettext(
-						'One admin user has been reactivated.',
-						'%s admin users have been reactivated.',
-						$num
-					),
-					$locale->formatNumber($num)
-				)
-			)
-		);
+        $this->app->messages->add(
+            new SwatMessage(
+                sprintf(
+                    Admin::ngettext(
+                        'One admin user has been reactivated.',
+                        '%s admin users have been reactivated.',
+                        $num
+                    ),
+                    $locale->formatNumber($num)
+                )
+            )
+        );
+    }
 
-	}
+    // build phase
 
+    public function buildInternal()
+    {
+        parent::buildInternal();
 
-
-	// build phase
-
-
-	public function buildInternal()
-	{
-		parent::buildInternal();
-
-		$users = SwatDB::query(
-			$this->app->db,
-			sprintf(
-				'select name from AdminUser
+        $users = SwatDB::query(
+            $this->app->db,
+            sprintf(
+                'select name from AdminUser
 				where id in (%s)
 				order by name asc',
-				$this->getItemList('integer')
-			),
-			'AdminUserWrapper'
-		);
+                $this->getItemList('integer')
+            ),
+            'AdminUserWrapper'
+        );
 
-		ob_start();
+        ob_start();
 
-		$h3_tag = new SwatHtmlTag('h3');
-		$h3_tag->setContent(
-			Admin::ngettext(
-				'Reactivate the following admin user?',
-				'Reactivate the following admin users?',
-				count($users)
-			)
-		);
-		$h3_tag->display();
+        $h3_tag = new SwatHtmlTag('h3');
+        $h3_tag->setContent(
+            Admin::ngettext(
+                'Reactivate the following admin user?',
+                'Reactivate the following admin users?',
+                count($users)
+            )
+        );
+        $h3_tag->display();
 
-		if (count($users) > 0) {
-			echo '<ul>';
-			foreach ($users as $user) {
-				$li_tag = new SwatHtmlTag('li');
-				$li_tag->setContent($user->name);
-				$li_tag->display();
-			}
-			echo '</ul>';
-		}
+        if (count($users) > 0) {
+            echo '<ul>';
+            foreach ($users as $user) {
+                $li_tag = new SwatHtmlTag('li');
+                $li_tag->setContent($user->name);
+                $li_tag->display();
+            }
+            echo '</ul>';
+        }
 
-		$message = $this->ui->getWidget('confirmation_message');
-		$message->content = ob_get_clean();
-		$message->content_type = 'text/xml';
+        $message = $this->ui->getWidget('confirmation_message');
+        $message->content = ob_get_clean();
+        $message->content_type = 'text/xml';
 
-		if (count($users) === 0) {
-			$this->switchToCancelButton();
-		}
-	}
-
-
+        if (count($users) === 0) {
+            $this->switchToCancelButton();
+        }
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/Reactivate.php
+++ b/Admin/components/AdminUser/Reactivate.php
@@ -65,7 +65,7 @@ class AdminAdminUserReactivate extends AdminDBConfirmation
 				order by name asc',
                 $this->getItemList('integer')
             ),
-            'AdminUserWrapper'
+            AdminUserWrapper::class
         );
 
         ob_start();

--- a/Admin/components/AdminUser/Reactivate.php
+++ b/Admin/components/AdminUser/Reactivate.php
@@ -10,7 +10,7 @@
 class AdminAdminUserReactivate extends AdminDBConfirmation
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -19,10 +19,10 @@ class AdminAdminUserReactivate extends AdminDBConfirmation
 		$this->navbar->createEntry(Admin::_('Reactivate'));
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processDBData
+
 
 	protected function processDBData(): void
 	{
@@ -57,10 +57,10 @@ class AdminAdminUserReactivate extends AdminDBConfirmation
 
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	public function buildInternal()
 	{
@@ -108,7 +108,7 @@ class AdminAdminUserReactivate extends AdminDBConfirmation
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/include/AdminUserTableView.php
+++ b/Admin/components/AdminUser/include/AdminUserTableView.php
@@ -1,28 +1,21 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUserTableView extends SwatTableView
 {
+    protected function getRowClasses($row, $count)
+    {
+        $classes = parent::getRowClasses($row, $count);
 
+        if ($row->is_active) {
+            $classes[] = 'active';
+        } else {
+            $classes[] = 'inactive';
+        }
 
-	protected function getRowClasses($row, $count)
-	{
-		$classes = parent::getRowClasses($row, $count);
-
-		if ($row->is_active) {
-			$classes[] = 'active';
-		} else {
-			$classes[] = 'inactive';
-		}
-
-		return $classes;
-	}
-
-
+        return $classes;
+    }
 }
-
-?>

--- a/Admin/components/AdminUser/include/AdminUserTableView.php
+++ b/Admin/components/AdminUser/include/AdminUserTableView.php
@@ -7,7 +7,7 @@
  */
 class AdminUserTableView extends SwatTableView
 {
-	// {{{ protected function getRowClasses()
+
 
 	protected function getRowClasses($row, $count)
 	{
@@ -22,7 +22,7 @@ class AdminUserTableView extends SwatTableView
 		return $classes;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/include/HistoryCellRenderer.php
+++ b/Admin/components/AdminUser/include/HistoryCellRenderer.php
@@ -9,14 +9,14 @@
  */
 class AdminUserHistoryCellRenderer extends SwatCellRenderer
 {
-	// {{{ public properties
+
 
 	public $date;
 	public $user;
 	public $title;
 
-	// }}}
-	// {{{ public function render()
+
+
 
 	public function render()
 	{
@@ -30,7 +30,7 @@ class AdminUserHistoryCellRenderer extends SwatCellRenderer
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/components/AdminUser/include/HistoryCellRenderer.php
+++ b/Admin/components/AdminUser/include/HistoryCellRenderer.php
@@ -1,36 +1,26 @@
 <?php
 
 /**
- * Custom cell renderer for the history link on AdminUsers index page
+ * Custom cell renderer for the history link on AdminUsers index page.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUserHistoryCellRenderer extends SwatCellRenderer
 {
+    public $date;
+    public $user;
+    public $title;
 
-
-	public $date;
-	public $user;
-	public $title;
-
-
-
-
-	public function render()
-	{
-		if ($this->date !== null) {
-			echo ' (';
-			$anchor = new SwatHtmlTag('a');
-			$anchor->setContent($this->title);
-			$anchor->href = sprintf('AdminUser/Details&id=%s', $this->user);
-			$anchor->display();
-			echo ')';
-		}
-	}
-
-
+    public function render()
+    {
+        if ($this->date !== null) {
+            echo ' (';
+            $anchor = new SwatHtmlTag('a');
+            $anchor->setContent($this->title);
+            $anchor->href = sprintf('AdminUser/Details&id=%s', $this->user);
+            $anchor->display();
+            echo ')';
+        }
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminComponent.php
+++ b/Admin/dataobjects/AdminComponent.php
@@ -13,7 +13,7 @@
  */
 class AdminComponent extends SwatDBDataObject
 {
-	// {{{ public properties
+
 
 	/**
 	 * Unique identifier
@@ -75,8 +75,8 @@ class AdminComponent extends SwatDBDataObject
 	 */
 	public $visible;
 
-	// }}}
-	// {{{ public function loadByShortname()
+
+
 
 	/**
 	 * Loads an admin component by its shortname
@@ -114,8 +114,8 @@ class AdminComponent extends SwatDBDataObject
 		return true;
 	}
 
-	// }}}
-	// {{{ public function loadFromShortname()
+
+
 
 	/**
 	 * Loads an admin component by its shortname
@@ -133,8 +133,8 @@ class AdminComponent extends SwatDBDataObject
 		return $this->loadByShortname($shortname);
 	}
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -147,8 +147,8 @@ class AdminComponent extends SwatDBDataObject
 		);
 	}
 
-	// }}}
-	// {{{ protected function loadSubComponents()
+
+
 
 	/**
 	 * @return AdminSubComponentWrapper
@@ -167,8 +167,8 @@ class AdminComponent extends SwatDBDataObject
 		);
 	}
 
-	// }}}
-	// {{{ protected function loadGroups()
+
+
 
 	/**
 	 * @return AdminGroupWrapper
@@ -189,7 +189,7 @@ class AdminComponent extends SwatDBDataObject
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminComponent.php
+++ b/Admin/dataobjects/AdminComponent.php
@@ -131,7 +131,7 @@ class AdminComponent extends SwatDBDataObject
 
         $this->registerInternalProperty(
             'section',
-            SwatDBClassMap::get('AdminSection')
+            SwatDBClassMap::get(AdminSection::class)
         );
     }
 
@@ -148,7 +148,7 @@ class AdminComponent extends SwatDBDataObject
         return SwatDB::query(
             $this->db,
             $sql,
-            SwatDBClassMap::get('AdminSubComponentWrapper')
+            SwatDBClassMap::get(AdminSubComponentWrapper::class)
         );
     }
 
@@ -167,7 +167,7 @@ class AdminComponent extends SwatDBDataObject
         return SwatDB::query(
             $this->db,
             $sql,
-            SwatDBClassMap::get('AdminGroupWrapper')
+            SwatDBClassMap::get(AdminGroupWrapper::class)
         );
     }
 }

--- a/Admin/dataobjects/AdminComponent.php
+++ b/Admin/dataobjects/AdminComponent.php
@@ -9,6 +9,17 @@
  *
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property int $id
+ * @property ?string $shortname
+ * @property ?string $title
+ * @property ?string $description
+ * @property int $displayorder
+ * @property bool $enabled
+ * @property bool $visible
+ * @property AdminSection $section
+ * @property AdminSubComponentWrapper $sub_components
+ * @property AdminGroupWrapper $groups
  */
 class AdminComponent extends SwatDBDataObject
 {
@@ -46,7 +57,7 @@ class AdminComponent extends SwatDBDataObject
      * Order of display of this component relative to other components in this
      * component's section.
      *
-     * @var string
+     * @var int
      */
     public $displayorder;
 

--- a/Admin/dataobjects/AdminComponent.php
+++ b/Admin/dataobjects/AdminComponent.php
@@ -1,195 +1,173 @@
 <?php
 
 /**
- * Component to perform a particular administration task
+ * Component to perform a particular administration task.
  *
  * Components are the main organizational unit in the Admin package. Each
  * component is composed of a set of AdminPage objects that work together to
  * administer an item.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminComponent extends SwatDBDataObject
 {
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
+    /**
+     * Shortname of this component.
+     *
+     * This shortname is used for building Admin page URIs.
+     *
+     * @var string
+     */
+    public $shortname;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    /**
+     * Title of this component.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * Shortname of this component
-	 *
-	 * This shortname is used for building Admin page URIs.
-	 *
-	 * @var string
-	 */
-	public $shortname;
+    /**
+     * Optional description of this component.
+     *
+     * @var string
+     */
+    public $description;
 
-	/**
-	 * Title of this component
-	 *
-	 * @var string
-	 */
-	public $title;
+    /**
+     * Order of display of this component relative to other components in this
+     * component's section.
+     *
+     * @var string
+     */
+    public $displayorder;
 
-	/**
-	 * Optional description of this component
-	 *
-	 * @var string
-	 */
-	public $description;
+    /**
+     * Whether or not this component is enabled.
+     *
+     * If a component is not enabled, it is inaccessible to all users. The
+     * <i>$enabled</i> property overrides the {@link AdminComponent::$visible}
+     * property.
+     *
+     * @var bool
+     */
+    public $enabled;
 
-	/**
-	 * Order of display of this component relative to other components in this
-	 * component's section
-	 *
-	 * @var string
-	 */
-	public $displayorder;
+    /**
+     * Whether or not links to this component should be shown in the admin.
+     *
+     * This property does not affect the ability of users to load this
+     * component. It only affects whether or not links to this component are
+     * displayed.
+     *
+     * @var bool
+     */
+    public $visible;
 
-	/**
-	 * Whether or not this component is enabled
-	 *
-	 * If a component is not enabled, it is inaccessible to all users. The
-	 * <i>$enabled</i> property overrides the {@link AdminComponent::$visible}
-	 * property.
-	 *
-	 * @var boolean
-	 */
-	public $enabled;
+    /**
+     * Loads an admin component by its shortname.
+     *
+     * @param string $shortname the shortname of the admin component to load
+     *
+     * @return bool true if loading this component was successful and
+     *              false if a component with the given shortname does not
+     *              exist
+     */
+    public function loadByShortname($shortname)
+    {
+        $this->checkDB();
 
-	/**
-	 * Whether or not links to this component should be shown in the admin
-	 *
-	 * This property does not affect the ability of users to load this
-	 * component. It only affects whether or not links to this component are
-	 * displayed.
-	 *
-	 * @var boolean
-	 */
-	public $visible;
+        $row = null;
 
+        if ($this->table !== null) {
+            $sql = sprintf(
+                'select * from %s where shortname = %s',
+                $this->table,
+                $this->db->quote($shortname, 'text')
+            );
 
+            $rs = SwatDB::query($this->db, $sql, null);
+            $row = $rs->fetchRow(MDB2_FETCHMODE_ASSOC);
+        }
 
+        if ($row === null) {
+            return false;
+        }
 
-	/**
-	 * Loads an admin component by its shortname
-	 *
-	 * @param string $shortname the shortname of the admin component to load.
-	 *
-	 * @return boolean true if loading this component was successful and
-	 *                  false if a component with the given shortname does not
-	 *                  exist.
-	 */
-	public function loadByShortname($shortname)
-	{
-		$this->checkDB();
+        $this->initFromRow($row);
+        $this->generatePropertyHashes();
 
-		$row = null;
+        return true;
+    }
 
-		if ($this->table !== null) {
-			$sql = sprintf(
-				'select * from %s where shortname = %s',
-				$this->table,
-				$this->db->quote($shortname, 'text')
-			);
+    /**
+     * Loads an admin component by its shortname.
+     *
+     * @param string $shortname the shortname of the admin component to load
+     *
+     * @return bool true if loading this component was successful and
+     *              false if a component with the given shortname does not
+     *              exist
+     *
+     * @deprecated Use {@link AdminComponent::loadByShortname}
+     */
+    public function loadFromShortname($shortname)
+    {
+        return $this->loadByShortname($shortname);
+    }
 
-			$rs = SwatDB::query($this->db, $sql, null);
-			$row = $rs->fetchRow(MDB2_FETCHMODE_ASSOC);
-		}
+    protected function init()
+    {
+        $this->table = 'AdminComponent';
+        $this->id_field = 'integer:id';
 
-		if ($row === null) {
-			return false;
-		}
+        $this->registerInternalProperty(
+            'section',
+            SwatDBClassMap::get('AdminSection')
+        );
+    }
 
-		$this->initFromRow($row);
-		$this->generatePropertyHashes();
+    /**
+     * @return AdminSubComponentWrapper
+     */
+    protected function loadSubComponents()
+    {
+        $sql = sprintf(
+            'select * from AdminSubComponent where component = %s',
+            $this->db->quote($this->id, 'integer')
+        );
 
-		return true;
-	}
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get('AdminSubComponentWrapper')
+        );
+    }
 
-
-
-
-	/**
-	 * Loads an admin component by its shortname
-	 *
-	 * @param string $shortname the shortname of the admin component to load.
-	 *
-	 * @return boolean true if loading this component was successful and
-	 *                  false if a component with the given shortname does not
-	 *                  exist.
-	 *
-	 * @deprecated Use {@link AdminComponent::loadByShortname}
-	 */
-	public function loadFromShortname($shortname)
-	{
-		return $this->loadByShortname($shortname);
-	}
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminComponent';
-		$this->id_field = 'integer:id';
-
-		$this->registerInternalProperty(
-			'section',
-			SwatDBClassMap::get('AdminSection')
-		);
-	}
-
-
-
-
-	/**
-	 * @return AdminSubComponentWrapper
-	 */
-	protected function loadSubComponents()
-	{
-		$sql = sprintf(
-			'select * from AdminSubComponent where component = %s',
-			$this->db->quote($this->id, 'integer')
-		);
-
-		return SwatDB::query(
-			$this->db,
-			$sql,
-			SwatDBClassMap::get('AdminSubComponentWrapper')
-		);
-	}
-
-
-
-
-	/**
-	 * @return AdminGroupWrapper
-	 */
-	protected function loadGroups()
-	{
-		$sql = sprintf(
-			'select * from AdminGroup
+    /**
+     * @return AdminGroupWrapper
+     */
+    protected function loadGroups()
+    {
+        $sql = sprintf(
+            'select * from AdminGroup
 			inner join AdminComponentAdminGroupBinding as binding on
 				binding.groupnum = AdminGroup.id and binding.component = %s',
-			$this->db->quote($this->id, 'integer')
-		);
+            $this->db->quote($this->id, 'integer')
+        );
 
-		return SwatDB::query(
-			$this->db,
-			$sql,
-			SwatDBClassMap::get('AdminGroupWrapper')
-		);
-	}
-
-
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            SwatDBClassMap::get('AdminGroupWrapper')
+        );
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminComponent.php
+++ b/Admin/dataobjects/AdminComponent.php
@@ -10,16 +10,16 @@
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property int $id
- * @property ?string $shortname
- * @property ?string $title
- * @property ?string $description
- * @property int $displayorder
- * @property bool $enabled
- * @property bool $visible
- * @property AdminSection $section
+ * @property int                      $id
+ * @property ?string                  $shortname
+ * @property ?string                  $title
+ * @property ?string                  $description
+ * @property int                      $displayorder
+ * @property bool                     $enabled
+ * @property bool                     $visible
+ * @property AdminSection             $section
  * @property AdminSubComponentWrapper $sub_components
- * @property AdminGroupWrapper $groups
+ * @property AdminGroupWrapper        $groups
  */
 class AdminComponent extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminComponentWrapper.php
+++ b/Admin/dataobjects/AdminComponentWrapper.php
@@ -1,25 +1,19 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminComponent objects
+ * A recordset wrapper class for AdminComponent objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminComponent
  */
 class AdminComponentWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminComponent';
-		$this->index_field = 'id';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminComponent';
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminComponentWrapper.php
+++ b/Admin/dataobjects/AdminComponentWrapper.php
@@ -13,7 +13,7 @@ class AdminComponentWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminComponent';
+        $this->row_wrapper_class = AdminComponent::class;
         $this->index_field = 'id';
     }
 }

--- a/Admin/dataobjects/AdminComponentWrapper.php
+++ b/Admin/dataobjects/AdminComponentWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminComponentWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -19,7 +19,7 @@ class AdminComponentWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminGroup.php
+++ b/Admin/dataobjects/AdminGroup.php
@@ -10,8 +10,8 @@
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property int $id
- * @property ?string $title
+ * @property int                   $id
+ * @property ?string               $title
  * @property AdminComponentWrapper $components
  */
 class AdminGroup extends SwatDBDataObject

--- a/Admin/dataobjects/AdminGroup.php
+++ b/Admin/dataobjects/AdminGroup.php
@@ -1,67 +1,54 @@
 <?php
 
 /**
- * Group of admin users
+ * Group of admin users.
  *
  * Groups are used to oranize users in the Admin package. Groups are assigned
  * a set of component access rights. Users are assigned to groups. In this way,
  * users receive access to only certain components.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminGroup extends SwatDBDataObject
 {
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
+    /**
+     * Title of this group.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    protected function init()
+    {
+        $this->table = 'AdminGroup';
+        $this->id_field = 'integer:id';
+    }
 
-	/**
-	 * Title of this group
-	 *
-	 * @var string
-	 */
-	public $title;
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminGroup';
-		$this->id_field = 'integer:id';
-	}
-
-
-
-
-	/**
-	 * Loads the components that this group has access to
-	 *
-	 * @return AdminComponentWrapper the components this group has access to.
-	 */
-	protected function loadComponents()
-	{
-		$sql = sprintf(
-			'select AdminComponent.*
+    /**
+     * Loads the components that this group has access to.
+     *
+     * @return AdminComponentWrapper the components this group has access to
+     */
+    protected function loadComponents()
+    {
+        $sql = sprintf(
+            'select AdminComponent.*
 			from AdminComponent
 				inner join AdminComponentAdmingroupBinding on
 					AdminComponentAdminGroupBinding.component =
 						AdminComponent.id
 			where groupnum = %s',
-			$this->db->quote($this->id, 'integer')
-		);
+            $this->db->quote($this->id, 'integer')
+        );
 
-		return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
-	}
-
-
+        return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminGroup.php
+++ b/Admin/dataobjects/AdminGroup.php
@@ -9,6 +9,10 @@
  *
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property int $id
+ * @property ?string $title
+ * @property AdminComponentWrapper $components
  */
 class AdminGroup extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminGroup.php
+++ b/Admin/dataobjects/AdminGroup.php
@@ -49,6 +49,6 @@ class AdminGroup extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
+        return SwatDB::query($this->db, $sql, AdminComponentWrapper::class);
     }
 }

--- a/Admin/dataobjects/AdminGroup.php
+++ b/Admin/dataobjects/AdminGroup.php
@@ -13,7 +13,7 @@
  */
 class AdminGroup extends SwatDBDataObject
 {
-	// {{{ public properties
+
 
 	/**
 	 * Unique identifier
@@ -29,8 +29,8 @@ class AdminGroup extends SwatDBDataObject
 	 */
 	public $title;
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -38,8 +38,8 @@ class AdminGroup extends SwatDBDataObject
 		$this->id_field = 'integer:id';
 	}
 
-	// }}}
-	// {{{ protected function loadComponents()
+
+
 
 	/**
 	 * Loads the components that this group has access to
@@ -61,7 +61,7 @@ class AdminGroup extends SwatDBDataObject
 		return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminGroupWrapper.php
+++ b/Admin/dataobjects/AdminGroupWrapper.php
@@ -1,25 +1,19 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminGroup objects
+ * A recordset wrapper class for AdminGroup objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminGroup
  */
 class AdminGroupWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminGroup';
-		$this->index_field = 'id';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminGroup';
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminGroupWrapper.php
+++ b/Admin/dataobjects/AdminGroupWrapper.php
@@ -13,7 +13,7 @@ class AdminGroupWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminGroup';
+        $this->row_wrapper_class = AdminGroup::class;
         $this->index_field = 'id';
     }
 }

--- a/Admin/dataobjects/AdminGroupWrapper.php
+++ b/Admin/dataobjects/AdminGroupWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminGroupWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -19,7 +19,7 @@ class AdminGroupWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminSection.php
+++ b/Admin/dataobjects/AdminSection.php
@@ -10,13 +10,12 @@
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property int $id
- * @property ?string $title
- * @property ?string $description
- * @property int $display_order
- * @property bool $visible
+ * @property int                   $id
+ * @property ?string               $title
+ * @property ?string               $description
+ * @property int                   $display_order
+ * @property bool                  $visible
  * @property AdminComponentWrapper $components
- *
  */
 class AdminSection extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminSection.php
+++ b/Admin/dataobjects/AdminSection.php
@@ -65,6 +65,6 @@ class AdminSection extends SwatDBDataObject
             $this->db->quote($this->id, 'integer')
         );
 
-        return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
+        return SwatDB::query($this->db, $sql, AdminComponentWrapper::class);
     }
 }

--- a/Admin/dataobjects/AdminSection.php
+++ b/Admin/dataobjects/AdminSection.php
@@ -1,81 +1,70 @@
 <?php
 
 /**
- * Section to group multiple components together
+ * Section to group multiple components together.
  *
  * Sections group components together for organization and display. Similar
  * components should be grouped in the same section. Sections are not related
  * to component access.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSection extends SwatDBDataObject
 {
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
+    /**
+     * Title of this section.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    /**
+     * Optional description of this section.
+     *
+     * @var string
+     */
+    public $description;
 
-	/**
-	 * Title of this section
-	 *
-	 * @var string
-	 */
-	public $title;
+    /**
+     * Order of display of this section relative ot other sections.
+     *
+     * @var int
+     */
+    public $displayorder;
 
-	/**
-	 * Optional description of this section
-	 *
-	 * @var string
-	 */
-	public $description;
+    /**
+     * Whether or not this section is shown when sections are displayed.
+     *
+     * @var bool
+     */
+    public $visible;
 
-	/**
-	 * Order of display of this section relative ot other sections
-	 *
-	 * @var integer
-	 */
-	public $displayorder;
+    protected function init()
+    {
+        $this->table = 'AdminSection';
+        $this->id_field = 'integer:id';
+    }
 
-	/**
-	 * Whether or not this section is shown when sections are displayed
-	 *
-	 * @var boolean
-	 */
-	public $visible;
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminSection';
-		$this->id_field = 'integer:id';
-	}
-
-
-
-
-	/**
-	 * @return AdminComponentWrapper
-	 */
-	protected function loadComponents()
-	{
-		$sql = sprintf('select * from AdminComponent
+    /**
+     * @return AdminComponentWrapper
+     */
+    protected function loadComponents()
+    {
+        $sql = sprintf(
+            'select * from AdminComponent
 			where section = %s
 			order by displayorder, title',
-			$this->db->quote($this->id, 'integer'));
+            $this->db->quote($this->id, 'integer')
+        );
 
-		return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
-	}
-
-
+        return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminSection.php
+++ b/Admin/dataobjects/AdminSection.php
@@ -9,6 +9,14 @@
  *
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property int $id
+ * @property ?string $title
+ * @property ?string $description
+ * @property int $display_order
+ * @property bool $visible
+ * @property AdminComponentWrapper $components
+ *
  */
 class AdminSection extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminSection.php
+++ b/Admin/dataobjects/AdminSection.php
@@ -13,7 +13,7 @@
  */
 class AdminSection extends SwatDBDataObject
 {
-	// {{{ public properties
+
 
 	/**
 	 * Unique identifier
@@ -50,8 +50,8 @@ class AdminSection extends SwatDBDataObject
 	 */
 	public $visible;
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -59,8 +59,8 @@ class AdminSection extends SwatDBDataObject
 		$this->id_field = 'integer:id';
 	}
 
-	// }}}
-	// {{{ protected function loadComponents()
+
+
 
 	/**
 	 * @return AdminComponentWrapper
@@ -75,7 +75,7 @@ class AdminSection extends SwatDBDataObject
 		return SwatDB::query($this->db, $sql, 'AdminComponentWrapper');
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminSectionWrapper.php
+++ b/Admin/dataobjects/AdminSectionWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminSectionWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -19,7 +19,7 @@ class AdminSectionWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminSectionWrapper.php
+++ b/Admin/dataobjects/AdminSectionWrapper.php
@@ -13,7 +13,7 @@ class AdminSectionWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminSection';
+        $this->row_wrapper_class = AdminSection::class;
         $this->index_field = 'id';
     }
 }

--- a/Admin/dataobjects/AdminSectionWrapper.php
+++ b/Admin/dataobjects/AdminSectionWrapper.php
@@ -1,25 +1,19 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminSection objects
+ * A recordset wrapper class for AdminSection objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminSection
  */
 class AdminSectionWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminSection';
-		$this->index_field = 'id';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminSection';
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminSubComponent.php
+++ b/Admin/dataobjects/AdminSubComponent.php
@@ -9,16 +9,15 @@
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property int $id
- * @property ?string $shortname
- * @property ?string $title
- * @property ?string $description
- * @property int $display_order
- * @property bool $enabled
- * @property bool $visible
- * @property AdminSection $section
+ * @property int            $id
+ * @property ?string        $shortname
+ * @property ?string        $title
+ * @property ?string        $description
+ * @property int            $display_order
+ * @property bool           $enabled
+ * @property bool           $visible
+ * @property AdminSection   $section
  * @property AdminComponent $component
- *
  */
 class AdminSubComponent extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminSubComponent.php
+++ b/Admin/dataobjects/AdminSubComponent.php
@@ -1,156 +1,141 @@
 <?php
 
 /**
- * Sub-Component to perform a particular administration task within a component
+ * Sub-Component to perform a particular administration task within a component.
  *
  * A part of a component designed to help achieve the complition of an
  * administative task.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminSubComponent extends SwatDBDataObject
 {
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
+    /**
+     * Shortname of this sub-component.
+     *
+     * This shortname is used for building Admin page URIs.
+     *
+     * @var string
+     */
+    public $shortname;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    /**
+     * Title of this sub-component.
+     *
+     * @var string
+     */
+    public $title;
 
-	/**
-	 * Shortname of this sub-component
-	 *
-	 * This shortname is used for building Admin page URIs.
-	 *
-	 * @var string
-	 */
-	public $shortname;
+    /**
+     * Optional description of this sub-component.
+     *
+     * @var string
+     */
+    public $description;
 
-	/**
-	 * Title of this sub-component
-	 *
-	 * @var string
-	 */
-	public $title;
+    /**
+     * Order of display of this sub-component relative to other sub-components
+     * in this sub-component's section.
+     *
+     * @var string
+     */
+    public $displayorder;
 
-	/**
-	 * Optional description of this sub-component
-	 *
-	 * @var string
-	 */
-	public $description;
+    /**
+     * Whether or not this sub-component is enabled.
+     *
+     * If a sub-component is not enabled, it is inaccessible to all users. The
+     * <i>$enabled</i> property overrides the
+     * {@link AdminSubComponent::$visible} property.
+     *
+     * @var bool
+     */
+    public $enabled;
 
-	/**
-	 * Order of display of this sub-component relative to other sub-components
-	 * in this sub-component's section
-	 *
-	 * @var string
-	 */
-	public $displayorder;
+    /**
+     * Whether or not links to this sub-component should be shown in the admin.
+     *
+     * This property does not affect the ability of users to load this
+     * sub-component. It only affects whether or not links to this
+     * sub-component are displayed.
+     *
+     * @var bool
+     */
+    public $visible;
 
-	/**
-	 * Whether or not this sub-component is enabled
-	 *
-	 * If a sub-component is not enabled, it is inaccessible to all users. The
-	 * <i>$enabled</i> property overrides the
-	 * {@link AdminSubComponent::$visible} property.
-	 *
-	 * @var boolean
-	 */
-	public $enabled;
+    /**
+     * Loads an admin sub-component by its shortname.
+     *
+     * @param string $shortname the shortname of the sub-component to load
+     *
+     * @return bool true if loading this sub-component was successful and
+     *              false if a sub-component with the given shortname does
+     *              not exist
+     */
+    public function loadByShortname($shortname)
+    {
+        $this->checkDB();
 
-	/**
-	 * Whether or not links to this sub-component should be shown in the admin
-	 *
-	 * This property does not affect the ability of users to load this
-	 * sub-component. It only affects whether or not links to this
-	 * sub-component are displayed.
-	 *
-	 * @var boolean
-	 */
-	public $visible;
+        $row = null;
 
+        if ($this->table !== null) {
+            $sql = sprintf(
+                'select * from %s where shortname = %s',
+                $this->table,
+                $this->db->quote($shortname, 'text')
+            );
 
+            $rs = SwatDB::query($this->db, $sql, null);
+            $row = $rs->fetchRow(MDB2_FETCHMODE_ASSOC);
+        }
 
+        if ($row === null) {
+            return false;
+        }
 
-	/**
-	 * Loads an admin sub-component by its shortname
-	 *
-	 * @param string $shortname the shortname of the sub-component to load.
-	 *
-	 * @return boolean true if loading this sub-component was successful and
-	 *                  false if a sub-component with the given shortname does
-	 *                  not exist.
-	 */
-	public function loadByShortname($shortname)
-	{
-		$this->checkDB();
+        $this->initFromRow($row);
+        $this->generatePropertyHashes();
 
-		$row = null;
+        return true;
+    }
 
-		if ($this->table !== null) {
-			$sql = sprintf(
-				'select * from %s where shortname = %s',
-				$this->table,
-				$this->db->quote($shortname, 'text')
-			);
+    /**
+     * Loads an admin sub-component by its shortname.
+     *
+     * @param string $shortname the shortname of the sub-component to load
+     *
+     * @return bool true if loading this sub-component was successful and
+     *              false if a sub-component with the given shortname does
+     *              not exist
+     *
+     * @deprecated Use {@link AdminSubComponent::loadByShortname}
+     */
+    public function loadFromShortname($shortname)
+    {
+        return $this->loadByShortname($shortname);
+    }
 
-			$rs = SwatDB::query($this->db, $sql, null);
-			$row = $rs->fetchRow(MDB2_FETCHMODE_ASSOC);
-		}
+    protected function init()
+    {
+        $this->table = 'AdminSubComponent';
+        $this->id_field = 'integer:id';
 
-		if ($row === null) {
-			return false;
-		}
+        $this->registerInternalProperty(
+            'section',
+            SwatDBClassMap::get('AdminSection')
+        );
 
-		$this->initFromRow($row);
-		$this->generatePropertyHashes();
-		return true;
-	}
-
-
-
-
-	/**
-	 * Loads an admin sub-component by its shortname
-	 *
-	 * @param string $shortname the shortname of the sub-component to load.
-	 *
-	 * @return boolean true if loading this sub-component was successful and
-	 *                  false if a sub-component with the given shortname does
-	 *                  not exist.
-	 *
-	 * @deprecated Use {@link AdminSubComponent::loadByShortname}
-	 */
-	public function loadFromShortname($shortname)
-	{
-		return $this->loadByShortname($shortname);
-	}
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminSubComponent';
-		$this->id_field = 'integer:id';
-
-		$this->registerInternalProperty(
-			'section',
-			SwatDBClassMap::get('AdminSection')
-		);
-
-		$this->registerInternalProperty(
-			'component',
-			SwatDBClassMap::get('AdminComponent')
-		);
-	}
-
-
+        $this->registerInternalProperty(
+            'component',
+            SwatDBClassMap::get('AdminComponent')
+        );
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminSubComponent.php
+++ b/Admin/dataobjects/AdminSubComponent.php
@@ -12,7 +12,7 @@
  */
 class AdminSubComponent extends SwatDBDataObject
 {
-	// {{{ public properties
+
 
 	/**
 	 * Unique identifier
@@ -74,8 +74,8 @@ class AdminSubComponent extends SwatDBDataObject
 	 */
 	public $visible;
 
-	// }}}
-	// {{{ public function loadByShortname()
+
+
 
 	/**
 	 * Loads an admin sub-component by its shortname
@@ -112,8 +112,8 @@ class AdminSubComponent extends SwatDBDataObject
 		return true;
 	}
 
-	// }}}
-	// {{{ public function loadFromShortname()
+
+
 
 	/**
 	 * Loads an admin sub-component by its shortname
@@ -131,8 +131,8 @@ class AdminSubComponent extends SwatDBDataObject
 		return $this->loadByShortname($shortname);
 	}
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -150,7 +150,7 @@ class AdminSubComponent extends SwatDBDataObject
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminSubComponent.php
+++ b/Admin/dataobjects/AdminSubComponent.php
@@ -130,12 +130,12 @@ class AdminSubComponent extends SwatDBDataObject
 
         $this->registerInternalProperty(
             'section',
-            SwatDBClassMap::get('AdminSection')
+            SwatDBClassMap::get(AdminSection::class)
         );
 
         $this->registerInternalProperty(
             'component',
-            SwatDBClassMap::get('AdminComponent')
+            SwatDBClassMap::get(AdminComponent::class)
         );
     }
 }

--- a/Admin/dataobjects/AdminSubComponent.php
+++ b/Admin/dataobjects/AdminSubComponent.php
@@ -8,6 +8,17 @@
  *
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property int $id
+ * @property ?string $shortname
+ * @property ?string $title
+ * @property ?string $description
+ * @property int $display_order
+ * @property bool $enabled
+ * @property bool $visible
+ * @property AdminSection $section
+ * @property AdminComponent $component
+ *
  */
 class AdminSubComponent extends SwatDBDataObject
 {
@@ -45,7 +56,7 @@ class AdminSubComponent extends SwatDBDataObject
      * Order of display of this sub-component relative to other sub-components
      * in this sub-component's section.
      *
-     * @var string
+     * @var int
      */
     public $displayorder;
 

--- a/Admin/dataobjects/AdminSubComponentWrapper.php
+++ b/Admin/dataobjects/AdminSubComponentWrapper.php
@@ -1,25 +1,19 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminSubComponent objects
+ * A recordset wrapper class for AdminSubComponent objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminSubComponent
  */
 class AdminSubComponentWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminSubComponent';
-		$this->index_field = 'id';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminSubComponent';
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminSubComponentWrapper.php
+++ b/Admin/dataobjects/AdminSubComponentWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminSubComponentWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -19,7 +19,7 @@ class AdminSubComponentWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminSubComponentWrapper.php
+++ b/Admin/dataobjects/AdminSubComponentWrapper.php
@@ -13,7 +13,7 @@ class AdminSubComponentWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminSubComponent';
+        $this->row_wrapper_class = AdminSubComponent::class;
         $this->index_field = 'id';
     }
 }

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -10,7 +10,7 @@
  */
 class AdminUser extends SwatDBDataObject
 {
-	// {{{ class constants
+
 
 	/**
 	 * The number of days after which a user is considered inactive
@@ -22,8 +22,8 @@ class AdminUser extends SwatDBDataObject
 	 */
 	const EXPIRY_DAYS = 90;
 
-	// }}}
-	// {{{ public properties
+
+
 
 	/**
 	 * Unique identifier
@@ -147,8 +147,8 @@ class AdminUser extends SwatDBDataObject
 	 */
 	public $two_fa_timeslice;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * @var SiteInstance
@@ -160,8 +160,8 @@ class AdminUser extends SwatDBDataObject
 	 */
 	protected $two_fa_authenticated = false;
 
-	// }}}
-	// {{{ public function isAuthenticated()
+
+
 
 	/**
 	 * Checks if a user is authenticated for an admin application
@@ -227,8 +227,8 @@ class AdminUser extends SwatDBDataObject
 		return $authenticated;
 	}
 
-	// }}}
-	// {{{ public function hasAccess()
+
+
 
 	/**
 	 * Gets whether or not this user has access to the given component
@@ -257,8 +257,8 @@ class AdminUser extends SwatDBDataObject
 		return SwatDB::queryOne($this->db, $sql);
 	}
 
-	// }}}
-	// {{{ public function hasAccessByShortname()
+
+
 
 	/**
 	 * Gets whether or not this user has access to the given component
@@ -290,8 +290,8 @@ class AdminUser extends SwatDBDataObject
 		return SwatDB::queryOne($this->db, $sql);
 	}
 
-	// }}}
-	// {{{ public function setPasswordHash()
+
+
 
 	/**
 	 * Sets this account's password hash
@@ -307,8 +307,8 @@ class AdminUser extends SwatDBDataObject
 		$this->password_salt = null;
 	}
 
-	// }}}
-	// {{{ public function resetPassword()
+
+
 
 	/**
 	 * Resets this user's password
@@ -350,8 +350,8 @@ class AdminUser extends SwatDBDataObject
 		return $password_tag;
 	}
 
-	// }}}
-	// {{{ public function loadFromEmail()
+
+
 
 	/**
 	 * Loads a user from the database with just an email address
@@ -383,8 +383,8 @@ class AdminUser extends SwatDBDataObject
 		return $this->load($id);
 	}
 
-	// }}}
-	// {{{ public function setInstance()
+
+
 
 	/**
 	 * Sets the instance to use when loading instance-specific information for
@@ -397,8 +397,8 @@ class AdminUser extends SwatDBDataObject
 		$this->instance = $instance;
 	}
 
-	// }}}
-	// {{{ public function isActive()
+
+
 
 	/**
 	 * Checks to see if this user is active
@@ -448,24 +448,24 @@ class AdminUser extends SwatDBDataObject
 		return $is_active;
 	}
 
-	// }}}
-	// {{{ public function set2FaAuthenticated()
+
+
 
 	public function set2FaAuthenticated($authenticated = true)
 	{
 		$this->two_fa_authenticated = $authenticated;
 	}
 
-	// }}}
-	// {{{ public function is2FaAuthenticated()
+
+
 
 	public function is2FaAuthenticated()
 	{
 		return $this->two_fa_authenticated;
 	}
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -476,8 +476,8 @@ class AdminUser extends SwatDBDataObject
 		$this->registerDateProperty('activation_date');
 	}
 
-	// }}}
-	// {{{ protected function loadHistory()
+
+
 
 	/**
 	 * Gets user history for this user
@@ -511,8 +511,8 @@ class AdminUser extends SwatDBDataObject
 		return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
 	}
 
-	// }}}
-	// {{{ protected function loadMostRecentHistory()
+
+
 
 	/**
 	 * Gets most recent login history for this user
@@ -551,8 +551,8 @@ class AdminUser extends SwatDBDataObject
 		)->getFirst();
 	}
 
-	// }}}
-	// {{{ protected function loadInstances()
+
+
 
 	/**
 	 * Load the Instances that this user has access to
@@ -574,8 +574,8 @@ class AdminUser extends SwatDBDataObject
 		return SwatDB::query($this->db, $sql, $wrapper_class);
 	}
 
-	// }}}
-	// {{{ protected function loadGroups()
+
+
 
 	/**
 	 * Loads the Groups that this user has access to
@@ -596,8 +596,8 @@ class AdminUser extends SwatDBDataObject
 		return SwatDB::query($this->db, $sql, 'AdminGroupWrapper');
 	}
 
-	// }}}
-	// {{{ protected function getSerializablePrivateProperties()
+
+
 
 	protected function getSerializablePrivateProperties()
 	{
@@ -606,7 +606,7 @@ class AdminUser extends SwatDBDataObject
 		return $properties;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -8,25 +8,25 @@
  *
  * @see       AdminGroup
  *
- * @property int $id
- * @property string $email
- * @property string $name
- * @property string $password
- * @property ?string $password_salt
- * @property ?string $password_tag
- * @property ?SwatDate $password_tag_date
- * @property bool $force_change_password
- * @property bool $enabled
- * @property string $menu_state
- * @property bool $all_instances
- * @property ?SwatDate $activation_date
- * @property ?string $two_fa_secret
- * @property int $two_fa_timeslice
- * @property SiteInstance $instance
+ * @property int                     $id
+ * @property string                  $email
+ * @property string                  $name
+ * @property string                  $password
+ * @property ?string                 $password_salt
+ * @property ?string                 $password_tag
+ * @property ?SwatDate               $password_tag_date
+ * @property bool                    $force_change_password
+ * @property bool                    $enabled
+ * @property string                  $menu_state
+ * @property bool                    $all_instances
+ * @property ?SwatDate               $activation_date
+ * @property ?string                 $two_fa_secret
+ * @property int                     $two_fa_timeslice
+ * @property SiteInstance            $instance
  * @property AdminUserHistoryWrapper $history
- * @property AdminUserHistory $most_recent_history
- * @property SiteInstanceWrapper $instances
- * @property AdminGroupWrapper $groups
+ * @property AdminUserHistory        $most_recent_history
+ * @property SiteInstanceWrapper     $instances
+ * @property AdminGroupWrapper       $groups
  */
 class AdminUser extends SwatDBDataObject
 {

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -461,7 +461,7 @@ class AdminUser extends SwatDBDataObject
             $this->db->quote($instance_id, 'integer'),
         );
 
-        return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
+        return SwatDB::query($this->db, $sql, AdminUserHistoryWrapper::class);
     }
 
     /**
@@ -497,7 +497,7 @@ class AdminUser extends SwatDBDataObject
         return SwatDB::query(
             $this->db,
             $sql,
-            'AdminUserHistoryWrapper',
+            AdminUserHistoryWrapper::class,
         )->getFirst();
     }
 
@@ -517,7 +517,7 @@ class AdminUser extends SwatDBDataObject
             $this->db->quote($this->id, 'integer'),
         );
 
-        $wrapper_class = SwatDBClassMap::get('SiteInstanceWrapper');
+        $wrapper_class = SwatDBClassMap::get(SiteInstanceWrapper::class);
 
         return SwatDB::query($this->db, $sql, $wrapper_class);
     }
@@ -538,7 +538,7 @@ class AdminUser extends SwatDBDataObject
             $this->db->quote($this->id, 'integer'),
         );
 
-        return SwatDB::query($this->db, $sql, 'AdminGroupWrapper');
+        return SwatDB::query($this->db, $sql, AdminGroupWrapper::class);
     }
 
     protected function getSerializablePrivateProperties()

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -1,280 +1,260 @@
 <?php
 
 /**
- * User account for an admin
+ * User account for an admin.
  *
- * @package   Admin
  * @copyright 2007-2023 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminGroup
  */
 class AdminUser extends SwatDBDataObject
 {
+    /**
+     * The number of days after which a user is considered inactive.
+     *
+     * If a user has no sign-in activity for this many days, it will be
+     * prevented from signing into the admin.
+     *
+     * @see AdminUser::isActive()
+     */
+    public const EXPIRY_DAYS = 90;
 
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
-	/**
-	 * The number of days after which a user is considered inactive
-	 *
-	 * If a user has no sign-in activity for this many days, it will be
-	 * prevented from signing into the admin.
-	 *
-	 * @see AdminUser::isActive()
-	 */
-	const EXPIRY_DAYS = 90;
+    /**
+     * Email address of this user.
+     *
+     * @var string
+     */
+    public $email;
 
+    /**
+     * Full name of this user.
+     *
+     * @var string
+     */
+    public $name;
 
+    /**
+     * Hashed version of this user's salted password.
+     *
+     * @var string
+     */
+    public $password;
 
+    /**
+     * The salt value used to protect this user's password.
+     *
+     * @var string
+     */
+    public $password_salt;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    /**
+     * Token used for password regeneration for this user.
+     *
+     * This field is usually null unless this user is being forced to reset
+     * his or her password.
+     *
+     * @var string
+     */
+    public $password_tag;
 
-	/**
-	 * Email address of this user
-	 *
-	 * @var string
-	 */
-	public $email;
+    /**
+     * Date when the reset password tag was created.
+     *
+     * This is used to expire old reset password requests.
+     *
+     * @var SwatDate
+     */
+    public $password_tag_date;
 
-	/**
-	 * Full name of this user
-	 *
-	 * @var string
-	 */
-	public $name;
+    /**
+     * Whether or not this user will be forced to change his or her password
+     * upon login.
+     *
+     * @var bool
+     */
+    public $force_change_password;
 
-	/**
-	 * Hashed version of this user's salted password
-	 *
-	 * @var string
-	 */
-	public $password;
+    /**
+     * Whether or not this user is enabled.
+     *
+     * Users that are not enabled will not be able to login to the admin.
+     *
+     * @var bool
+     */
+    public $enabled;
 
-	/**
-	 * The salt value used to protect this user's password
-	 *
-	 * @var string
-	 */
-	public $password_salt;
+    /**
+     * Serialized menu state for this user.
+     *
+     * This is a serialized instance of an AdminMenuStateStore object.
+     *
+     * @var string
+     *
+     * @see AdminMenuView
+     * @see AdminMenuStateStore
+     */
+    public $menu_state;
 
-	/**
-	 * Token used for password regeneration for this user
-	 *
-	 * This field is usually null unless this user is being forced to reset
-	 * his or her password.
-	 *
-	 * @var string
-	 */
-	public $password_tag;
+    /**
+     * Whether or not this user has access to all instances.
+     *
+     * Only relevent on a multiple instance site. This allows the user to login
+     * to all instance admins regardless of AdminUserInstanceBindings. Also
+     * this user can login into a master admin loading with a null instance.
+     *
+     * @var bool
+     */
+    public $all_instances;
 
-	/**
-	 * Date when the reset password tag was created
-	 *
-	 * This is used to expire old reset password requests.
-	 *
-	 * @var SwatDate
-	 */
-	public $password_tag_date;
+    /**
+     * Date when the user account was activated.
+     *
+     * @var SwatDate
+     */
+    public $activation_date;
 
-	/**
-	 * Whether or not this user will be forced to change his or her password
-	 * upon login
-	 *
-	 * @var boolean
-	 */
-	public $force_change_password;
+    /**
+     * 2FA Secret.
+     *
+     * @var string
+     */
+    public $two_fa_secret;
 
-	/**
-	 * Whether or not this user is enabled
-	 *
-	 * Users that are not enabled will not be able to login to the admin.
-	 *
-	 * @var boolean
-	 */
-	public $enabled;
+    /**
+     * 2FA Enabled.
+     *
+     * @var bool
+     */
+    public $two_fa_enabled = false;
 
-	/**
-	 * Serialized menu state for this user
-	 *
-	 * This is a serialized instance of an AdminMenuStateStore object.
-	 *
-	 * @var string
-	 *
-	 * @see AdminMenuView
-	 * @see AdminMenuStateStore
-	 */
-	public $menu_state;
+    /**
+     * 2FA Time-slice.
+     *
+     * @var int
+     */
+    public $two_fa_timeslice;
 
-	/**
-	 * Whether or not this user has access to all instances
-	 *
-	 * Only relevent on a multiple instance site. This allows the user to login
-	 * to all instance admins regardless of AdminUserInstanceBindings. Also
-	 * this user can login into a master admin loading with a null instance.
-	 *
-	 * @var boolean
-	 */
-	public $all_instances;
+    /**
+     * @var SiteInstance
+     */
+    protected $instance;
 
-	/**
-	 * Date when the user account was activated.
-	 *
-	 * @var SwatDate
-	 */
-	public $activation_date;
+    /**
+     * @var bool
+     */
+    protected $two_fa_authenticated = false;
 
-	/**
-	 * 2FA Secret
-	 *
-	 * @var string
-	 */
-	public $two_fa_secret;
+    /**
+     * Checks if a user is authenticated for an admin application.
+     *
+     * After a user's username and password have been verified, perform
+     * additional checks on the user's authentication. This method should be
+     * checked on every page load -- not just at login -- to ensure the user
+     * has permission to access the specified admin application. It also checks
+     * whether or not this user belongs to the current site instance as well as
+     * well as performing all regular checks.
+     *
+     * @param AdminApplication $app the application to authenticate this user
+     *                              against
+     *
+     * @return bool true if this user has authenticated access to the
+     *              admin and false if this user does not
+     */
+    public function isAuthenticated(AdminApplication $app)
+    {
+        $authenticated = false;
 
-	/**
-	 * 2FA Enabled
-	 *
-	 * @var boolean
-	 */
-	public $two_fa_enabled = false;
+        // Only validate agains instances if site is actually using the
+        // instance module.
+        if ($app->hasModule('SiteMultipleInstanceModule')) {
+            if ($this->all_instances) {
+                // This user has acess to all instances
+                $authenticated = true;
+            } else {
+                // Ensure the admin user has a binding to the current instance.
+                $instance = $app->getModule('SiteMultipleInstanceModule');
+                $instance_id = $instance->getId();
 
-	/**
-	 * 2FA Time-slice
-	 *
-	 * @var integer
-	 */
-	public $two_fa_timeslice;
+                if (
+                    $instance_id !== null
+                    && isset($this->instances[$instance_id])
+                ) {
+                    $authenticated = true;
+                }
+            }
 
+            // Make sure instance is set so activation check works properly.
+            if ($app->getInstance() instanceof SiteInstance) {
+                $this->setInstance($app->getInstance());
+            }
+        } else {
+            $authenticated = true;
+        }
 
+        $is_2fa_valid =
+            // Valid if 2Fa is disabled at app level
+            !$app->is2FaEnabled()
+            // Or if 2Fa disabled for this user
+            || !$this->two_fa_enabled
+            // Or if the user is 2Fa authenticated
+            || $this->two_fa_authenticated;
 
+        return $authenticated
+            && $this->isActive()
+            && !$this->force_change_password
+            && $is_2fa_valid;
+    }
 
-	/**
-	 * @var SiteInstance
-	 */
-	protected $instance;
+    /**
+     * Gets whether or not this user has access to the given component.
+     *
+     * @param AdminComponent $component the component to check
+     *
+     * @return bool true if this used has access to the given component and
+     *              false if this used does not have access to the given
+     *              component
+     */
+    public function hasAccess(AdminComponent $component)
+    {
+        $this->checkDB();
 
-	/**
-	 * @var boolean
-	 */
-	protected $two_fa_authenticated = false;
-
-
-
-
-	/**
-	 * Checks if a user is authenticated for an admin application
-	 *
-	 * After a user's username and password have been verified, perform
-	 * additional checks on the user's authentication. This method should be
-	 * checked on every page load -- not just at login -- to ensure the user
-	 * has permission to access the specified admin application. It also checks
-	 * whether or not this user belongs to the current site instance as well as
-	 * well as performing all regular checks.
-	 *
-	 * @param AdminApplication $app the application to authenticate this user
-	 *                               against.
-	 *
-	 * @return boolean true if this user has authenticated access to the
-	 *                 admin and false if this user does not.
-	 */
-	public function isAuthenticated(AdminApplication $app)
-	{
-		$authenticated = false;
-
-		// Only validate agains instances if site is actually using the
-		// instance module.
-		if ($app->hasModule('SiteMultipleInstanceModule')) {
-			if ($this->all_instances) {
-				// This user has acess to all instances
-				$authenticated = true;
-			} else {
-				// Ensure the admin user has a binding to the current instance.
-				$instance = $app->getModule('SiteMultipleInstanceModule');
-				$instance_id = $instance->getId();
-
-				if (
-					$instance_id !== null &&
-					isset($this->instances[$instance_id])
-				) {
-					$authenticated = true;
-				}
-			}
-
-			// Make sure instance is set so activation check works properly.
-			if ($app->getInstance() instanceof SiteInstance) {
-				$this->setInstance($app->getInstance());
-			}
-		} else {
-			$authenticated = true;
-		}
-
-		$is_2fa_valid =
-			// Valid if 2Fa is disabled at app level
-			!$app->is2FaEnabled() ||
-			// Or if 2Fa disabled for this user
-			!$this->two_fa_enabled ||
-			// Or if the user is 2Fa authenticated
-			$this->two_fa_authenticated;
-
-		$authenticated =
-			$authenticated &&
-			$this->isActive() &&
-			!$this->force_change_password &&
-			$is_2fa_valid;
-
-		return $authenticated;
-	}
-
-
-
-
-	/**
-	 * Gets whether or not this user has access to the given component
-	 *
-	 * @param AdminComponent $component the component to check.
-	 *
-	 * @return boolean true if this used has access to the given component and
-	 *                  false if this used does not have access to the given
-	 *                  component.
-	 */
-	public function hasAccess(AdminComponent $component)
-	{
-		$this->checkDB();
-
-		$sql = sprintf(
-			'select %s in (
+        $sql = sprintf(
+            'select %s in (
 			select component from AdminComponentAdminGroupBinding
 				inner join AdminUserAdminGroupBinding on
 					AdminComponentAdminGroupBinding.groupnum =
 						AdminUserAdminGroupBinding.groupnum and
 							AdminUserAdminGroupBinding.usernum = %s)',
-			$this->db->quote($component->id, 'integer'),
-			$this->db->quote($this->id, 'integer'),
-		);
+            $this->db->quote($component->id, 'integer'),
+            $this->db->quote($this->id, 'integer'),
+        );
 
-		return SwatDB::queryOne($this->db, $sql);
-	}
+        return SwatDB::queryOne($this->db, $sql);
+    }
 
+    /**
+     * Gets whether or not this user has access to the given component.
+     *
+     * @param string $shortname the shortname of the component to check
+     *
+     * @return bool true if this used has access to the given component and
+     *              false if this used does not have access to the given
+     *              component
+     */
+    public function hasAccessByShortname($shortname)
+    {
+        $this->checkDB();
 
-
-
-	/**
-	 * Gets whether or not this user has access to the given component
-	 *
-	 * @param string $shortname the shortname of the component to check
-	 *
-	 * @return boolean true if this used has access to the given component and
-	 *                  false if this used does not have access to the given
-	 *                  component.
-	 */
-	public function hasAccessByShortname($shortname)
-	{
-		$this->checkDB();
-
-		$sql = sprintf(
-			'select id from AdminComponent
+        $sql = sprintf(
+            'select id from AdminComponent
 				inner join AdminComponentAdminGroupBinding on
 					AdminComponent.id =
 						AdminComponentAdminGroupBinding.component
@@ -283,330 +263,289 @@ class AdminUser extends SwatDBDataObject
 						AdminUserAdminGroupBinding.groupnum and
 							AdminUserAdminGroupBinding.usernum = %s
 			where shortname = %s',
-			$this->db->quote($this->id, 'integer'),
-			$this->db->quote($shortname, 'text'),
-		);
+            $this->db->quote($this->id, 'integer'),
+            $this->db->quote($shortname, 'text'),
+        );
 
-		return SwatDB::queryOne($this->db, $sql);
-	}
+        return SwatDB::queryOne($this->db, $sql);
+    }
 
+    /**
+     * Sets this account's password hash.
+     *
+     * @param string $password_hash the password hash for this account
+     */
+    public function setPasswordHash($password_hash)
+    {
+        $this->password = $password_hash;
 
+        // Note: AdminUser now uses crypt() for password hashing. The salt
+        // is stored in the same field as the hashed password.
+        $this->password_salt = null;
+    }
 
+    /**
+     * Resets this user's password.
+     *
+     * Creates a unique tag enabling this user to reset his/her own password.
+     * The password tag is saved for this user and should be sent to this user
+     * in an email with further instructions.
+     *
+     * @return string $password_tag a unique tag to verify the account when
+     *                resetting the password
+     *
+     * @see AdminResetPasswordMailMessage
+     */
+    public function resetPassword()
+    {
+        $this->checkDB();
 
-	/**
-	 * Sets this account's password hash
-	 *
-	 * @param string $password_hash the password hash for this account.
-	 */
-	public function setPasswordHash($password_hash)
-	{
-		$this->password = $password_hash;
+        $password_tag = SwatString::hash(uniqid(rand(), true));
+        $now = new SwatDate();
+        $now->toUTC();
 
-		// Note: AdminUser now uses crypt() for password hashing. The salt
-		// is stored in the same field as the hashed password.
-		$this->password_salt = null;
-	}
-
-
-
-
-	/**
-	 * Resets this user's password
-	 *
-	 * Creates a unique tag enabling this user to reset his/her own password.
-	 * The password tag is saved for this user and should be sent to this user
-	 * in an email with further instructions.
-	 *
-	 * @return string $password_tag a unique tag to verify the account when
-	 *                               resetting the password.
-	 *
-	 * @see AdminResetPasswordMailMessage
-	 */
-	public function resetPassword()
-	{
-		$this->checkDB();
-
-		$password_tag = SwatString::hash(uniqid(rand(), true));
-		$now = new SwatDate();
-		$now->toUTC();
-
-		/*
-		 * Update the database with new password tag. Don't use the regular
-		 * dataobject saving here in case other fields have changed.
-		 */
-		$id_field = new SwatDBField($this->id_field, 'integer');
-		$sql = sprintf(
-			'update %s set password_tag = %s, password_tag_date = %s
+        /*
+         * Update the database with new password tag. Don't use the regular
+         * dataobject saving here in case other fields have changed.
+         */
+        $id_field = new SwatDBField($this->id_field, 'integer');
+        $sql = sprintf(
+            'update %s set password_tag = %s, password_tag_date = %s
 			where %s = %s',
-			$this->table,
-			$this->db->quote($password_tag, 'text'),
-			$this->db->quote($now->getDate(), 'date'),
-			$id_field->name,
-			$this->db->quote($this->{$id_field->name}, $id_field->type),
-		);
+            $this->table,
+            $this->db->quote($password_tag, 'text'),
+            $this->db->quote($now->getDate(), 'date'),
+            $id_field->name,
+            $this->db->quote($this->{$id_field->name}, $id_field->type),
+        );
 
-		SwatDB::exec($this->db, $sql);
+        SwatDB::exec($this->db, $sql);
 
-		return $password_tag;
-	}
+        return $password_tag;
+    }
 
+    /**
+     * Loads a user from the database with just an email address.
+     *
+     * This is useful for password recovery and email address verification.
+     *
+     * @param string $email the email address of the user
+     *
+     * @return bool true if the loading was successful and false if it was
+     *              not
+     */
+    public function loadFromEmail($email)
+    {
+        $this->checkDB();
 
-
-
-	/**
-	 * Loads a user from the database with just an email address
-	 *
-	 * This is useful for password recovery and email address verification.
-	 *
-	 * @param string $email the email address of the user.
-	 *
-	 * @return boolean true if the loading was successful and false if it was
-	 *                  not.
-	 */
-	public function loadFromEmail($email)
-	{
-		$this->checkDB();
-
-		$sql = sprintf(
-			'select id from %s
+        $sql = sprintf(
+            'select id from %s
 			where lower(email) = lower(%s)',
-			$this->table,
-			$this->db->quote($email, 'text'),
-		);
+            $this->table,
+            $this->db->quote($email, 'text'),
+        );
 
-		$id = SwatDB::queryOne($this->db, $sql);
+        $id = SwatDB::queryOne($this->db, $sql);
 
-		if ($id === null) {
-			return false;
-		}
+        if ($id === null) {
+            return false;
+        }
 
-		return $this->load($id);
-	}
+        return $this->load($id);
+    }
 
+    /**
+     * Sets the instance to use when loading instance-specific information for
+     * this user.
+     *
+     * @param SiteInstance $instance the instance to use
+     */
+    public function setInstance(SiteInstance $instance)
+    {
+        $this->instance = $instance;
+    }
 
+    /**
+     * Checks to see if this user is active.
+     *
+     * Users are inactive if they haven't logged in or been activated in the
+     * last 90 days.
+     *
+     * @return bool
+     *
+     * @see AdminUser::EXPIRY_DAYS
+     */
+    public function isActive()
+    {
+        $is_active = false;
 
+        $comparison_date = null;
+        $comparison_dates = [];
 
-	/**
-	 * Sets the instance to use when loading instance-specific information for
-	 * this user.
-	 *
-	 * @param SiteInstance $instance the instance to use.
-	 */
-	public function setInstance(SiteInstance $instance)
-	{
-		$this->instance = $instance;
-	}
+        if ($this->most_recent_history instanceof AdminUserHistory) {
+            $comparison_dates[] = $this->most_recent_history->login_date;
+        }
 
+        if ($this->activation_date instanceof SwatDate) {
+            $comparison_dates[] = $this->activation_date;
+        }
 
+        // Get the most recent activity date (either user history or activation
+        // date)
+        foreach ($comparison_dates as $date) {
+            if (
+                !$comparison_date instanceof SwatDate
+                || $date->after($comparison_date)
+            ) {
+                $comparison_date = $date;
+            }
+        }
 
+        $threshold = new SwatDate();
+        $threshold->subtractDays(static::EXPIRY_DAYS);
+        if (
+            $comparison_date instanceof SwatDate
+            && $comparison_date->after($threshold)
+        ) {
+            $is_active = true;
+        }
 
-	/**
-	 * Checks to see if this user is active
-	 *
-	 * Users are inactive if they haven't logged in or been activated in the
-	 * last 90 days.
-	 *
-	 * @return boolean
-	 *
-	 * @see AdminUser::EXPIRY_DAYS
-	 */
-	public function isActive()
-	{
-		$is_active = false;
+        return $is_active;
+    }
 
-		$comparison_date = null;
-		$comparison_dates = [];
+    public function set2FaAuthenticated($authenticated = true)
+    {
+        $this->two_fa_authenticated = $authenticated;
+    }
 
-		if ($this->most_recent_history instanceof AdminUserHistory) {
-			$comparison_dates[] = $this->most_recent_history->login_date;
-		}
+    public function is2FaAuthenticated()
+    {
+        return $this->two_fa_authenticated;
+    }
 
-		if ($this->activation_date instanceof SwatDate) {
-			$comparison_dates[] = $this->activation_date;
-		}
+    protected function init()
+    {
+        $this->table = 'AdminUser';
+        $this->id_field = 'integer:id';
 
-		// Get the most recent activity date (either user history or activation
-		// date)
-		foreach ($comparison_dates as $date) {
-			if (
-				!$comparison_date instanceof SwatDate ||
-				$date->after($comparison_date)
-			) {
-				$comparison_date = $date;
-			}
-		}
+        $this->registerDateProperty('password_tag_date');
+        $this->registerDateProperty('activation_date');
+    }
 
-		$threshold = new SwatDate();
-		$threshold->subtractDays(static::EXPIRY_DAYS);
-		if (
-			$comparison_date instanceof SwatDate &&
-			$comparison_date->after($threshold)
-		) {
-			$is_active = true;
-		}
+    /**
+     * Gets user history for this user.
+     *
+     * If account instance is set with the {@link AdminUser::setInstance()}
+     * method, history will be limited to that instance.
+     *
+     * @return AdminUserHistoryWrapper a set of {@link AdminUserHistory}
+     *                                 objects containing this admin user's
+     *                                 login history
+     *
+     * @see AdminUser::setInstance()
+     */
+    protected function loadHistory()
+    {
+        $instance_id = null;
 
-		return $is_active;
-	}
+        if ($this->instance instanceof SiteInstance) {
+            $instance_id = $this->instance->getId();
+        }
 
-
-
-
-	public function set2FaAuthenticated($authenticated = true)
-	{
-		$this->two_fa_authenticated = $authenticated;
-	}
-
-
-
-
-	public function is2FaAuthenticated()
-	{
-		return $this->two_fa_authenticated;
-	}
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminUser';
-		$this->id_field = 'integer:id';
-
-		$this->registerDateProperty('password_tag_date');
-		$this->registerDateProperty('activation_date');
-	}
-
-
-
-
-	/**
-	 * Gets user history for this user
-	 *
-	 * If account instance is set with the {@link AdminUser::setInstance()}
-	 * method, history will be limited to that instance.
-	 *
-	 * @return AdminUserHistoryWrapper a set of {@link AdminUserHistory}
-	 *                                 objects containing this admin user's
-	 *                                 login history.
-	 *
-	 * @see AdminUser::setInstance()
-	 */
-	protected function loadHistory()
-	{
-		$instance_id = null;
-
-		if ($this->instance instanceof SiteInstance) {
-			$instance_id = $this->instance->getId();
-		}
-
-		$sql = sprintf(
-			'select * from AdminUserHistory
+        $sql = sprintf(
+            'select * from AdminUserHistory
 			where usernum = %s and instance %s %s
 			order by login_date desc',
-			$this->db->quote($this->id, 'integer'),
-			SwatDB::equalityOperator($instance_id),
-			$this->db->quote($instance_id, 'integer'),
-		);
+            $this->db->quote($this->id, 'integer'),
+            SwatDB::equalityOperator($instance_id),
+            $this->db->quote($instance_id, 'integer'),
+        );
 
-		return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
-	}
+        return SwatDB::query($this->db, $sql, 'AdminUserHistoryWrapper');
+    }
 
+    /**
+     * Gets most recent login history for this user.
+     *
+     * If account instance is set with the {@link AdminUser::setInstance()}
+     * method, history will be limited to that instance.
+     *
+     * @return AdminUserHistory a {@link AdminUserHistory} containing
+     *                          this admin user's most recent login history
+     *
+     * @see AdminUser::setInstance()
+     */
+    protected function loadMostRecentHistory()
+    {
+        $instance_id = null;
 
+        if ($this->instance instanceof SiteInstance) {
+            $instance_id = $this->instance->getId();
+        }
 
-
-	/**
-	 * Gets most recent login history for this user
-	 *
-	 * If account instance is set with the {@link AdminUser::setInstance()}
-	 * method, history will be limited to that instance.
-	 *
-	 * @return AdminUserHistory a {@link AdminUserHistory} containing
-	 *                          this admin user's most recent login history.
-	 *
-	 * @see AdminUser::setInstance()
-	 */
-	protected function loadMostRecentHistory()
-	{
-		$instance_id = null;
-
-		if ($this->instance instanceof SiteInstance) {
-			$instance_id = $this->instance->getId();
-		}
-
-		$sql = sprintf(
-			'select * from AdminUserHistory
+        $sql = sprintf(
+            'select * from AdminUserHistory
 			where usernum = %s and instance %s %s
 			order by login_date desc',
-			$this->db->quote($this->id, 'integer'),
-			SwatDB::equalityOperator($instance_id),
-			$this->db->quote($instance_id, 'integer'),
-		);
+            $this->db->quote($this->id, 'integer'),
+            SwatDB::equalityOperator($instance_id),
+            $this->db->quote($instance_id, 'integer'),
+        );
 
-		$this->db->setLimit(1);
+        $this->db->setLimit(1);
 
-		return SwatDB::query(
-			$this->db,
-			$sql,
-			'AdminUserHistoryWrapper',
-		)->getFirst();
-	}
+        return SwatDB::query(
+            $this->db,
+            $sql,
+            'AdminUserHistoryWrapper',
+        )->getFirst();
+    }
 
-
-
-
-	/**
-	 * Load the Instances that this user has access to
-	 *
-	 * @return SiteInstanceWrapper the site instances this user belongs to.
-	 */
-	protected function loadInstances()
-	{
-		$sql = sprintf(
-			'select Instance.*
+    /**
+     * Load the Instances that this user has access to.
+     *
+     * @return SiteInstanceWrapper the site instances this user belongs to
+     */
+    protected function loadInstances()
+    {
+        $sql = sprintf(
+            'select Instance.*
 				from Instance
 				inner join AdminUserInstanceBinding on
 					AdminUserInstanceBinding.instance = Instance.id
 				where AdminUserInstanceBinding.usernum = %s',
-			$this->db->quote($this->id, 'integer'),
-		);
+            $this->db->quote($this->id, 'integer'),
+        );
 
-		$wrapper_class = SwatDBClassMap::get('SiteInstanceWrapper');
-		return SwatDB::query($this->db, $sql, $wrapper_class);
-	}
+        $wrapper_class = SwatDBClassMap::get('SiteInstanceWrapper');
 
+        return SwatDB::query($this->db, $sql, $wrapper_class);
+    }
 
-
-
-	/**
-	 * Loads the Groups that this user has access to
-	 *
-	 * @return AdminGroupWrapper the Admin Groups this user belongs to.
-	 */
-	protected function loadGroups()
-	{
-		$sql = sprintf(
-			'select AdminGroup.*
+    /**
+     * Loads the Groups that this user has access to.
+     *
+     * @return AdminGroupWrapper the Admin Groups this user belongs to
+     */
+    protected function loadGroups()
+    {
+        $sql = sprintf(
+            'select AdminGroup.*
 				from AdminGroup
 				inner join AdminUserAdminGroupBinding on
 					AdminUserAdminGroupBinding.groupnum = AdminGroup.id
 				where usernum = %s',
-			$this->db->quote($this->id, 'integer'),
-		);
+            $this->db->quote($this->id, 'integer'),
+        );
 
-		return SwatDB::query($this->db, $sql, 'AdminGroupWrapper');
-	}
+        return SwatDB::query($this->db, $sql, 'AdminGroupWrapper');
+    }
 
+    protected function getSerializablePrivateProperties()
+    {
+        $properties = parent::getSerializablePrivateProperties();
+        $properties[] = 'two_fa_authenticated';
 
-
-
-	protected function getSerializablePrivateProperties()
-	{
-		$properties = parent::getSerializablePrivateProperties();
-		$properties[] = 'two_fa_authenticated';
-		return $properties;
-	}
-
-
+        return $properties;
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminUser.php
+++ b/Admin/dataobjects/AdminUser.php
@@ -7,6 +7,26 @@
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
  * @see       AdminGroup
+ *
+ * @property int $id
+ * @property string $email
+ * @property string $name
+ * @property string $password
+ * @property ?string $password_salt
+ * @property ?string $password_tag
+ * @property ?SwatDate $password_tag_date
+ * @property bool $force_change_password
+ * @property bool $enabled
+ * @property string $menu_state
+ * @property bool $all_instances
+ * @property ?SwatDate $activation_date
+ * @property ?string $two_fa_secret
+ * @property int $two_fa_timeslice
+ * @property SiteInstance $instance
+ * @property AdminUserHistoryWrapper $history
+ * @property AdminUserHistory $most_recent_history
+ * @property SiteInstanceWrapper $instances
+ * @property AdminGroupWrapper $groups
  */
 class AdminUser extends SwatDBDataObject
 {
@@ -130,10 +150,8 @@ class AdminUser extends SwatDBDataObject
 
     /**
      * 2FA Enabled.
-     *
-     * @var bool
      */
-    public $two_fa_enabled = false;
+    public bool $two_fa_enabled = false;
 
     /**
      * 2FA Time-slice.
@@ -147,10 +165,7 @@ class AdminUser extends SwatDBDataObject
      */
     protected $instance;
 
-    /**
-     * @var bool
-     */
-    protected $two_fa_authenticated = false;
+    protected bool $two_fa_authenticated = false;
 
     /**
      * Checks if a user is authenticated for an admin application.

--- a/Admin/dataobjects/AdminUserHistory.php
+++ b/Admin/dataobjects/AdminUserHistory.php
@@ -1,56 +1,46 @@
 <?php
 
 /**
- * History record for an admin user
+ * History record for an admin user.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUserHistory extends SwatDBDataObject
 {
+    /**
+     * Unique identifier.
+     *
+     * @var int
+     */
+    public $id;
 
+    /**
+     * Date an admin user logged in to the admin.
+     *
+     * @var SwatDate
+     */
+    public $login_date;
 
-	/**
-	 * Unique identifier
-	 *
-	 * @var integer
-	 */
-	public $id;
+    /**
+     * HTTP user-agent used by an admin user to log in to the admin.
+     *
+     * @var string
+     */
+    public $login_agent;
 
-	/**
-	 * Date an admin user logged in to the admin
-	 *
-	 * @var SwatDate
-	 */
-	public $login_date;
+    /**
+     * IP address used by an admin user to log in to the admin.
+     *
+     * @var string
+     */
+    public $remote_ip;
 
-	/**
-	 * HTTP user-agent used by an admin user to log in to the admin
-	 *
-	 * @var string
-	 */
-	public $login_agent;
-
-	/**
-	 * IP address used by an admin user to log in to the admin
-	 *
-	 * @var string
-	 */
-	public $remote_ip;
-
-
-
-
-	protected function init()
-	{
-		$this->table = 'AdminUserHistory';
-		$this->id_field = 'integer:id';
-		$this->registerDateProperty('login_date');
-		$this->registerInternalProperty('instance', 'Instance');
-	}
-
-
+    protected function init()
+    {
+        $this->table = 'AdminUserHistory';
+        $this->id_field = 'integer:id';
+        $this->registerDateProperty('login_date');
+        $this->registerInternalProperty('instance', 'Instance');
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminUserHistory.php
+++ b/Admin/dataobjects/AdminUserHistory.php
@@ -5,6 +5,12 @@
  *
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
+ * @property int $id
+ * @property ?SwatDate $login_date
+ * @property ?string $login_agent
+ * @property ?string $remote_ip
+ * @property ?SiteInstance $instance
  */
 class AdminUserHistory extends SwatDBDataObject
 {
@@ -41,6 +47,6 @@ class AdminUserHistory extends SwatDBDataObject
         $this->table = 'AdminUserHistory';
         $this->id_field = 'integer:id';
         $this->registerDateProperty('login_date');
-        $this->registerInternalProperty('instance', 'Instance');
+        $this->registerInternalProperty('instance', SiteInstance::class);
     }
 }

--- a/Admin/dataobjects/AdminUserHistory.php
+++ b/Admin/dataobjects/AdminUserHistory.php
@@ -9,7 +9,7 @@
  */
 class AdminUserHistory extends SwatDBDataObject
 {
-	// {{{ public properties
+
 
 	/**
 	 * Unique identifier
@@ -39,8 +39,8 @@ class AdminUserHistory extends SwatDBDataObject
 	 */
 	public $remote_ip;
 
-	// }}}
-	// {{{ protected function init()
+
+
 
 	protected function init()
 	{
@@ -50,7 +50,7 @@ class AdminUserHistory extends SwatDBDataObject
 		$this->registerInternalProperty('instance', 'Instance');
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminUserHistory.php
+++ b/Admin/dataobjects/AdminUserHistory.php
@@ -6,10 +6,10 @@
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  *
- * @property int $id
- * @property ?SwatDate $login_date
- * @property ?string $login_agent
- * @property ?string $remote_ip
+ * @property int           $id
+ * @property ?SwatDate     $login_date
+ * @property ?string       $login_agent
+ * @property ?string       $remote_ip
  * @property ?SiteInstance $instance
  */
 class AdminUserHistory extends SwatDBDataObject

--- a/Admin/dataobjects/AdminUserHistoryWrapper.php
+++ b/Admin/dataobjects/AdminUserHistoryWrapper.php
@@ -13,7 +13,7 @@ class AdminUserHistoryWrapper extends SwatDBRecordsetWrapper
     protected function init()
     {
         parent::init();
-        $this->row_wrapper_class = 'AdminUserHistory';
+        $this->row_wrapper_class = AdminUserHistory::class;
         $this->index_field = 'id';
     }
 }

--- a/Admin/dataobjects/AdminUserHistoryWrapper.php
+++ b/Admin/dataobjects/AdminUserHistoryWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminUserHistoryWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -19,7 +19,7 @@ class AdminUserHistoryWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminUserHistoryWrapper.php
+++ b/Admin/dataobjects/AdminUserHistoryWrapper.php
@@ -1,25 +1,19 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminUserHistory objects
+ * A recordset wrapper class for AdminUserHistory objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminUserHistory
  */
 class AdminUserHistoryWrapper extends SwatDBRecordsetWrapper
 {
-
-
-	protected function init()
-	{
-		parent::init();
-		$this->row_wrapper_class = 'AdminUserHistory';
-		$this->index_field = 'id';
-	}
-
-
+    protected function init()
+    {
+        parent::init();
+        $this->row_wrapper_class = 'AdminUserHistory';
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminUserWrapper.php
+++ b/Admin/dataobjects/AdminUserWrapper.php
@@ -1,29 +1,23 @@
 <?php
 
 /**
- * A recordset wrapper class for AdminUser objects
+ * A recordset wrapper class for AdminUser objects.
  *
- * @package   Admin
  * @copyright 2007-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
+ *
  * @see       AdminUser
  */
 class AdminUserWrapper extends SwatDBRecordsetWrapper
 {
+    protected function init()
+    {
+        parent::init();
 
+        $admin_user_class =
+            SwatDBClassMap::get('AdminUser');
 
-	protected function init()
-	{
-		parent::init();
-
-		$admin_user_class =
-			SwatDBClassMap::get('AdminUser');
-
-		$this->row_wrapper_class = $admin_user_class;
-		$this->index_field = 'id';
-	}
-
-
+        $this->row_wrapper_class = $admin_user_class;
+        $this->index_field = 'id';
+    }
 }
-
-?>

--- a/Admin/dataobjects/AdminUserWrapper.php
+++ b/Admin/dataobjects/AdminUserWrapper.php
@@ -10,7 +10,7 @@
  */
 class AdminUserWrapper extends SwatDBRecordsetWrapper
 {
-	// {{{ protected function init()
+
 
 	protected function init()
 	{
@@ -23,7 +23,7 @@ class AdminUserWrapper extends SwatDBRecordsetWrapper
 		$this->index_field = 'id';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/dataobjects/AdminUserWrapper.php
+++ b/Admin/dataobjects/AdminUserWrapper.php
@@ -14,10 +14,7 @@ class AdminUserWrapper extends SwatDBRecordsetWrapper
     {
         parent::init();
 
-        $admin_user_class =
-            SwatDBClassMap::get('AdminUser');
-
-        $this->row_wrapper_class = $admin_user_class;
+        $this->row_wrapper_class = SwatDBClassMap::get(AdminUser::class);
         $this->index_field = 'id';
     }
 }

--- a/Admin/exceptions/AdminException.php
+++ b/Admin/exceptions/AdminException.php
@@ -1,29 +1,22 @@
 <?php
 
 /**
- * An exception in Admin
+ * An exception in Admin.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminException extends SwatException
 {
+    public function __construct($message = null, $code = 0)
+    {
+        if (is_object($message) && ($message instanceof PEAR_Error)) {
+            $error = $message;
+            $message = $error->getMessage();
+            $message .= "\n" . $error->getUserInfo();
+            $code = $error->getCode();
+        }
 
-
-	public function __construct($message = null, $code = 0)
-	{
-		if (is_object($message) && ($message instanceof PEAR_Error)) {
-			$error = $message;
-			$message = $error->getMessage();
-			$message.= "\n".$error->getUserInfo();
-			$code = $error->getCode();
-		}
-
-		parent::__construct($message, $code);
-	}
-
-
+        parent::__construct($message, $code);
+    }
 }
-
-?>

--- a/Admin/exceptions/AdminException.php
+++ b/Admin/exceptions/AdminException.php
@@ -9,7 +9,7 @@
  */
 class AdminException extends SwatException
 {
-	// {{{ public function __construct()
+
 
 	public function __construct($message = null, $code = 0)
 	{
@@ -23,7 +23,7 @@ class AdminException extends SwatException
 		parent::__construct($message, $code);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/exceptions/AdminNoAccessException.php
+++ b/Admin/exceptions/AdminNoAccessException.php
@@ -1,57 +1,44 @@
 <?php
 
 /**
- * Thrown when access to a page is not allowed
+ * Thrown when access to a page is not allowed.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminNoAccessException extends AdminUserException
 {
+    /**
+     * The user that was denied access.
+     *
+     * @var AdminUser
+     */
+    protected $user;
 
+    /**
+     * Creates a new no access exception.
+     *
+     * @param string    $message the message of the exception
+     * @param int       $code    the code of the exception
+     * @param AdminUser $user    optional. The user that was denied access.
+     */
+    public function __construct(
+        $message = null,
+        $code = 0,
+        ?AdminUser $user = null
+    ) {
+        parent::__construct($message, $code);
+        $this->user = $user;
+        $this->title = Admin::_('No Access');
+    }
 
-	/**
-	 * The user that was denied access
-	 *
-	 * @var AdminUser
-	 */
-	protected $user;
-
-
-
-
-	/**
-	 * Creates a new no access exception
-	 *
-	 * @param string $message the message of the exception.
-	 * @param integer $code the code of the exception.
-	 * @param AdminUser $user optional. The user that was denied access.
-	 */
-	public function __construct(
-		$message = null,
-		$code = 0,
-		AdminUser $user = null
-	) {
-		parent::__construct($message, $code);
-		$this->user = $user;
-		$this->title = Admin::_('No Access');
-	}
-
-
-
-
-	/**
-	 * Gets the user that was denied access
-	 *
-	 * @return AdminUser the user that was denied access.
-	 */
-	public function getUser()
-	{
-		return $this->user;
-	}
-
-
+    /**
+     * Gets the user that was denied access.
+     *
+     * @return AdminUser the user that was denied access
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
 }
-
-?>

--- a/Admin/exceptions/AdminNoAccessException.php
+++ b/Admin/exceptions/AdminNoAccessException.php
@@ -9,7 +9,7 @@
  */
 class AdminNoAccessException extends AdminUserException
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The user that was denied access
@@ -18,8 +18,8 @@ class AdminNoAccessException extends AdminUserException
 	 */
 	protected $user;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new no access exception
@@ -38,8 +38,8 @@ class AdminNoAccessException extends AdminUserException
 		$this->title = Admin::_('No Access');
 	}
 
-	// }}}
-	// {{{ public function getUser()
+
+
 
 	/**
 	 * Gets the user that was denied access
@@ -51,7 +51,7 @@ class AdminNoAccessException extends AdminUserException
 		return $this->user;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/exceptions/AdminNotFoundException.php
+++ b/Admin/exceptions/AdminNotFoundException.php
@@ -9,7 +9,7 @@
  */
 class AdminNotFoundException extends AdminUserException
 {
-	// {{{ public function __construct()
+
 
 	/**
 	 * Creates a new not found exception
@@ -23,7 +23,7 @@ class AdminNotFoundException extends AdminUserException
 		$this->title = Admin::_('Not Found');
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/exceptions/AdminNotFoundException.php
+++ b/Admin/exceptions/AdminNotFoundException.php
@@ -1,29 +1,22 @@
 <?php
 
 /**
- * Thrown when something is not found
+ * Thrown when something is not found.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminNotFoundException extends AdminUserException
 {
-
-
-	/**
-	 * Creates a new not found exception
-	 *
-	 * @param string $message the message of the exception.
-	 * @param integer $code the code of the exception.
-	 */
-	public function __construct($message = null, $code = 0)
-	{
-		parent::__construct($message, $code);
-		$this->title = Admin::_('Not Found');
-	}
-
-
+    /**
+     * Creates a new not found exception.
+     *
+     * @param string $message the message of the exception
+     * @param int    $code    the code of the exception
+     */
+    public function __construct($message = null, $code = 0)
+    {
+        parent::__construct($message, $code);
+        $this->title = Admin::_('Not Found');
+    }
 }
-
-?>

--- a/Admin/exceptions/AdminUserException.php
+++ b/Admin/exceptions/AdminUserException.php
@@ -4,17 +4,10 @@
  * Base class for exceptions that are thrown in response to user input and
  * should be handled gracefully.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminUserException extends AdminException
 {
-
-
-	public $title = null;
-
-
+    public $title;
 }
-
-?>

--- a/Admin/exceptions/AdminUserException.php
+++ b/Admin/exceptions/AdminUserException.php
@@ -10,11 +10,11 @@
  */
 class AdminUserException extends AdminException
 {
-	// {{{ public properties
+
 
 	public $title = null;
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/layouts/AdminDefaultLayout.php
+++ b/Admin/layouts/AdminDefaultLayout.php
@@ -77,7 +77,7 @@ class AdminDefaultLayout extends AdminLayout
                     $this->app->session->getUserId(),
                     'integer'
                 ),
-                'AdminMenuStore'
+                AdminMenuStore::class
             );
 
             $class = $this->app->getMenuViewClass();

--- a/Admin/layouts/AdminDefaultLayout.php
+++ b/Admin/layouts/AdminDefaultLayout.php
@@ -11,7 +11,7 @@
  */
 class AdminDefaultLayout extends AdminLayout
 {
-	// {{{ public properties
+
 
 	/**
 	 * Breadcrumb navigation
@@ -36,8 +36,8 @@ class AdminDefaultLayout extends AdminLayout
 	 */
 	public $menu = null;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	public function __construct($app, $filename = null)
 	{
@@ -46,10 +46,10 @@ class AdminDefaultLayout extends AdminLayout
 		$this->navbar->separator = ' › ';
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ public function init()
+
 
 	public function init()
 	{
@@ -59,8 +59,8 @@ class AdminDefaultLayout extends AdminLayout
 		$this->initMenu();
 	}
 
-	// }}}
-	// {{{ protected function initLogoutForm()
+
+
 
 	protected function initLogoutForm()
 	{
@@ -76,8 +76,8 @@ class AdminDefaultLayout extends AdminLayout
 		$this->logout_form->add($form_field);
 	}
 
-	// }}}
-	// {{{ protected function initMenu()
+
+
 
 	/**
 	 * Initializes layout menu view
@@ -99,10 +99,10 @@ class AdminDefaultLayout extends AdminLayout
 		$this->menu->init();
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize()
+
 
 	public function finalize()
 	{
@@ -129,8 +129,8 @@ class AdminDefaultLayout extends AdminLayout
 		$this->addHtmlHeadEntrySet($this->menu->getHtmlHeadEntrySet());
 	}
 
-	// }}}
-	// {{{ protected function displayHeader()
+
+
 
 	/**
 	 * Display admin page header
@@ -151,16 +151,16 @@ class AdminDefaultLayout extends AdminLayout
 		echo '</div>';
 	}
 
-	// }}}
-	// {{{ protected function displayNavBar()
+
+
 
 	protected function displayNavBar()
 	{
 		$this->navbar->display();
 	}
 
-	// }}}
-	// {{{ protected function displayMenu()
+
+
 
 	/**
 	 * Display admin page menu
@@ -173,7 +173,7 @@ class AdminDefaultLayout extends AdminLayout
 		$this->menu->display();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/layouts/AdminDefaultLayout.php
+++ b/Admin/layouts/AdminDefaultLayout.php
@@ -1,179 +1,152 @@
 <?php
 
 /**
- * Default layout used for the majority of admin components
+ * Default layout used for the majority of admin components.
  *
  * Includes navigation menu and lagout form.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDefaultLayout extends AdminLayout
 {
+    /**
+     * Breadcrumb navigation.
+     *
+     * @var SwatNavBar
+     */
+    public $navbar;
 
+    /**
+     * The logout form for this page.
+     *
+     * This form is responsible for displaying the admin logout button.
+     *
+     * @var SwatForm
+     */
+    public $logout_form;
 
-	/**
-	 * Breadcrumb navigation
-	 *
-	 * @var SwatNavBar
-	 */
-	public $navbar;
+    /**
+     * This admin application's menu view.
+     *
+     * @var AdminMenuView
+     */
+    public $menu;
 
-	/**
-	 * The logout form for this page
-	 *
-	 * This form is responsible for displaying the admin logout button.
-	 *
-	 * @var SwatForm
-	 */
-	public $logout_form = null;
+    public function __construct($app, $filename = null)
+    {
+        parent::__construct($app, $filename);
+        $this->navbar = new AdminNavBar();
+        $this->navbar->separator = ' › ';
+    }
 
-	/**
-	 * This admin application's menu view
-	 *
-	 * @var AdminMenuView
-	 */
-	public $menu = null;
+    // init phase
 
+    public function init()
+    {
+        parent::init();
 
+        $this->initLogoutForm();
+        $this->initMenu();
+    }
 
+    protected function initLogoutForm()
+    {
+        $this->logout_form = new SwatForm('logout');
+        $this->logout_form->action = 'AdminSite/Logout';
 
-	public function __construct($app, $filename = null)
-	{
-		parent::__construct($app, $filename);
-		$this->navbar = new AdminNavBar();
-		$this->navbar->separator = ' › ';
-	}
+        $form_field = new SwatFormField('logout_button_container');
 
+        $button = new SwatButton('logout_button');
+        $button->title = Admin::_('Logout');
 
+        $form_field->add($button);
+        $this->logout_form->add($form_field);
+    }
 
-	// init phase
+    /**
+     * Initializes layout menu view.
+     */
+    protected function initMenu()
+    {
+        if ($this->menu === null) {
+            $menu_store = SwatDB::executeStoredProc(
+                $this->app->db,
+                'getAdminMenu',
+                $this->app->db->quote(
+                    $this->app->session->getUserId(),
+                    'integer'
+                ),
+                'AdminMenuStore'
+            );
 
+            $class = $this->app->getMenuViewClass();
+            $this->menu = new $class();
+            $this->menu->setModel($menu_store);
+        }
 
-	public function init()
-	{
-		parent::init();
+        $this->menu->init();
+    }
 
-		$this->initLogoutForm();
-		$this->initMenu();
-	}
+    // finalize phase
 
+    public function finalize()
+    {
+        parent::finalize();
 
+        $this->startCapture('navbar');
+        $this->displayNavBar();
+        $this->endCapture();
 
+        $this->startCapture('header');
+        $this->displayHeader();
+        $this->endCapture();
 
-	protected function initLogoutForm()
-	{
-		$this->logout_form = new SwatForm('logout');
-		$this->logout_form->action = 'AdminSite/Logout';
+        $this->startCapture('menu');
+        $this->displayMenu();
+        $this->endCapture();
 
-		$form_field = new SwatFormField('logout_button_container');
+        $page_title = $this->navbar->getLastEntry()->title;
+        $this->data->title = SwatString::minimizeEntities($page_title) .
+            ' - ' . SwatString::minimizeEntities($this->app->title);
 
-		$button = new SwatButton('logout_button');
-		$button->title = Admin::_('Logout');
+        $this->addHtmlHeadEntrySet($this->navbar->getHtmlHeadEntrySet());
+        $this->addHtmlHeadEntrySet($this->logout_form->getHtmlHeadEntrySet());
+        $this->addHtmlHeadEntrySet($this->menu->getHtmlHeadEntrySet());
+    }
 
-		$form_field->add($button);
-		$this->logout_form->add($form_field);
-	}
+    /**
+     * Display admin page header.
+     *
+     * Display common elements for the header of an admin page. Sub-classes
+     * should call this from their implementation of {@link AdminPage::display()}.
+     */
+    protected function displayHeader()
+    {
+        echo '<div id="admin-syslinks">',
+        '<span id="admin-identifier">Welcome ',
+        SwatString::minimizeEntities($this->app->session->getName()),
+        ' &nbsp; ',
+        '<a href="AdminSite/Profile">Login Settings</a> &nbsp; </span>';
 
+        $this->logout_form->display();
 
+        echo '</div>';
+    }
 
+    protected function displayNavBar()
+    {
+        $this->navbar->display();
+    }
 
-	/**
-	 * Initializes layout menu view
-	 */
-	protected function initMenu()
-	{
-		if ($this->menu === null) {
-			$menu_store = SwatDB::executeStoredProc($this->app->db,
-				'getAdminMenu',
-				$this->app->db->quote($this->app->session->getUserId(),
-					'integer'),
-				'AdminMenuStore');
-
-			$class = $this->app->getMenuViewClass();
-			$this->menu = new $class();
-			$this->menu->setModel($menu_store);
-		}
-
-		$this->menu->init();
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->startCapture('navbar');
-		$this->displayNavBar();
-		$this->endCapture();
-
-		$this->startCapture('header');
-		$this->displayHeader();
-		$this->endCapture();
-
-		$this->startCapture('menu');
-		$this->displayMenu();
-		$this->endCapture();
-
-		$page_title = $this->navbar->getLastEntry()->title;
-		$this->data->title = SwatString::minimizeEntities($page_title).
-			' - '.SwatString::minimizeEntities($this->app->title);
-
-		$this->addHtmlHeadEntrySet($this->navbar->getHtmlHeadEntrySet());
-		$this->addHtmlHeadEntrySet($this->logout_form->getHtmlHeadEntrySet());
-		$this->addHtmlHeadEntrySet($this->menu->getHtmlHeadEntrySet());
-	}
-
-
-
-
-	/**
-	 * Display admin page header
-	 *
-	 * Display common elements for the header of an admin page. Sub-classes
-	 * should call this from their implementation of {@link AdminPage::display()}.
-	 */
-	protected function displayHeader()
-	{
-		echo '<div id="admin-syslinks">',
-			'<span id="admin-identifier">Welcome ',
-			SwatString::minimizeEntities($this->app->session->getName()),
-			' &nbsp; ',
-			'<a href="AdminSite/Profile">Login Settings</a> &nbsp; </span>';
-
-		$this->logout_form->display();
-
-		echo '</div>';
-	}
-
-
-
-
-	protected function displayNavBar()
-	{
-		$this->navbar->display();
-	}
-
-
-
-
-	/**
-	 * Display admin page menu
-	 *
-	 * Display the menu of an admin page. Sub-classes should call this
-	 * from their implementation of {@link AdminPage::display()}.
-	 */
-	protected function displayMenu()
-	{
-		$this->menu->display();
-	}
-
-
+    /**
+     * Display admin page menu.
+     *
+     * Display the menu of an admin page. Sub-classes should call this
+     * from their implementation of {@link AdminPage::display()}.
+     */
+    protected function displayMenu()
+    {
+        $this->menu->display();
+    }
 }
-
-?>

--- a/Admin/layouts/AdminLayout.php
+++ b/Admin/layouts/AdminLayout.php
@@ -10,7 +10,7 @@
 abstract class AdminLayout extends SiteLayout
 {
 	// build phase
-	// {{{ public function build()
+
 
 	public function build()
 	{
@@ -23,8 +23,8 @@ abstract class AdminLayout extends SiteLayout
 		$this->addHtmlHeadEntry('packages/admin/styles/admin-swat-local.css');
 	}
 
-	// }}}
-	// {{{ protected function getTagByFlagFile()
+
+
 
 	protected function getTagByFlagFile()
 	{
@@ -41,7 +41,7 @@ abstract class AdminLayout extends SiteLayout
 		return $tag;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/layouts/AdminLayout.php
+++ b/Admin/layouts/AdminLayout.php
@@ -1,47 +1,38 @@
 <?php
 
 /**
- * Base class for admin layouts
+ * Base class for admin layouts.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminLayout extends SiteLayout
 {
-	// build phase
+    // build phase
 
+    public function build()
+    {
+        parent::build();
 
-	public function build()
-	{
-		parent::build();
+        $yui = new SwatYUI(['fonts', 'grids']);
+        $this->addHtmlHeadEntrySet($yui->getHtmlHeadEntrySet());
 
-		$yui = new SwatYUI(array('fonts', 'grids'));
-		$this->addHtmlHeadEntrySet($yui->getHtmlHeadEntrySet());
+        $this->addHtmlHeadEntry('packages/admin/styles/admin-layout.css');
+        $this->addHtmlHeadEntry('packages/admin/styles/admin-swat-local.css');
+    }
 
-		$this->addHtmlHeadEntry('packages/admin/styles/admin-layout.css');
-		$this->addHtmlHeadEntry('packages/admin/styles/admin-swat-local.css');
-	}
+    protected function getTagByFlagFile()
+    {
+        $tag = null;
 
+        $www_root = dirname($_SERVER['SCRIPT_FILENAME']);
+        $filename = $www_root . DIRECTORY_SEPARATOR .
+            '..' . DIRECTORY_SEPARATOR . '.resource-tag';
 
+        if (file_exists($filename) && is_readable($filename)) {
+            $tag = trim(file_get_contents($filename));
+        }
 
-
-	protected function getTagByFlagFile()
-	{
-		$tag = null;
-
-		$www_root = dirname($_SERVER['SCRIPT_FILENAME']);
-		$filename = $www_root.DIRECTORY_SEPARATOR.
-			'..'.DIRECTORY_SEPARATOR.'.resource-tag';
-
-		if (file_exists($filename) && is_readable($filename)) {
-			$tag = trim(file_get_contents($filename));
-		}
-
-		return $tag;
-	}
-
-
+        return $tag;
+    }
 }
-
-?>

--- a/Admin/layouts/AdminLoginLayout.php
+++ b/Admin/layouts/AdminLoginLayout.php
@@ -1,14 +1,9 @@
 <?php
 
 /**
- * Layout for the login page
+ * Layout for the login page.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-class AdminLoginLayout extends AdminLayout
-{
-}
-
-?>
+class AdminLoginLayout extends AdminLayout {}

--- a/Admin/layouts/AdminMenuXMLRPCServerLayout.php
+++ b/Admin/layouts/AdminMenuXMLRPCServerLayout.php
@@ -1,55 +1,46 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
 {
+    /**
+     * This application's menu view.
+     *
+     * @var AdminMenuView
+     */
+    public $menu;
 
+    // init phase
 
-	/**
-	 * This application's menu view
-	 *
-	 * @var AdminMenuView
-	 */
-	public $menu = null;
+    public function init()
+    {
+        parent::init();
+        $this->initMenu();
+    }
 
+    /**
+     * Initializes layout menu view.
+     */
+    protected function initMenu()
+    {
+        if ($this->menu === null) {
+            $menu_store = SwatDB::executeStoredProc(
+                $this->app->db,
+                'getAdminMenu',
+                $this->app->db->quote(
+                    $this->app->session->getUserId(),
+                    'integer'
+                ),
+                'AdminMenuStore'
+            );
 
+            $class = $this->app->getMenuViewClass();
+            $this->menu = new $class($menu_store, $this->app);
+        }
 
-	// init phase
-
-
-	public function init()
-	{
-		parent::init();
-		$this->initMenu();
-	}
-
-
-
-
-	/**
-	 * Initializes layout menu view
-	 */
-	protected function initMenu()
-	{
-		if ($this->menu === null) {
-			$menu_store = SwatDB::executeStoredProc($this->app->db,
-				'getAdminMenu',
-				$this->app->db->quote($this->app->session->getUserId(),
-					'integer'),
-				'AdminMenuStore');
-
-			$class = $this->app->getMenuViewClass();
-			$this->menu = new $class($menu_store, $this->app);
-		}
-
-		$this->menu->init();
-	}
-
-
+        $this->menu->init();
+    }
 }
-
-?>

--- a/Admin/layouts/AdminMenuXMLRPCServerLayout.php
+++ b/Admin/layouts/AdminMenuXMLRPCServerLayout.php
@@ -34,7 +34,7 @@ class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
                     $this->app->session->getUserId(),
                     'integer'
                 ),
-                'AdminMenuStore'
+                AdminMenuStore::class
             );
 
             $class = $this->app->getMenuViewClass();

--- a/Admin/layouts/AdminMenuXMLRPCServerLayout.php
+++ b/Admin/layouts/AdminMenuXMLRPCServerLayout.php
@@ -7,7 +7,7 @@
  */
 class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
 {
-	// {{{ public properties
+
 
 	/**
 	 * This application's menu view
@@ -16,10 +16,10 @@ class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
 	 */
 	public $menu = null;
 
-	// }}}
+
 
 	// init phase
-	// {{{ public function init()
+
 
 	public function init()
 	{
@@ -27,8 +27,8 @@ class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
 		$this->initMenu();
 	}
 
-	// }}}
-	// {{{ protected function initMenu()
+
+
 
 	/**
 	 * Initializes layout menu view
@@ -49,7 +49,7 @@ class AdminMenuXMLRPCServerLayout extends SiteXMLRPCServerLayout
 		$this->menu->init();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminApproval.php
+++ b/Admin/pages/AdminApproval.php
@@ -1,214 +1,166 @@
 <?php
 
 /**
- * Generic admin approval page
+ * Generic admin approval page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * approval page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2008-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminApproval extends AdminPage
 {
-
-
-	protected $id;
-	protected $data_object;
-	protected $pending_ids = array();
-
-
-
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->ui->loadFromXML($this->getUiXml());
-
-		$this->pending_ids = $this->getPendingIds();
-
-		if (count($this->pending_ids) === 0) {
-			$this->relocate();
-		}
-
-		$this->id = $this->app->initVar('id');
-		if ($this->id === null) {
-			$this->id = $this->getNextId();
-		} else {
-			$this->id = (integer)$this->id;
-		}
-
-		$this->initDataObject($this->id);
-	}
-
-
-
-
-	abstract protected function initDataObject($id);
-
-
-
-
-	abstract protected function getPendingIds();
-
-
-
-
-	protected function getNextId()
-	{
-		$found = ($this->data_object === null);
-
-		foreach ($this->pending_ids as $id) {
-			if ($found) {
-				return $id;
-			} elseif ($id === $this->id) {
-				$found = true;
-			}
-		}
-
-		return null;
-	}
-
-
-
-
-	protected function getRemainingCount()
-	{
-		$count = 0;
-		$found = false;
-
-		foreach ($this->pending_ids as $id) {
-			if ($found) {
-				$count++;
-			} elseif ($id === $this->id) {
-				$found = true;
-			}
-		}
-
-		return $count;
-	}
-
-
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/approval.xml';
-	}
-
-
-
-	// process phase
-
-
-	protected function processInternal()
-	{
-		parent::processInternal();
-
-		$form = $this->ui->getWidget('form');
-
-		if ($form->isProcessed()) {
-			$this->save();
-			$this->relocate();
-		}
-	}
-
-
-
-
-	protected function save()
-	{
-		if ($this->ui->getWidget('approve_button')->hasBeenClicked()) {
-			$this->approve();
-		} elseif ($this->ui->getWidget('delete_button')->hasBeenClicked()) {
-			$this->delete();
-		}
-	}
-
-
-
-
-	abstract protected function approve();
-
-
-
-
-	protected function delete()
-	{
-		$this->data_object->delete();
-	}
-
-
-
-
-	protected function relocate()
-	{
-		$next_id = $this->getNextId();
-
-		$relocate_uri = ($next_id === null)
-			? ''
-			: sprintf(
-				'%s/%s?id=%d',
-				$this->component,
-				$this->subcomponent,
-				$next_id
-			);
-
-		$this->app->relocate($relocate_uri);
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$form = $this->ui->getWidget('form');
-		$form->action = $this->source.'?id='.$this->id;
-
-		ob_start();
-		$this->displayContent();
-		$this->ui->getWidget('content')->content = ob_get_clean();
-
-		$remaining = $this->getRemainingCount();
-		if ($remaining > 0) {
-			$locale = SwatI18NLocale::get();
-			$this->ui->getWidget('status')->content = sprintf(
-				Admin::_('%s%s%s still pending'),
-				'<span class="pending">',
-				SwatString::minimizeEntities($locale->formatNumber($remaining)),
-				'</span>'
-			);
-		}
-	}
-
-
-
-
-	abstract protected function displayContent();
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-
-		$this->layout->addHtmlHeadEntry(
-			'packages/admin/styles/admin-approval-page.css'
-		);
-	}
-
-
+    protected $id;
+    protected $data_object;
+    protected $pending_ids = [];
+
+    // init phase
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->ui->loadFromXML($this->getUiXml());
+
+        $this->pending_ids = $this->getPendingIds();
+
+        if (count($this->pending_ids) === 0) {
+            $this->relocate();
+        }
+
+        $this->id = $this->app->initVar('id');
+        if ($this->id === null) {
+            $this->id = $this->getNextId();
+        } else {
+            $this->id = (int) $this->id;
+        }
+
+        $this->initDataObject($this->id);
+    }
+
+    abstract protected function initDataObject($id);
+
+    abstract protected function getPendingIds();
+
+    protected function getNextId()
+    {
+        $found = ($this->data_object === null);
+
+        foreach ($this->pending_ids as $id) {
+            if ($found) {
+                return $id;
+            }
+            if ($id === $this->id) {
+                $found = true;
+            }
+        }
+
+        return null;
+    }
+
+    protected function getRemainingCount()
+    {
+        $count = 0;
+        $found = false;
+
+        foreach ($this->pending_ids as $id) {
+            if ($found) {
+                $count++;
+            } elseif ($id === $this->id) {
+                $found = true;
+            }
+        }
+
+        return $count;
+    }
+
+    protected function getUiXml()
+    {
+        return __DIR__ . '/approval.xml';
+    }
+
+    // process phase
+
+    protected function processInternal()
+    {
+        parent::processInternal();
+
+        $form = $this->ui->getWidget('form');
+
+        if ($form->isProcessed()) {
+            $this->save();
+            $this->relocate();
+        }
+    }
+
+    protected function save()
+    {
+        if ($this->ui->getWidget('approve_button')->hasBeenClicked()) {
+            $this->approve();
+        } elseif ($this->ui->getWidget('delete_button')->hasBeenClicked()) {
+            $this->delete();
+        }
+    }
+
+    abstract protected function approve();
+
+    protected function delete()
+    {
+        $this->data_object->delete();
+    }
+
+    protected function relocate()
+    {
+        $next_id = $this->getNextId();
+
+        $relocate_uri = ($next_id === null)
+            ? ''
+            : sprintf(
+                '%s/%s?id=%d',
+                $this->component,
+                $this->subcomponent,
+                $next_id
+            );
+
+        $this->app->relocate($relocate_uri);
+    }
+
+    // build phase
+
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+
+        $form = $this->ui->getWidget('form');
+        $form->action = $this->source . '?id=' . $this->id;
+
+        ob_start();
+        $this->displayContent();
+        $this->ui->getWidget('content')->content = ob_get_clean();
+
+        $remaining = $this->getRemainingCount();
+        if ($remaining > 0) {
+            $locale = SwatI18NLocale::get();
+            $this->ui->getWidget('status')->content = sprintf(
+                Admin::_('%s%s%s still pending'),
+                '<span class="pending">',
+                SwatString::minimizeEntities($locale->formatNumber($remaining)),
+                '</span>'
+            );
+        }
+    }
+
+    abstract protected function displayContent();
+
+    // finalize phase
+
+    public function finalize()
+    {
+        parent::finalize();
+
+        $this->layout->addHtmlHeadEntry(
+            'packages/admin/styles/admin-approval-page.css'
+        );
+    }
 }
-
-?>

--- a/Admin/pages/AdminApproval.php
+++ b/Admin/pages/AdminApproval.php
@@ -12,16 +12,16 @@
  */
 abstract class AdminApproval extends AdminPage
 {
-	// {{{ protected properties
+
 
 	protected $id;
 	protected $data_object;
 	protected $pending_ids = array();
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -45,18 +45,18 @@ abstract class AdminApproval extends AdminPage
 		$this->initDataObject($this->id);
 	}
 
-	// }}}
-	// {{{ abstract protected function initDataObject()
+
+
 
 	abstract protected function initDataObject($id);
 
-	// }}}
-	// {{{ abstract protected function getPendingIds()
+
+
 
 	abstract protected function getPendingIds();
 
-	// }}}
-	// {{{ protected function getNextId()
+
+
 
 	protected function getNextId()
 	{
@@ -73,8 +73,8 @@ abstract class AdminApproval extends AdminPage
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getRemainingCount()
+
+
 
 	protected function getRemainingCount()
 	{
@@ -92,18 +92,18 @@ abstract class AdminApproval extends AdminPage
 		return $count;
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/approval.xml';
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -117,8 +117,8 @@ abstract class AdminApproval extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function save()
+
+
 
 	protected function save()
 	{
@@ -129,21 +129,21 @@ abstract class AdminApproval extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ abstract protected function approve()
+
+
 
 	abstract protected function approve();
 
-	// }}}
-	// {{{ protected function delete()
+
+
 
 	protected function delete()
 	{
 		$this->data_object->delete();
 	}
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	protected function relocate()
 	{
@@ -161,10 +161,10 @@ abstract class AdminApproval extends AdminPage
 		$this->app->relocate($relocate_uri);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -189,15 +189,15 @@ abstract class AdminApproval extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ abstract protected function displayContent()
+
+
 
 	abstract protected function displayContent();
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize()
+
 
 	public function finalize()
 	{
@@ -208,7 +208,7 @@ abstract class AdminApproval extends AdminPage
 		);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminConfirmation.php
+++ b/Admin/pages/AdminConfirmation.php
@@ -13,7 +13,7 @@
 abstract class AdminConfirmation extends AdminPage
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -22,18 +22,18 @@ abstract class AdminConfirmation extends AdminPage
 		$this->navbar->createEntry(Admin::_('Confirmation'));
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/confirmation.xml';
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -72,8 +72,8 @@ abstract class AdminConfirmation extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function processResponse()
+
+
 
 	/**
 	 * Process the response
@@ -84,8 +84,8 @@ abstract class AdminConfirmation extends AdminPage
 	 */
 	abstract protected function processResponse(): void;
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	/**
 	 * Relocates to the previous page after processsing confirmation response
@@ -97,10 +97,10 @@ abstract class AdminConfirmation extends AdminPage
 		$this->app->relocate($url);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -109,8 +109,8 @@ abstract class AdminConfirmation extends AdminPage
 		$this->buildMessages();
 	}
 
-	// }}}
-	// {{{ protected function buildForm()
+
+
 
 	protected function buildForm()
 	{
@@ -123,8 +123,8 @@ abstract class AdminConfirmation extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function switchToCancelButton()
+
+
 
 	/**
 	 * Switches the default yes/no buttons to a cancel button
@@ -138,7 +138,7 @@ abstract class AdminConfirmation extends AdminPage
 		$this->ui->getWidget('no_button')->title = Admin::_('Cancel');
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminConfirmation.php
+++ b/Admin/pages/AdminConfirmation.php
@@ -1,144 +1,117 @@
 <?php
 
 /**
- * Generic admin confirmation page
+ * Generic admin confirmation page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * confirmation page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminConfirmation extends AdminPage
 {
-	// init phase
+    // init phase
 
+    protected function initInternal()
+    {
+        parent::initInternal();
+        $this->ui->loadFromXML($this->getUiXml());
+        $this->navbar->createEntry(Admin::_('Confirmation'));
+    }
 
-	protected function initInternal()
-	{
-		parent::initInternal();
-		$this->ui->loadFromXML($this->getUiXml());
-		$this->navbar->createEntry(Admin::_('Confirmation'));
-	}
+    protected function getUiXml()
+    {
+        return __DIR__ . '/confirmation.xml';
+    }
 
+    // process phase
 
+    protected function processInternal()
+    {
+        parent::processInternal();
 
+        $form = $this->ui->getWidget('confirmation_form');
+        $relocate = false;
 
-	protected function getUiXml()
-	{
-		return __DIR__.'/confirmation.xml';
-	}
+        if ($form->isAuthenticated()) {
+            if ($form->isProcessed()) {
+                if ($this->ui->getWidget('no_button')->hasBeenClicked()) {
+                    // if the no (aka cancel) button has been hit, relocate even
+                    // if the form doesn't validate or process.
+                    $relocate = true;
+                } elseif (!$form->hasMessage()) {
+                    // only process the response if the form validated and we're
+                    // not already relocating.
+                    $this->processResponse();
 
+                    $relocate = true;
+                }
+            }
 
+            if ($relocate) {
+                $this->relocate();
+            }
+        } else {
+            $message = new SwatMessage(Admin::_('There is a problem with the ' .
+                'information submitted.'), 'warning');
 
-	// process phase
+            $message->secondary_content =
+                Admin::_('In order to ensure your security, we were unable to ' .
+                'process your request. Please try again.');
 
+            $this->app->messages->add($message);
+        }
+    }
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+    /**
+     * Process the response.
+     *
+     * This method is called to perform whatever processing is required in
+     * response to the button clicked. It is called by the
+     * {@link AdminConfirmation::process} method.
+     */
+    abstract protected function processResponse(): void;
 
-		$form = $this->ui->getWidget('confirmation_form');
-		$relocate = false;
+    /**
+     * Relocates to the previous page after processsing confirmation response.
+     */
+    protected function relocate()
+    {
+        $form = $this->ui->getWidget('confirmation_form');
+        $url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
+        $this->app->relocate($url);
+    }
 
-		if ($form->isAuthenticated()) {
-			if ($form->isProcessed()) {
-				if ($this->ui->getWidget('no_button')->hasBeenClicked()) {
-					// if the no (aka cancel) button has been hit, relocate even
-					// if the form doesn't validate or process.
-					$relocate = true;
-				} elseif (!$form->hasMessage()) {
-					// only process the response if the form validated and we're
-					// not already relocating.
-					$this->processResponse();
+    // build phase
 
-					$relocate = true;
-				}
-			}
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+        $this->buildForm();
+        $this->buildMessages();
+    }
 
-			if ($relocate) {
-				$this->relocate();
-			}
-		} else {
-			$message = new SwatMessage(Admin::_('There is a problem with the '.
-				'information submitted.'), 'warning');
+    protected function buildForm()
+    {
+        $form = $this->ui->getWidget('confirmation_form');
+        $form->action = $this->source;
 
-			$message->secondary_content =
-				Admin::_('In order to ensure your security, we were unable to '.
-				'process your request. Please try again.');
+        if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
+            $url = $this->getRefererURL();
+            $form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
+        }
+    }
 
-			$this->app->messages->add($message);
-		}
-	}
-
-
-
-
-	/**
-	 * Process the response
-	 *
-	 * This method is called to perform whatever processing is required in
-	 * response to the button clicked. It is called by the
-	 * {@link AdminConfirmation::process} method.
-	 */
-	abstract protected function processResponse(): void;
-
-
-
-
-	/**
-	 * Relocates to the previous page after processsing confirmation response
-	 */
-	protected function relocate()
-	{
-		$form = $this->ui->getWidget('confirmation_form');
-		$url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
-		$this->app->relocate($url);
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-		$this->buildForm();
-		$this->buildMessages();
-	}
-
-
-
-
-	protected function buildForm()
-	{
-		$form = $this->ui->getWidget('confirmation_form');
-		$form->action = $this->source;
-
-		if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
-			$url = $this->getRefererURL();
-			$form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
-		}
-	}
-
-
-
-
-	/**
-	 * Switches the default yes/no buttons to a cancel button
-	 *
-	 * Call this method if a confirmation page is displayed and the desired
-	 * action of the user is impossible.
-	 */
-	protected function switchToCancelButton()
-	{
-		$this->ui->getWidget('yes_button')->visible = false;
-		$this->ui->getWidget('no_button')->title = Admin::_('Cancel');
-	}
-
-
+    /**
+     * Switches the default yes/no buttons to a cancel button.
+     *
+     * Call this method if a confirmation page is displayed and the desired
+     * action of the user is impossible.
+     */
+    protected function switchToCancelButton()
+    {
+        $this->ui->getWidget('yes_button')->visible = false;
+        $this->ui->getWidget('no_button')->title = Admin::_('Cancel');
+    }
 }
-
-?>

--- a/Admin/pages/AdminDBConfirmation.php
+++ b/Admin/pages/AdminDBConfirmation.php
@@ -12,7 +12,7 @@
  */
 abstract class AdminDBConfirmation extends AdminConfirmation
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The current items of this confirmation page
@@ -31,8 +31,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 	 */
 	protected $extended_selected;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	/**
 	 * Creates a new database-driven confirmation page
@@ -52,8 +52,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		$this->items = new SwatViewSelection(array());
 	}
 
-	// }}}
-	// {{{ public function setItems()
+
+
 
 	/**
 	 * Sets the items of this confirmation page
@@ -87,8 +87,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		$form->addHiddenField('extended_selected', $this->extended_selected);
 	}
 
-	// }}}
-	// {{{ protected function getItemList()
+
+
 
 	/**
 	 * Get the items of this confirmation page as a database-quoted list
@@ -108,8 +108,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		return implode(',', $list);
 	}
 
-	// }}}
-	// {{{ protected function getItemCount()
+
+
 
 	/**
 	 * Gets the number of items on this confirmation page
@@ -121,8 +121,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		return count($this->items);
 	}
 
-	// }}}
-	// {{{ protected function getFirstItem()
+
+
 
 	/**
 	 * Gets the first item on this confirmation page
@@ -137,10 +137,10 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		return $this->items->current();
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -152,10 +152,10 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 			$this->setItems($items);
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processResponse()
+
 
 	protected function processResponse(): void
 	{
@@ -179,8 +179,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		}
 	}
 
-	// }}}
-	// {{{ protected function generateMessage()
+
+
 
 	protected function generateMessage(Throwable $e)
 	{
@@ -196,8 +196,8 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 		$this->app->messages->add($message);
 	}
 
-	// }}}
-	// {{{ protected function processDBData()
+
+
 
 	/**
 	 * Processes data in the database
@@ -213,10 +213,10 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 			$form->getHiddenField('extended_selected'));
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -227,7 +227,7 @@ abstract class AdminDBConfirmation extends AdminConfirmation
 			$this->setItems(new SwatViewSelection(array($id)));
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminDBConfirmation.php
+++ b/Admin/pages/AdminDBConfirmation.php
@@ -1,233 +1,208 @@
 <?php
 
 /**
- * Generic admin database confirmation page
+ * Generic admin database confirmation page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * DB confirmation page, inherit directly from AdminConfirmation instead.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminDBConfirmation extends AdminConfirmation
 {
+    /**
+     * The current items of this confirmation page.
+     *
+     * @var SwatViewSelection
+     *
+     * @see AdminDBConfirmation::setItems()
+     */
+    protected $items;
 
+    /**
+     * Whether the extended "all items" checkbox was checked or not.
+     *
+     * @var bool
+     *
+     * @see SwatCheckAll::isExtendedSelected()
+     */
+    protected $extended_selected;
 
-	/**
-	 * The current items of this confirmation page
-	 *
-	 * @var SwatViewSelection
-	 *
-	 * @see AdminDBConfirmation::setItems()
-	 */
-	protected $items;
+    /**
+     * Creates a new database-driven confirmation page.
+     *
+     * @param SiteLayout $layout optional
+     */
+    public function __construct(
+        SiteApplication $app,
+        ?SiteLayout $layout = null,
+        array $arguments = []
+    ) {
+        parent::__construct($app, $layout, $arguments);
 
-	/**
-	 * Whether the extended "all items" checkbox was checked or not
-	 *
-	 * @var boolean
-	 * @see SwatCheckAll::isExtendedSelected()
-	 */
-	protected $extended_selected;
+        // don't use setItems() here because the UI has not been constructed
+        // yet and the hidden value cannot be added to the form
+        $this->items = new SwatViewSelection([]);
+    }
 
+    /**
+     * Sets the items of this confirmation page.
+     *
+     * @param array|SwatViewSelection $items             the items of this confirmation
+     *                                                   page. Developers are encouraged
+     *                                                   to use a SwatViewSelection; array
+     *                                                   is provided for backwards
+     *                                                   compatibility.
+     * @param bool                    $extended_selected whether the extended "all items"
+     *                                                   checkbox was checked or not
+     */
+    public function setItems($items, $extended_selected = false)
+    {
+        $this->extended_selected = $extended_selected;
 
+        if (is_array($items)) {
+            $items = new SwatViewSelection($items);
+        }
 
+        if (!$items instanceof SwatViewSelection) {
+            throw new SwatInvalidClassException(
+                'The $items parameter must be either a SwatViewSelection or ' .
+                'an array.',
+                0,
+                $items
+            );
+        }
 
-	/**
-	 * Creates a new database-driven confirmation page
-	 *
-	 * @param SiteApplication $app
-	 * @param SiteLayout $layout optional.
-	 */
-	public function __construct(
-		SiteApplication $app,
-		SiteLayout $layout = null,
-		array $arguments = array()
-	) {
-		parent::__construct($app, $layout, $arguments);
+        $this->items = $items;
 
-		// don't use setItems() here because the UI has not been constructed
-		// yet and the hidden value cannot be added to the form
-		$this->items = new SwatViewSelection(array());
-	}
+        // Add a hidden field to this confirmation page's form to store the
+        // current items of this confirmation page across requests
+        $form = $this->ui->getWidget('confirmation_form');
+        $form->addHiddenField('items', $this->items);
+        $form->addHiddenField('extended_selected', $this->extended_selected);
+    }
 
+    /**
+     * Get the items of this confirmation page as a database-quoted list.
+     *
+     * @param string $type optional. The MDB2 datatype used to quote the items.
+     *                     By default, 'integer' is used.
+     *
+     * @return string a comma-seperated, database-quoted list of items
+     */
+    protected function getItemList($type = 'integer')
+    {
+        $list = [];
 
+        foreach ($this->items as $item) {
+            $list[] = $this->app->db->quote($item, $type);
+        }
 
+        return implode(',', $list);
+    }
 
-	/**
-	 * Sets the items of this confirmation page
-	 *
-	 * @param SwatViewSelection|array $items the items of this confirmation
-	 *                                        page. Developers are encouraged
-	 *                                        to use a SwatViewSelection; array
-	 *                                        is provided for backwards
-	 *                                        compatibility.
-	 * @param boolean $extended_selected  whether the extended "all items"
-	 *                                     checkbox was checked or not
-	 */
-	public function setItems($items, $extended_selected = false)
-	{
-		$this->extended_selected = $extended_selected;
+    /**
+     * Gets the number of items on this confirmation page.
+     *
+     * @return int the number of items on this confirmation page
+     */
+    protected function getItemCount()
+    {
+        return count($this->items);
+    }
 
-		if (is_array($items))
-			$items = new SwatViewSelection($items);
+    /**
+     * Gets the first item on this confirmation page.
+     *
+     * @return mixed the first item
+     *
+     * @see AdminDBConfirmation::setItems()
+     */
+    protected function getFirstItem()
+    {
+        $this->items->rewind();
 
-		if (!($items instanceof SwatViewSelection))
-			throw new SwatInvalidClassException(
-				'The $items parameter must be either a SwatViewSelection or '.
-				'an array.', 0, $items);
+        return $this->items->current();
+    }
 
-		$this->items = $items;
+    // init phase
 
-		// Add a hidden field to this confirmation page's form to store the
-		// current items of this confirmation page across requests
-		$form = $this->ui->getWidget('confirmation_form');
-		$form->addHiddenField('items', $this->items);
-		$form->addHiddenField('extended_selected', $this->extended_selected);
-	}
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $form = $this->ui->getWidget('confirmation_form');
+        $items = $form->getHiddenField('items');
+        if ($items !== null) {
+            $this->setItems($items);
+        }
+    }
 
+    // process phase
 
+    protected function processResponse(): void
+    {
+        $form = $this->ui->getWidget('confirmation_form');
 
-	/**
-	 * Get the items of this confirmation page as a database-quoted list
-	 *
-	 * @param string $type optional. The MDB2 datatype used to quote the items.
-	 *                      By default, 'integer' is used.
-	 *
-	 * @return string a comma-seperated, database-quoted list of items.
-	 */
-	protected function getItemList($type = 'integer')
-	{
-		$list = array();
+        if ($this->ui->getWidget('yes_button')->hasBeenClicked()) {
+            try {
+                $transaction = new SwatDBTransaction($this->app->db);
+                $this->processDBData();
+                $transaction->commit();
+            } catch (SwatDBException $e) {
+                $transaction->rollback();
+                $this->generateMessage($e);
+                $e->processAndContinue();
+            } catch (SwatException $e) {
+                $this->generateMessage($e);
+                $e->processAndContinue();
+            }
+        }
+    }
 
-		foreach ($this->items as $item)
-			$list[] = $this->app->db->quote($item, $type);
+    protected function generateMessage(Throwable $e)
+    {
+        if ($e instanceof SwatDBException) {
+            $message = new SwatMessage(
+                Admin::_('A database error has occured.'),
+                SwatMessage::SYSTEM_ERROR
+            );
+        } else {
+            $message = new SwatMessage(
+                Admin::_('An error has occured.'),
+                SwatMessage::SYSTEM_ERROR
+            );
+        }
 
-		return implode(',', $list);
-	}
+        $this->app->messages->add($message);
+    }
 
+    /**
+     * Processes data in the database.
+     *
+     * This method is called to process data after an affirmative
+     * confirmation response. Sub-classes should implement this method and
+     * perform whatever actions are necessary to process the response.
+     */
+    protected function processDBData(): void
+    {
+        $form = $this->ui->getWidget('confirmation_form');
+        $this->setItems(
+            $form->getHiddenField('items'),
+            $form->getHiddenField('extended_selected')
+        );
+    }
 
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-	/**
-	 * Gets the number of items on this confirmation page
-	 *
-	 * @return integer the number of items on this confirmation page.
-	 */
-	protected function getItemCount()
-	{
-		return count($this->items);
-	}
-
-
-
-
-	/**
-	 * Gets the first item on this confirmation page
-	 *
-	 * @return mixed the first item.
-	 *
-	 * @see AdminDBConfirmation::setItems()
-	 */
-	protected function getFirstItem()
-	{
-		$this->items->rewind();
-		return $this->items->current();
-	}
-
-
-
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$form = $this->ui->getWidget('confirmation_form');
-		$items = $form->getHiddenField('items');
-		if ($items !== null)
-			$this->setItems($items);
-	}
-
-
-
-	// process phase
-
-
-	protected function processResponse(): void
-	{
-		$form = $this->ui->getWidget('confirmation_form');
-
-		if ($this->ui->getWidget('yes_button')->hasBeenClicked()) {
-			try {
-				$transaction = new SwatDBTransaction($this->app->db);
-				$this->processDBData();
-				$transaction->commit();
-
-			} catch (SwatDBException $e) {
-				$transaction->rollback();
-				$this->generateMessage($e);
-				$e->processAndContinue();
-
-			} catch (SwatException $e) {
-				$this->generateMessage($e);
-				$e->processAndContinue();
-			}
-		}
-	}
-
-
-
-
-	protected function generateMessage(Throwable $e)
-	{
-		if ($e instanceof SwatDBException) {
-			$message = new SwatMessage(
-				Admin::_('A database error has occured.'),
-				SwatMessage::SYSTEM_ERROR);
-		} else {
-			$message = new SwatMessage(Admin::_('An error has occured.'),
-				SwatMessage::SYSTEM_ERROR);
-		}
-
-		$this->app->messages->add($message);
-	}
-
-
-
-
-	/**
-	 * Processes data in the database
-	 *
-	 * This method is called to process data after an affirmative
-	 * confirmation response. Sub-classes should implement this method and
-	 * perform whatever actions are necessary to process the response.
-	 */
-	protected function processDBData(): void
-	{
-		$form = $this->ui->getWidget('confirmation_form');
-		$this->setItems($form->getHiddenField('items'),
-			$form->getHiddenField('extended_selected'));
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$id = SiteApplication::initVar('id', null, SiteApplication::VAR_GET);
-		if ($id !== null)
-			$this->setItems(new SwatViewSelection(array($id)));
-	}
-
-
+        $id = SiteApplication::initVar('id', null, SiteApplication::VAR_GET);
+        if ($id !== null) {
+            $this->setItems(new SwatViewSelection([$id]));
+        }
+    }
 }
-
-?>

--- a/Admin/pages/AdminDBDelete.php
+++ b/Admin/pages/AdminDBDelete.php
@@ -13,14 +13,14 @@
  */
 abstract class AdminDBDelete extends AdminDBConfirmation
 {
-	// {{{ protected properties
+
 
 	protected $single_delete = false;
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -48,10 +48,10 @@ abstract class AdminDBDelete extends AdminDBConfirmation
 		$this->navbar->createEntry(Admin::_('Delete'));
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function generateMessage()
+
 
 	protected function generateMessage(Throwable $e)
 	{
@@ -68,8 +68,8 @@ abstract class AdminDBDelete extends AdminDBConfirmation
 		$this->app->messages->add($message);
 	}
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	protected function relocate()
 	{
@@ -92,7 +92,7 @@ abstract class AdminDBDelete extends AdminDBConfirmation
 		}
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminDBDelete.php
+++ b/Admin/pages/AdminDBDelete.php
@@ -1,98 +1,89 @@
 <?php
 
 /**
- * Generic admin database delete page
+ * Generic admin database delete page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * delete page, inherit directly from {@link AdminConfirmation} or
  * {@link AdminDBConfirmation} instead.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminDBDelete extends AdminDBConfirmation
 {
+    protected $single_delete = false;
 
+    // init phase
 
-	protected $single_delete = false;
+    protected function initInternal()
+    {
+        parent::initInternal();
 
+        $this->single_delete = (bool) SiteApplication::initVar(
+            'single_delete',
+            false,
+            SiteApplication::VAR_POST
+        );
 
+        $id = SiteApplication::initVar('id', null, SiteApplication::VAR_GET);
 
-	// init phase
+        if ($id !== null) {
+            $this->setItems([$id]);
+            $this->single_delete = true;
+            $form = $this->ui->getWidget('confirmation_form');
+            $form->addHiddenField('single_delete', $this->single_delete);
+        }
 
+        $yes_button = $this->ui->getWidget('yes_button');
+        $yes_button->setFromStock('delete');
 
-	protected function initInternal()
-	{
-		parent::initInternal();
+        $no_button = $this->ui->getWidget('no_button');
+        $no_button->setFromStock('cancel');
 
-		$this->single_delete = (boolean)SiteApplication::initVar(
-			'single_delete', false, SiteApplication::VAR_POST);
+        $this->navbar->popEntry();
+        $this->navbar->createEntry(Admin::_('Delete'));
+    }
 
-		$id = SiteApplication::initVar('id', null, SiteApplication::VAR_GET);
+    // process phase
 
-		if ($id !== null) {
-			$this->setItems(array($id));
-			$this->single_delete = true;
-			$form = $this->ui->getWidget('confirmation_form');
-			$form->addHiddenField('single_delete', $this->single_delete);
-		}
-
-		$yes_button = $this->ui->getWidget('yes_button');
-		$yes_button->setFromStock('delete');
-
-		$no_button = $this->ui->getWidget('no_button');
-		$no_button->setFromStock('cancel');
-
-		$this->navbar->popEntry();
-		$this->navbar->createEntry(Admin::_('Delete'));
-	}
-
-
-
-	// process phase
-
-
-	protected function generateMessage(Throwable $e)
-	{
-		if ($e instanceof SwatDBException) {
-			$message = new SwatMessage(Admin::_('A database error has occured.
+    protected function generateMessage(Throwable $e)
+    {
+        if ($e instanceof SwatDBException) {
+            $message = new SwatMessage(
+                Admin::_('A database error has occured.
 				The item(s) were not deleted.'),
-				'system-error');
-		} else {
-			$message = new SwatMessage(Admin::_('An error has occured.
+                'system-error'
+            );
+        } else {
+            $message = new SwatMessage(
+                Admin::_('An error has occured.
 				The item(s) were not deleted.'),
-				'system-error');
-		}
+                'system-error'
+            );
+        }
 
-		$this->app->messages->add($message);
-	}
+        $this->app->messages->add($message);
+    }
 
+    protected function relocate()
+    {
+        $form = $this->ui->getWidget('confirmation_form');
+        $url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
+        // always search for only the component name with slashes. This helps
+        // for cases where the page name has a match to the component name we're
+        // checking against, and if the trailing slash is missing, we're
+        // redirecting to the index anyway.
+        $component = '/' . $this->getComponentName() . '/';
 
-
-
-	protected function relocate()
-	{
-		$form = $this->ui->getWidget('confirmation_form');
-		$url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
-		// always search for only the component name with slashes. This helps
-		// for cases where the page name has a match to the component name we're
-		// checking against, and if the trailing slash is missing, we're
-		// redirecting to the index anyway.
-		$component = '/'.$this->getComponentName().'/';
-
-		// if the component name is in the relocate url, relocate to the
-		// the component index page to prevent relocating to a details page that
-		// will no longer exist.
-		if (mb_strpos($url, $component) === false ||
-			$form->button->id == 'no_button') {
-			parent::relocate();
-		} else {
-			$this->app->relocate($this->getComponentName());
-		}
-	}
-
-
+        // if the component name is in the relocate url, relocate to the
+        // the component index page to prevent relocating to a details page that
+        // will no longer exist.
+        if (mb_strpos($url, $component) === false
+            || $form->button->id == 'no_button') {
+            parent::relocate();
+        } else {
+            $this->app->relocate($this->getComponentName());
+        }
+    }
 }
-
-?>

--- a/Admin/pages/AdminDBEdit.php
+++ b/Admin/pages/AdminDBEdit.php
@@ -13,7 +13,7 @@
 abstract class AdminDBEdit extends AdminEdit
 {
 	// process phase
-	// {{{ protected function saveData()
+
 
 	protected function saveData(): bool
 	{
@@ -55,8 +55,8 @@ abstract class AdminDBEdit extends AdminEdit
 		return $relocate;
 	}
 
-	// }}}
-	// {{{ abstract protected function saveDBData()
+
+
 
 	/**
 	 * Save the data from the database
@@ -68,10 +68,10 @@ abstract class AdminDBEdit extends AdminEdit
 	 */
 	abstract protected function saveDBData(): void;
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function loadData()
+
 
 	protected function loadData()
 	{
@@ -79,8 +79,8 @@ abstract class AdminDBEdit extends AdminEdit
 		return true;
 	}
 
-	// }}}
-	// {{{ abstract protected function loadDBData()
+
+
 
 	/**
 	 * Load the data from the database
@@ -92,7 +92,7 @@ abstract class AdminDBEdit extends AdminEdit
 	 */
 	abstract protected function loadDBData();
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminDBEdit.php
+++ b/Admin/pages/AdminDBEdit.php
@@ -1,98 +1,84 @@
 <?php
 
 /**
- * Generic admin database edit page
+ * Generic admin database edit page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * edit page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminDBEdit extends AdminEdit
 {
-	// process phase
+    // process phase
 
+    protected function saveData(): bool
+    {
+        $relocate = true;
+        $message = null;
 
-	protected function saveData(): bool
-	{
-		$relocate = true;
-		$message = null;
+        try {
+            $transaction = new SwatDBTransaction($this->app->db);
+            $this->saveDBData();
+            $transaction->commit();
+        } catch (SwatDBException $e) {
+            $transaction->rollback();
 
-		try {
-			$transaction = new SwatDBTransaction($this->app->db);
-			$this->saveDBData();
-			$transaction->commit();
-		} catch (SwatDBException $e) {
-			$transaction->rollback();
+            $message = new SwatMessage(
+                Admin::_(
+                    'A database error has occurred. The item was not saved.'
+                ),
+                'system-error'
+            );
 
-			$message = new SwatMessage(
-				Admin::_(
-					'A database error has occurred. The item was not saved.'
-				),
-				'system-error'
-			);
+            $e->processAndContinue();
+            $relocate = false;
+        } catch (SwatException $e) {
+            $message = new SwatMessage(
+                Admin::_(
+                    'An error has occurred. The item was not saved.'
+                ),
+                'system-error'
+            );
 
-			$e->processAndContinue();
-			$relocate = false;
-		} catch (SwatException $e) {
-			$message = new SwatMessage(
-				Admin::_(
-					'An error has occurred. The item was not saved.'
-				),
-				'system-error'
-			);
+            $e->processAndContinue();
+            $relocate = false;
+        }
 
-			$e->processAndContinue();
-			$relocate = false;
-		}
+        if ($message !== null) {
+            $this->app->messages->add($message);
+        }
 
-		if ($message !== null) {
-			$this->app->messages->add($message);
-		}
+        return $relocate;
+    }
 
-		return $relocate;
-	}
+    /**
+     * Save the data from the database.
+     *
+     * This method is called to save data from the widgets after processing.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to store the data. Widgets can be accessed through the
+     * $ui class variable.
+     */
+    abstract protected function saveDBData(): void;
 
+    // build phase
 
+    protected function loadData()
+    {
+        $this->loadDBData();
 
+        return true;
+    }
 
-	/**
-	 * Save the data from the database
-	 *
-	 * This method is called to save data from the widgets after processing.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to store the data. Widgets can be accessed through the
-	 * $ui class variable.
-	 */
-	abstract protected function saveDBData(): void;
-
-
-
-	// build phase
-
-
-	protected function loadData()
-	{
-		$this->loadDBData();
-		return true;
-	}
-
-
-
-
-	/**
-	 * Load the data from the database
-	 *
-	 * This method is called to load data to be edited into the widgets.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to obtain the data. Widgets can be accessed through the
-	 * $ui class variable.
-	 */
-	abstract protected function loadDBData();
-
-
+    /**
+     * Load the data from the database.
+     *
+     * This method is called to load data to be edited into the widgets.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to obtain the data. Widgets can be accessed through the
+     * $ui class variable.
+     */
+    abstract protected function loadDBData();
 }
-
-?>

--- a/Admin/pages/AdminDBOrder.php
+++ b/Admin/pages/AdminDBOrder.php
@@ -12,7 +12,7 @@
 abstract class AdminDBOrder extends AdminOrder
 {
 	// process phase
-	// {{{ protected function saveData()
+
 
 	protected function saveData()
 	{
@@ -41,15 +41,15 @@ abstract class AdminDBOrder extends AdminOrder
 		}
 	}
 
-	// }}}
-	// {{{ protected function saveDBData()
+
+
 
 	protected function saveDBData()
 	{
 		$this->saveIndexes();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminDBOrder.php
+++ b/Admin/pages/AdminDBOrder.php
@@ -1,55 +1,46 @@
 <?php
 
 /**
- * DB admin ordering page
+ * DB admin ordering page.
  *
  * An ordering page with DB error checking.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminDBOrder extends AdminOrder
 {
-	// process phase
+    // process phase
 
+    protected function saveData()
+    {
+        try {
+            $transaction = new SwatDBTransaction($this->app->db);
+            $this->saveDBData();
+            $transaction->commit();
+        } catch (SwatDBException $e) {
+            $transaction->rollback();
 
-	protected function saveData()
-	{
-		try {
-			$transaction = new SwatDBTransaction($this->app->db);
-			$this->saveDBData();
-			$transaction->commit();
+            $message = new SwatMessage(
+                Admin::_('A database error has occured. The item was not saved.'),
+                'system-error'
+            );
 
-		} catch (SwatDBException $e) {
-			$transaction->rollback();
+            $this->app->messages->add($message);
+            $e->process();
+        } catch (SwatException $e) {
+            $message = new SwatMessage(
+                Admin::_('An error has occured. The item was not saved.'),
+                'system-error'
+            );
 
-			$message = new SwatMessage(
-				Admin::_('A database error has occured. The item was not saved.'),
-				'system-error');
+            $this->app->messages->add($message);
+            $e->process();
+        }
+    }
 
-			$this->app->messages->add($message);
-			$e->process();
-
-		} catch (SwatException $e) {
-			$message = new SwatMessage(
-				Admin::_('An error has occured. The item was not saved.'),
-				'system-error');
-
-			$this->app->messages->add($message);
-			$e->process();
-		}
-	}
-
-
-
-
-	protected function saveDBData()
-	{
-		$this->saveIndexes();
-	}
-
-
+    protected function saveDBData()
+    {
+        $this->saveIndexes();
+    }
 }
-
-?>

--- a/Admin/pages/AdminEdit.php
+++ b/Admin/pages/AdminEdit.php
@@ -1,278 +1,230 @@
 <?php
 
 /**
- * Generic admin edit page
+ * Generic admin edit page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * edit page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminEdit extends AdminPage
 {
-
-
-	protected $id;
-
-
-
-
-	protected function isNew()
-	{
-		return ($this->id === null);
-	}
-
-
-
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->id = SiteApplication::initVar('id');
-
-		if (is_numeric($this->id)) {
-			$this->id = intval($this->id);
-		}
-	}
-
-
-
-	// process phase
-
-
-	protected function processInternal()
-	{
-		parent::processInternal();
-
-		$form = $this->ui->getWidget('edit_form');
-
-		if ($form->isProcessed()) {
-			$this->validate();
-
-			// validate() doesn't return anything, so explicitly
-			// check if the form has a message here
-			if ($form->hasMessage()) {
-				$message = new SwatMessage(
-					Admin::_(
-						'There is a problem with the information submitted.'
-					),
-					'error'
-				);
-
-				$message->secondary_content = Admin::_(
-					'Please address the fields highlighted below and '.
-					're-submit the form.'
-				);
-
-				$this->app->messages->add($message);
-			} else {
-				if ($this->saveData()) {
-					$this->relocate();
-				}
-			}
-		}
-	}
-
-
-
-
-	/**
-	 * Sub-classes should implement this method to perform validation.
-	 */
-	protected function validate(): void
-	{
-	}
-
-
-
-
-	/**
-	 * Save the data
-	 *
-	 * This method is called to save data from the widgets after processing.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to store the data. Widgets can be accessed through the
-	 * $ui class variable.
-	 *
-	 * @return bool true if save was successful.
-	 */
-	abstract protected function saveData(): bool;
-
-
-
-
-	/**
-	 * Generate a shortname
-	 *
-	 * This method allows edit pages to easily generate a unique shortname by
-	 * calling this method during their processing phase. The shortname is
-	 * generated from the text provided using SwatString::condenseToName() and
-	 * validated with AdminEdit::validateShortname().  If the initial shortname
-	 * is not valid an integer is appended and incremented until the shortname
-	 * is valid.  Sub-classes should override validateShortname() to perform
-	 * whatever checks are necessary to validate the shortname.
-	 *
-	 * @param string $text Text to generate the shortname from.
-	 * @return string A shortname.
-	 */
-	protected function generateShortname($text)
-	{
-		$shortname_base = SwatString::condenseToName($text);
-		$count = 1;
-		$shortname = $shortname_base;
-
-		while ($this->validateShortname($shortname) === false) {
-			$shortname = $shortname_base.$count++;
-		}
-
-		return $shortname;
-	}
-
-
-
-
-	/**
-	 * Validate a shortname
-	 *
-	 * This method is called by AdminEdit::generateShortname().
-	 * Sub-classes should override this method to perform
-	 * whatever checks are necessary to validate the shortname.
-	 *
-	 * @param string $shortname The shortname to validate.
-	 * @return boolean Whether the shortname is valid.
-	 */
-	protected function validateShortname($shortname)
-	{
-		return true;
-	}
-
-
-
-
-	/**
-	 * Relocate after process
-	 */
-	protected function relocate()
-	{
-		$form = $this->ui->getWidget('edit_form');
-		$url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
-		$this->app->relocate($url);
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$this->buildForm();
-		$this->buildFrame();
-		$this->buildButton();
-		$this->buildMessages();
-	}
-
-
-
-
-	protected function buildForm()
-	{
-		$form_found = true;
-		try {
-			$form = $this->ui->getWidget('edit_form');
-		} catch (SwatWidgetNotFoundException $e) {
-			$form_found = false;
-		}
-
-		if ($form_found) {
-			if (!$this->isNew() && !$form->isProcessed()) {
-				$this->loadData();
-			}
-
-			$form->action = $this->source;
-			$form->autofocus = true;
-			$form->addHiddenField('id', $this->id);
-
-			if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
-				$url = $this->getRefererURL();
-				$form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
-			}
-		}
-	}
-
-
-
-
-	/**
-	 * Load the data
-	 *
-	 * This method is called to load data to be edited into the widgets.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to obtain the data. Widgets can be accessed through the
-	 * $ui class variable.
-	 *
-	 * @return boolean true if load was successful.
-	 */
-	abstract protected function loadData();
-
-
-
-
-	protected function buildButton()
-	{
-		$button = $this->ui->getWidget('submit_button');
-
-		if ($button->title == 'Submit') {
-			if ($this->isNew()) {
-				$button->setFromStock('create');
-			} else {
-				$button->setFromStock('apply');
-			}
-		}
-	}
-
-
-
-
-	protected function buildFrame()
-	{
-		$frame = $this->ui->getWidget('edit_frame');
-
-		if ($this->isNew()) {
-			$frame->title = sprintf(
-				Admin::_('New %s'),
-				$frame->title
-			);
-		} else {
-			$frame->title = sprintf(
-				Admin::_('Edit %s'),
-				$frame->title
-			);
-		}
-	}
-
-
-
-
-	protected function buildNavBar()
-	{
-		if ($this->isNew()) {
-			$title = Admin::_('New');
-		} else {
-			$title = Admin::_('Edit');
-		}
-
-		$this->navbar->createEntry($title);
-	}
-
-
+    protected $id;
+
+    protected function isNew()
+    {
+        return $this->id === null;
+    }
+
+    // init phase
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->id = SiteApplication::initVar('id');
+
+        if (is_numeric($this->id)) {
+            $this->id = intval($this->id);
+        }
+    }
+
+    // process phase
+
+    protected function processInternal()
+    {
+        parent::processInternal();
+
+        $form = $this->ui->getWidget('edit_form');
+
+        if ($form->isProcessed()) {
+            $this->validate();
+
+            // validate() doesn't return anything, so explicitly
+            // check if the form has a message here
+            if ($form->hasMessage()) {
+                $message = new SwatMessage(
+                    Admin::_(
+                        'There is a problem with the information submitted.'
+                    ),
+                    'error'
+                );
+
+                $message->secondary_content = Admin::_(
+                    'Please address the fields highlighted below and ' .
+                    're-submit the form.'
+                );
+
+                $this->app->messages->add($message);
+            } else {
+                if ($this->saveData()) {
+                    $this->relocate();
+                }
+            }
+        }
+    }
+
+    /**
+     * Sub-classes should implement this method to perform validation.
+     */
+    protected function validate(): void {}
+
+    /**
+     * Save the data.
+     *
+     * This method is called to save data from the widgets after processing.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to store the data. Widgets can be accessed through the
+     * $ui class variable.
+     *
+     * @return bool true if save was successful
+     */
+    abstract protected function saveData(): bool;
+
+    /**
+     * Generate a shortname.
+     *
+     * This method allows edit pages to easily generate a unique shortname by
+     * calling this method during their processing phase. The shortname is
+     * generated from the text provided using SwatString::condenseToName() and
+     * validated with AdminEdit::validateShortname().  If the initial shortname
+     * is not valid an integer is appended and incremented until the shortname
+     * is valid.  Sub-classes should override validateShortname() to perform
+     * whatever checks are necessary to validate the shortname.
+     *
+     * @param string $text text to generate the shortname from
+     *
+     * @return string a shortname
+     */
+    protected function generateShortname($text)
+    {
+        $shortname_base = SwatString::condenseToName($text);
+        $count = 1;
+        $shortname = $shortname_base;
+
+        while ($this->validateShortname($shortname) === false) {
+            $shortname = $shortname_base . $count++;
+        }
+
+        return $shortname;
+    }
+
+    /**
+     * Validate a shortname.
+     *
+     * This method is called by AdminEdit::generateShortname().
+     * Sub-classes should override this method to perform
+     * whatever checks are necessary to validate the shortname.
+     *
+     * @param string $shortname the shortname to validate
+     *
+     * @return bool whether the shortname is valid
+     */
+    protected function validateShortname($shortname)
+    {
+        return true;
+    }
+
+    /**
+     * Relocate after process.
+     */
+    protected function relocate()
+    {
+        $form = $this->ui->getWidget('edit_form');
+        $url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
+        $this->app->relocate($url);
+    }
+
+    // build phase
+
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+
+        $this->buildForm();
+        $this->buildFrame();
+        $this->buildButton();
+        $this->buildMessages();
+    }
+
+    protected function buildForm()
+    {
+        $form_found = true;
+
+        try {
+            $form = $this->ui->getWidget('edit_form');
+        } catch (SwatWidgetNotFoundException $e) {
+            $form_found = false;
+        }
+
+        if ($form_found) {
+            if (!$this->isNew() && !$form->isProcessed()) {
+                $this->loadData();
+            }
+
+            $form->action = $this->source;
+            $form->autofocus = true;
+            $form->addHiddenField('id', $this->id);
+
+            if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
+                $url = $this->getRefererURL();
+                $form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
+            }
+        }
+    }
+
+    /**
+     * Load the data.
+     *
+     * This method is called to load data to be edited into the widgets.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to obtain the data. Widgets can be accessed through the
+     * $ui class variable.
+     *
+     * @return bool true if load was successful
+     */
+    abstract protected function loadData();
+
+    protected function buildButton()
+    {
+        $button = $this->ui->getWidget('submit_button');
+
+        if ($button->title == 'Submit') {
+            if ($this->isNew()) {
+                $button->setFromStock('create');
+            } else {
+                $button->setFromStock('apply');
+            }
+        }
+    }
+
+    protected function buildFrame()
+    {
+        $frame = $this->ui->getWidget('edit_frame');
+
+        if ($this->isNew()) {
+            $frame->title = sprintf(
+                Admin::_('New %s'),
+                $frame->title
+            );
+        } else {
+            $frame->title = sprintf(
+                Admin::_('Edit %s'),
+                $frame->title
+            );
+        }
+    }
+
+    protected function buildNavBar()
+    {
+        if ($this->isNew()) {
+            $title = Admin::_('New');
+        } else {
+            $title = Admin::_('Edit');
+        }
+
+        $this->navbar->createEntry($title);
+    }
 }
-
-?>

--- a/Admin/pages/AdminEdit.php
+++ b/Admin/pages/AdminEdit.php
@@ -12,22 +12,22 @@
  */
 abstract class AdminEdit extends AdminPage
 {
-	// {{{ protected variables
+
 
 	protected $id;
 
-	// }}}
-	// {{{ protected function isNew()
+
+
 
 	protected function isNew()
 	{
 		return ($this->id === null);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -40,10 +40,10 @@ abstract class AdminEdit extends AdminPage
 		}
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -78,8 +78,8 @@ abstract class AdminEdit extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function validate()
+
+
 
 	/**
 	 * Sub-classes should implement this method to perform validation.
@@ -88,8 +88,8 @@ abstract class AdminEdit extends AdminPage
 	{
 	}
 
-	// }}}
-	// {{{ abstract protected function saveData()
+
+
 
 	/**
 	 * Save the data
@@ -103,8 +103,8 @@ abstract class AdminEdit extends AdminPage
 	 */
 	abstract protected function saveData(): bool;
 
-	// }}}
-	// {{{ protected function generateShortname()
+
+
 
 	/**
 	 * Generate a shortname
@@ -133,8 +133,8 @@ abstract class AdminEdit extends AdminPage
 		return $shortname;
 	}
 
-	// }}}
-	// {{{ protected function validateShortname()
+
+
 
 	/**
 	 * Validate a shortname
@@ -151,8 +151,8 @@ abstract class AdminEdit extends AdminPage
 		return true;
 	}
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	/**
 	 * Relocate after process
@@ -164,10 +164,10 @@ abstract class AdminEdit extends AdminPage
 		$this->app->relocate($url);
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -179,8 +179,8 @@ abstract class AdminEdit extends AdminPage
 		$this->buildMessages();
 	}
 
-	// }}}
-	// {{{ protected function buildForm()
+
+
 
 	protected function buildForm()
 	{
@@ -207,8 +207,8 @@ abstract class AdminEdit extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ abstract protected function loadData()
+
+
 
 	/**
 	 * Load the data
@@ -222,8 +222,8 @@ abstract class AdminEdit extends AdminPage
 	 */
 	abstract protected function loadData();
 
-	// }}}
-	// {{{ protected function buildButton()
+
+
 
 	protected function buildButton()
 	{
@@ -238,8 +238,8 @@ abstract class AdminEdit extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildFrame()
+
+
 
 	protected function buildFrame()
 	{
@@ -258,8 +258,8 @@ abstract class AdminEdit extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildNavBar()
+
+
 
 	protected function buildNavBar()
 	{
@@ -272,7 +272,7 @@ abstract class AdminEdit extends AdminPage
 		$this->navbar->createEntry($title);
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminIndex.php
+++ b/Admin/pages/AdminIndex.php
@@ -1,196 +1,168 @@
 <?php
 
 /**
- * Generic admin index page
+ * Generic admin index page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * index page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminIndex extends AdminPage
 {
-	// process phase
+    // process phase
 
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+        $forms = $this->ui->getRoot()->getDescendants('SwatForm');
 
-		$forms = $this->ui->getRoot()->getDescendants('SwatForm');
+        foreach ($forms as $form) {
+            if ($form->isProcessed()) {
+                $view = $form->getFirstDescendant('SwatView');
+                $actions = $form->getFirstDescendant('SwatActions');
+                $selector = $form->getFirstDescendant('SwatViewSelector');
 
-		foreach ($forms as $form) {
-			if ($form->isProcessed()) {
-				$view = $form->getFirstDescendant('SwatView');
-				$actions = $form->getFirstDescendant('SwatActions');
-				$selector = $form->getFirstDescendant('SwatViewSelector');
+                if ($view instanceof SwatView
+                    && $selector instanceof SwatViewSelector
+                    && count($view->getSelection()) > 0
+                    && $actions instanceof SwatActions
+                    && $actions->selected !== null) {
+                    $this->processActions($view, $actions);
+                }
 
-				if ($view instanceof SwatView &&
-					$selector instanceof SwatViewSelector &&
-					count($view->getSelection()) > 0 &&
-					$actions instanceof SwatActions &&
-					$actions->selected !== null) {
+                // only one form can be processed in a single request
+                break;
+            }
+        }
+    }
 
-					$this->processActions($view, $actions);
-				}
+    /**
+     * Processes index actions.
+     *
+     * This method is called to perform whatever processing is required in
+     * response to actions. Sub-classes should implement this method.
+     * Widgets can be accessed through the $ui class variable.
+     *
+     * @param SwatView    $view    the view to get selected items from
+     * @param SwatActions $actions the actions list widget
+     */
+    protected function processActions(SwatView $view, SwatActions $actions) {}
 
-				// only one form can be processed in a single request
-				break;
-			}
-		}
-	}
+    // build phase
 
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
+        $this->buildViews();
+        $this->buildForms();
+        $this->buildMessages();
+    }
 
+    /**
+     * Builds tables views for this index page.
+     */
+    protected function buildViews()
+    {
+        $root = $this->ui->getRoot();
+        $views = $root->getDescendants('SwatView');
+        foreach ($views as $view) {
+            $this->buildView($view);
+        }
+    }
 
-	/**
-	 * Processes index actions
-	 *
-	 * This method is called to perform whatever processing is required in
-	 * response to actions. Sub-classes should implement this method.
-	 * Widgets can be accessed through the $ui class variable.
-	 *
-	 * @param SwatView $view the view to get selected items from.
-	 * @param SwatActions $actions the actions list widget.
-	 */
-	protected function processActions(SwatView $view, SwatActions $actions)
-	{
-	}
+    protected function buildView(SwatView $view)
+    {
+        if ($view->model === null) {
+            $view->model = $this->getTableModel($view);
+        }
+    }
 
+    /**
+     * Builds forms for this index page.
+     */
+    protected function buildForms()
+    {
+        $root = $this->ui->getRoot();
+        $forms = $root->getDescendants('SwatForm');
+        foreach ($forms as $form) {
+            $form->action = $this->getRelativeURL();
+            $view = $form->getFirstDescendant('SwatView');
+            $actions = $form->getFirstDescendant('SwatActions');
 
+            if ($view !== null && $view->model !== null && $actions !== null) {
+                $input_row =
+                    $view->getFirstDescendant('SwatTableViewInputRow');
 
-	// build phase
+                if (count($view->model) == 0) {
+                    $actions->visible = false;
+                } elseif ($input_row === null) {
+                    $actions->setViewSelector($view);
+                }
+            }
+        }
+    }
 
+    /**
+     * Retrieve data to display.
+     *
+     * This method is called to load data to be displayed in the table view.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to obtain the data.
+     *
+     * @return ?SwatTableModel a new SwatTableModel containing the data, or null
+     */
+    abstract protected function getTableModel(SwatView $view): ?SwatTableModel;
 
-	protected function buildInternal()
-	{
-		parent::buildInternal();
+    protected function getOrderByClause(
+        $view,
+        $default_orderby,
+        $column_prefix = null,
+        $column_map = []
+    ) {
+        $orderby = $default_orderby;
+        $add_direction = false;
 
-		$this->buildViews();
-		$this->buildForms();
-		$this->buildMessages();
-	}
+        if ($view instanceof SwatTableView && $view->orderby_column !== null) {
+            if (isset($column_map[$view->orderby_column->id])) {
+                if (is_array($column_map[$view->orderby_column->id])) {
+                    $orderby = '';
+                    $mapping = $column_map[$view->orderby_column->id];
+                    $count = 0;
+                    $total_count = count($mapping);
+                    foreach ($mapping as $value) {
+                        $count++;
+                        $orderby .= sprintf(
+                            '%s %s',
+                            $value,
+                            $view->orderby_column->getDirectionAsString()
+                        );
 
+                        if ($count != $total_count) {
+                            $orderby .= ',';
+                        }
+                    }
+                } else {
+                    $add_direction = true;
+                    $orderby = $column_map[$view->orderby_column->id];
+                }
+            } elseif ($column_prefix !== null) {
+                $add_direction = true;
+                $orderby = $column_prefix . '.' .
+                    $this->app->db->escape($view->orderby_column->id);
+            } else {
+                $add_direction = true;
+                $orderby = $this->app->db->escape($view->orderby_column->id);
+            }
 
+            if ($add_direction === true) {
+                $orderby .= ' ' . $view->orderby_column->getDirectionAsString();
+            }
+        }
 
-
-	/**
-	 * Builds tables views for this index page
-	 */
-	protected function buildViews()
-	{
-		$root = $this->ui->getRoot();
-		$views = $root->getDescendants('SwatView');
-		foreach ($views as $view) {
-			$this->buildView($view);
-		}
-	}
-
-
-
-
-	protected function buildView(SwatView $view)
-	{
-		if ($view->model === null) {
-			$view->model = $this->getTableModel($view);
-		}
-	}
-
-
-
-
-	/**
-	 * Builds forms for this index page
-	 */
-	protected function buildForms()
-	{
-		$root = $this->ui->getRoot();
-		$forms = $root->getDescendants('SwatForm');
-		foreach ($forms as $form) {
-			$form->action = $this->getRelativeURL();
-			$view = $form->getFirstDescendant('SwatView');
-			$actions = $form->getFirstDescendant('SwatActions');
-
-			if ($view !== null && $view->model !== null && $actions !== null) {
-				$input_row =
-					$view->getFirstDescendant('SwatTableViewInputRow');
-
-				if (count($view->model) == 0) {
-					$actions->visible = false;
-				} elseif ($input_row === null) {
-					$actions->setViewSelector($view);
-				}
-			}
-		}
-	}
-
-
-
-
-	/**
-	 * Retrieve data to display.
-	 *
-	 * This method is called to load data to be displayed in the table view.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to obtain the data.
-	 *
-	 * @return ?SwatTableModel A new SwatTableModel containing the data, or null.
-	 *
-	 */
-	abstract protected function getTableModel(SwatView $view): ?SwatTableModel;
-
-
-
-
-	protected function getOrderByClause(
-		$view,
-		$default_orderby,
-		$column_prefix = null,
-		$column_map = array()
-	) {
-		$orderby = $default_orderby;
-		$add_direction = false;
-
-		if ($view instanceof SwatTableView && $view->orderby_column !== null) {
-			if (isset($column_map[$view->orderby_column->id])) {
-				if (is_array($column_map[$view->orderby_column->id])) {
-					$orderby     = '';
-					$mapping     = $column_map[$view->orderby_column->id];
-					$count       = 0;
-					$total_count = count($mapping);
-					foreach ($mapping as $value) {
-						$count++;
-						$orderby.= sprintf('%s %s',
-							$value,
-							$view->orderby_column->getDirectionAsString());
-
-						if ($count != $total_count) {
-							$orderby.= ',';
-						}
-					}
-				} else {
-					$add_direction = true;
-					$orderby = $column_map[$view->orderby_column->id];
-				}
-			} elseif ($column_prefix !== null) {
-				$add_direction = true;
-				$orderby = $column_prefix.'.'.
-					$this->app->db->escape($view->orderby_column->id);
-			} else {
-				$add_direction = true;
-				$orderby = $this->app->db->escape($view->orderby_column->id);
-			}
-
-			if ($add_direction === true)
-				$orderby.= ' '.$view->orderby_column->getDirectionAsString();
-		}
-
-		return $orderby;
-	}
-
-
+        return $orderby;
+    }
 }
-
-?>

--- a/Admin/pages/AdminIndex.php
+++ b/Admin/pages/AdminIndex.php
@@ -13,7 +13,7 @@
 abstract class AdminIndex extends AdminPage
 {
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -42,8 +42,8 @@ abstract class AdminIndex extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function processActions()
+
+
 
 	/**
 	 * Processes index actions
@@ -59,10 +59,10 @@ abstract class AdminIndex extends AdminPage
 	{
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -73,8 +73,8 @@ abstract class AdminIndex extends AdminPage
 		$this->buildMessages();
 	}
 
-	// }}}
-	// {{{ protected function buildViews()
+
+
 
 	/**
 	 * Builds tables views for this index page
@@ -88,8 +88,8 @@ abstract class AdminIndex extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildView()
+
+
 
 	protected function buildView(SwatView $view)
 	{
@@ -98,8 +98,8 @@ abstract class AdminIndex extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildForms()
+
+
 
 	/**
 	 * Builds forms for this index page
@@ -126,8 +126,8 @@ abstract class AdminIndex extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ abstract protected function getTableModel()
+
+
 
 	/**
 	 * Retrieve data to display.
@@ -141,8 +141,8 @@ abstract class AdminIndex extends AdminPage
 	 */
 	abstract protected function getTableModel(SwatView $view): ?SwatTableModel;
 
-	// }}}
-	// {{{ protected function getOrderByClause()
+
+
 
 	protected function getOrderByClause(
 		$view,
@@ -190,7 +190,7 @@ abstract class AdminIndex extends AdminPage
 		return $orderby;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminObjectDelete.php
+++ b/Admin/pages/AdminObjectDelete.php
@@ -1,282 +1,212 @@
 <?php
 
 /**
- * Admin delete page for SwatDBDataObjects
+ * Admin delete page for SwatDBDataObjects.
  *
- * @package   Admin
  * @copyright 2014-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminObjectDelete extends AdminDBDelete
 {
-
-
-	/**
-	 * The dataobjects instance we are deleting on the page.
-	 *
-	 * @var SwatDBRecordsetWrapper
-	 *
-	 * @see AdminObjectDelete::getObjects()
-	 */
-	protected $objects;
-
-
-
-
-	abstract protected function getRecordsetWrapperClass();
-
-
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/confirmation.xml';
-	}
-
-
-
-
-	protected function getResolvedRecordsetWrapperClass()
-	{
-		return SwatDBClassMap::get($this->getRecordsetWrapperClass());
-	}
-
-
-
-
-	protected function getObjects()
-	{
-		return $this->objects;
-	}
-
-
-
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->initObjects();
-	}
-
-
-
-
-	protected function initObjects()
-	{
-		$wrapper_class = $this->getResolvedRecordsetWrapperClass();
-
-		$this->objects = SwatDB::query(
-			$this->app->db,
-			$this->getObjectsSql(),
-			$wrapper_class
-		);
-
-		if ($this->app->hasModule('SiteMemcacheModule')) {
-			$this->objects->setFlushableCache(
-				$this->app->getModule('SiteMemcacheModule')
-			);
-		}
-
-		if (count($this->objects) === 0) {
-			throw new AdminNotFoundException(
-				sprintf(
-					'No rows loaded for ‘%s’ wrapper',
-					$wrapper_class
-				)
-			);
-		}
-	}
-
-
-
-
-	abstract protected function getObjectsSql();
-
-
-
-	// process phase
-
-
-	protected function processDBData(): void
-	{
-		parent::processDBData();
-
-		// Build the message before actually deleting the objects, so that the
-		// message can have access to the objects for fancier messages.
-		$message = $this->getDeletedMessage();
-
-		$objects = $this->getObjects();
-		$this->deleteObjects($objects);
-
-		if ($message instanceof SwatMessage) {
-			$this->app->messages->add($message);
-		}
-	}
-
-
-
-
-	protected function deleteObjects(SwatDBRecordsetWrapper $objects)
-	{
-		foreach ($objects as $object) {
-			$this->deleteObject($object);
-		}
-	}
-
-
-
-
-	protected function deleteObject(SwatDBDataObject $object)
-	{
-		$object->delete();
-	}
-
-
-
-
-	protected function getDeletedMessage()
-	{
-		$message = null;
-
-		$message_type      = $this->getDeletedMessageType();
-		$primary_content   = $this->getDeletedMessagePrimaryContent();
-		$secondary_content = $this->getDeletedMessageSecondaryContent();
-		$content_type      = $this->getDeletedMessageContentType();
-
-		if ($primary_content != '') {
-			$message = new SwatMessage($primary_content, $message_type);
-
-			if ($secondary_content != '') {
-				$message->secondary_content = $secondary_content;
-			}
-
-			if ($content_type != '') {
-				$message->content_type = $content_type;
-			}
-		}
-
-		return $message;
-	}
-
-
-
-
-	protected function getDeletedMessagePrimaryContent()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getDeletedMessageSecondaryContent()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getDeletedMessageType()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getDeletedMessageContentType()
-	{
-		return null;
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		$this->buildConfirmationMessage();
-	}
-
-
-
-
-	/**
-	 * Allows building a default confirmation message including a header and
-	 * further body.
-	 *
-	 * This is optional and by default does nothing, but does allow for
-	 * some standard admin markup for delete confirmation messages that are not
-	 * AdminDependencies by subclassing only some of it's parts.
-	 */
-	protected function buildConfirmationMessage()
-	{
-		$message_content = $this->getConfirmationMessageContent();
-		if ($message_content != '') {
-			$message = $this->ui->getWidget('confirmation_message');
-			$message->content = $message_content;
-
-			$content_type = $this->getConfirmationMessageContentType();
-			if ($content_type != '') {
-				$message->content_type = $content_type;
-			}
-		}
-	}
-
-
-
-
-	protected function getConfirmationMessageContent()
-	{
-		$confirmation_message = '';
-
-		$header_message = $this->getConfirmationMessageHeader();
-		if ($header_message != '') {
-			$header = new SwatHtmlTag('h3');
-			$header->setContent($header_message);
-			$confirmation_message.= $header;
-		}
-
-		$body_message = $this->getConfirmationMessageBody();
-		if ($body_message != '') {
-			$confirmation_message.= $body_message;
-		}
-
-		return $confirmation_message;
-	}
-
-
-
-
-	protected function getConfirmationMessageContentType()
-	{
-		return 'text/xml';
-	}
-
-
-
-
-	protected function getConfirmationMessageHeader()
-	{
-		return '';
-	}
-
-
-
-
-	protected function getConfirmationMessageBody()
-	{
-		return '';
-	}
-
-
+    /**
+     * The dataobjects instance we are deleting on the page.
+     *
+     * @var SwatDBRecordsetWrapper
+     *
+     * @see AdminObjectDelete::getObjects()
+     */
+    protected $objects;
+
+    abstract protected function getRecordsetWrapperClass();
+
+    protected function getUiXml()
+    {
+        return __DIR__ . '/confirmation.xml';
+    }
+
+    protected function getResolvedRecordsetWrapperClass()
+    {
+        return SwatDBClassMap::get($this->getRecordsetWrapperClass());
+    }
+
+    protected function getObjects()
+    {
+        return $this->objects;
+    }
+
+    // init phase
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->initObjects();
+    }
+
+    protected function initObjects()
+    {
+        $wrapper_class = $this->getResolvedRecordsetWrapperClass();
+
+        $this->objects = SwatDB::query(
+            $this->app->db,
+            $this->getObjectsSql(),
+            $wrapper_class
+        );
+
+        if ($this->app->hasModule('SiteMemcacheModule')) {
+            $this->objects->setFlushableCache(
+                $this->app->getModule('SiteMemcacheModule')
+            );
+        }
+
+        if (count($this->objects) === 0) {
+            throw new AdminNotFoundException(
+                sprintf(
+                    'No rows loaded for ‘%s’ wrapper',
+                    $wrapper_class
+                )
+            );
+        }
+    }
+
+    abstract protected function getObjectsSql();
+
+    // process phase
+
+    protected function processDBData(): void
+    {
+        parent::processDBData();
+
+        // Build the message before actually deleting the objects, so that the
+        // message can have access to the objects for fancier messages.
+        $message = $this->getDeletedMessage();
+
+        $objects = $this->getObjects();
+        $this->deleteObjects($objects);
+
+        if ($message instanceof SwatMessage) {
+            $this->app->messages->add($message);
+        }
+    }
+
+    protected function deleteObjects(SwatDBRecordsetWrapper $objects)
+    {
+        foreach ($objects as $object) {
+            $this->deleteObject($object);
+        }
+    }
+
+    protected function deleteObject(SwatDBDataObject $object)
+    {
+        $object->delete();
+    }
+
+    protected function getDeletedMessage()
+    {
+        $message = null;
+
+        $message_type = $this->getDeletedMessageType();
+        $primary_content = $this->getDeletedMessagePrimaryContent();
+        $secondary_content = $this->getDeletedMessageSecondaryContent();
+        $content_type = $this->getDeletedMessageContentType();
+
+        if ($primary_content != '') {
+            $message = new SwatMessage($primary_content, $message_type);
+
+            if ($secondary_content != '') {
+                $message->secondary_content = $secondary_content;
+            }
+
+            if ($content_type != '') {
+                $message->content_type = $content_type;
+            }
+        }
+
+        return $message;
+    }
+
+    protected function getDeletedMessagePrimaryContent()
+    {
+        return null;
+    }
+
+    protected function getDeletedMessageSecondaryContent()
+    {
+        return null;
+    }
+
+    protected function getDeletedMessageType()
+    {
+        return null;
+    }
+
+    protected function getDeletedMessageContentType()
+    {
+        return null;
+    }
+
+    // build phase
+
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+
+        $this->buildConfirmationMessage();
+    }
+
+    /**
+     * Allows building a default confirmation message including a header and
+     * further body.
+     *
+     * This is optional and by default does nothing, but does allow for
+     * some standard admin markup for delete confirmation messages that are not
+     * AdminDependencies by subclassing only some of it's parts.
+     */
+    protected function buildConfirmationMessage()
+    {
+        $message_content = $this->getConfirmationMessageContent();
+        if ($message_content != '') {
+            $message = $this->ui->getWidget('confirmation_message');
+            $message->content = $message_content;
+
+            $content_type = $this->getConfirmationMessageContentType();
+            if ($content_type != '') {
+                $message->content_type = $content_type;
+            }
+        }
+    }
+
+    protected function getConfirmationMessageContent()
+    {
+        $confirmation_message = '';
+
+        $header_message = $this->getConfirmationMessageHeader();
+        if ($header_message != '') {
+            $header = new SwatHtmlTag('h3');
+            $header->setContent($header_message);
+            $confirmation_message .= $header;
+        }
+
+        $body_message = $this->getConfirmationMessageBody();
+        if ($body_message != '') {
+            $confirmation_message .= $body_message;
+        }
+
+        return $confirmation_message;
+    }
+
+    protected function getConfirmationMessageContentType()
+    {
+        return 'text/xml';
+    }
+
+    protected function getConfirmationMessageHeader()
+    {
+        return '';
+    }
+
+    protected function getConfirmationMessageBody()
+    {
+        return '';
+    }
 }
-
-?>

--- a/Admin/pages/AdminObjectDelete.php
+++ b/Admin/pages/AdminObjectDelete.php
@@ -9,7 +9,7 @@
  */
 abstract class AdminObjectDelete extends AdminDBDelete
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The dataobjects instance we are deleting on the page.
@@ -20,39 +20,39 @@ abstract class AdminObjectDelete extends AdminDBDelete
 	 */
 	protected $objects;
 
-	// }}}
-	// {{{ abstract protected function getRecordsetWrapperClass()
+
+
 
 	abstract protected function getRecordsetWrapperClass();
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/confirmation.xml';
 	}
 
-	// }}}
-	// {{{ protected function getResolvedRecordsetWrapperClass()
+
+
 
 	protected function getResolvedRecordsetWrapperClass()
 	{
 		return SwatDBClassMap::get($this->getRecordsetWrapperClass());
 	}
 
-	// }}}
-	// {{{ protected function getObjects()
+
+
 
 	protected function getObjects()
 	{
 		return $this->objects;
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -61,8 +61,8 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		$this->initObjects();
 	}
 
-	// }}}
-	// {{{ protected function initObjects()
+
+
 
 	protected function initObjects()
 	{
@@ -90,15 +90,15 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		}
 	}
 
-	// }}}
-	// {{{ abstract protected function getObjectsSql()
+
+
 
 	abstract protected function getObjectsSql();
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processDBData()
+
 
 	protected function processDBData(): void
 	{
@@ -116,8 +116,8 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		}
 	}
 
-	// }}}
-	// {{{ protected function deleteObjects()
+
+
 
 	protected function deleteObjects(SwatDBRecordsetWrapper $objects)
 	{
@@ -126,16 +126,16 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		}
 	}
 
-	// }}}
-	// {{{ protected function deleteObject()
+
+
 
 	protected function deleteObject(SwatDBDataObject $object)
 	{
 		$object->delete();
 	}
 
-	// }}}
-	// {{{ protected function getDeletedMessage()
+
+
 
 	protected function getDeletedMessage()
 	{
@@ -161,42 +161,42 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getDeletedMessagePrimaryContent()
+
+
 
 	protected function getDeletedMessagePrimaryContent()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getDeletedMessageSecondaryContent()
+
+
 
 	protected function getDeletedMessageSecondaryContent()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getDeletedMessageType()
+
+
 
 	protected function getDeletedMessageType()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getDeletedMessageContentType()
+
+
 
 	protected function getDeletedMessageContentType()
 	{
 		return null;
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -205,8 +205,8 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		$this->buildConfirmationMessage();
 	}
 
-	// }}}
-	// {{{ protected function buildConfirmationMessage()
+
+
 
 	/**
 	 * Allows building a default confirmation message including a header and
@@ -230,8 +230,8 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		}
 	}
 
-	// }}}
-	// {{{ protected function getConfirmationMessageContent()
+
+
 
 	protected function getConfirmationMessageContent()
 	{
@@ -252,31 +252,31 @@ abstract class AdminObjectDelete extends AdminDBDelete
 		return $confirmation_message;
 	}
 
-	// }}}
-	// {{{ protected function getConfirmationMessageContentType()
+
+
 
 	protected function getConfirmationMessageContentType()
 	{
 		return 'text/xml';
 	}
 
-	// }}}
-	// {{{ protected function getConfirmationMessageHeader()
+
+
 
 	protected function getConfirmationMessageHeader()
 	{
 		return '';
 	}
 
-	// }}}
-	// {{{ protected function getConfirmationMessageBody()
+
+
 
 	protected function getConfirmationMessageBody()
 	{
 		return '';
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -9,7 +9,7 @@
  */
 abstract class AdminObjectEdit extends AdminDBEdit
 {
-	// {{{ protected properties
+
 
 	/**
 	 * The dataobject instance we are editing on this page.
@@ -49,42 +49,42 @@ abstract class AdminObjectEdit extends AdminDBEdit
 	 */
 	protected $current_time;
 
-	// }}}
-	// {{{ abstract protected function getObjectClass()
+
+
 
 	abstract protected function getObjectClass();
 
-	// }}}
-	// {{{ abstract protected function getUiXml()
+
+
 
 	abstract protected function getUiXml();
 
-	// }}}
-	// {{{ protected function getResolvedObjectClass()
+
+
 
 	protected function getResolvedObjectClass()
 	{
 		return SwatDBClassMap::get($this->getObjectClass());
 	}
 
-	// }}}
-	// {{{ protected function getObject()
+
+
 
 	protected function getObject()
 	{
 		return $this->data_object;
 	}
 
-	// }}}
-	// {{{ protected function setObject()
+
+
 
 	protected function setObject(SwatDBDataObject $object)
 	{
 		$this->data_object = $object;
 	}
 
-	// }}}
-	// {{{ protected function getOldObject()
+
+
 
 	protected function getOldObject()
 	{
@@ -95,8 +95,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return $this->old_object;
 	}
 
-	// }}}
-	// {{{ protected function shouldReplaceObject()
+
+
 
 	/**
 	 * Whether or not to replace the object being edited with a new object.
@@ -112,16 +112,16 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return false;
 	}
 
-	// }}}
-	// {{{ protected function getObjectUiValueNames()
+
+
 
 	protected function getObjectUiValueNames()
 	{
 		return array();
 	}
 
-	// }}}
-	// {{{ protected function getCurrentTime()
+
+
 
 	protected function getCurrentTime()
 	{
@@ -133,8 +133,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return $this->current_time;
 	}
 
-	// }}}
-	// {{{ protected function getObjectTimeZone()
+
+
 
 	protected function getObjectTimeZone()
 	{
@@ -146,18 +146,18 @@ abstract class AdminObjectEdit extends AdminDBEdit
 			: $this->app->default_time_zone;
 	}
 
-	// }}}
-	// {{{ protected function getObjectTimeZonePropertyName()
+
+
 
 	protected function getObjectTimeZonePropertyName()
 	{
 		return 'time_zone';
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ public function init()
+
 
 	public function init()
 	{
@@ -173,8 +173,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$this->ui->init();
 	}
 
-	// }}}
-	// {{{ protected function initInternal()
+
+
 
 	protected function initInternal()
 	{
@@ -184,8 +184,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$this->initTimeZoneWidget();
 	}
 
-	// }}}
-	// {{{ protected function initObject()
+
+
 
 	protected function initObject()
 	{
@@ -204,8 +204,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function initTimeZoneWidget()
+
+
 
 	protected function initTimeZoneWidget()
 	{
@@ -216,8 +216,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function getNewObjectInstance()
+
+
 
 	protected function getNewObjectInstance()
 	{
@@ -234,10 +234,10 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return $data_object;
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function validateShortname()
+
 
 	protected function validateShortname($shortname)
 	{
@@ -256,8 +256,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return $valid;
 	}
 
-	// }}}
-	// {{{ protected function saveDBData()
+
+
 
 	protected function saveDBData(): void
 	{
@@ -277,8 +277,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$this->addSavedMessage();
 	}
 
-	// }}}
-	// {{{ protected function updateObject()
+
+
 
 	protected function updateObject()
 	{
@@ -323,8 +323,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function updateModifiedDate()
+
+
 
 	protected function updateModifiedDate()
 	{
@@ -340,16 +340,16 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function saveObject()
+
+
 
 	protected function saveObject()
 	{
 		$this->getObject()->save();
 	}
 
-	// }}}
-	// {{{ protected function deleteOldObject()
+
+
 
 	protected function deleteOldObject()
 	{
@@ -360,15 +360,15 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function postSaveObject()
+
+
 
 	protected function postSaveObject()
 	{
 	}
 
-	// }}}
-	// {{{ protected function addObjectToFlushOnSave()
+
+
 
 	protected function addObjectToFlushOnSave(SwatDBDataObject $object)
 	{
@@ -382,16 +382,16 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$this->data_objects_to_flush[] = $object;
 	}
 
-	// }}}
-	// {{{ protected function clearObjectsToFlush()
+
+
 
 	protected function clearObjectsToFlush()
 	{
 		$this->data_objects_to_flush = array();
 	}
 
-	// }}}
-	// {{{ protected function flushObjectsOnSave()
+
+
 
 	protected function flushObjectsOnSave()
 	{
@@ -402,8 +402,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function addSavedMessage()
+
+
 
 	protected function addSavedMessage()
 	{
@@ -415,8 +415,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessage()
+
+
 
 	protected function getSavedMessage()
 	{
@@ -441,48 +441,48 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		return $message;
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessagePrimaryContent()
+
+
 
 	protected function getSavedMessagePrimaryContent()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessageSecondaryContent()
+
+
 
 	protected function getSavedMessageSecondaryContent()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessageType()
+
+
 
 	protected function getSavedMessageType()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function getSavedMessageContentType()
+
+
 
 	protected function getSavedMessageContentType()
 	{
 		return null;
 	}
 
-	// }}}
-	// {{{ protected function assignUiValues()
+
+
 
 	protected function assignUiValues(array $names)
 	{
 		$this->assignUiValuesToObject($this->getObject(), $names);
 	}
 
-	// }}}
-	// {{{ protected function assignUiValuesToObject()
+
+
 
 	protected function assignUiValuesToObject(
 		SwatDBDataObject $object,
@@ -502,8 +502,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function assignUiValueToObject()
+
+
 
 	protected function assignUiValueToObject(
 		SwatDBDataObject $object,
@@ -536,34 +536,34 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function loadDBData()
+
 
 	protected function loadDBData()
 	{
 		$this->loadObject();
 	}
 
-	// }}}
-	// {{{ protected function loadObject()
+
+
 
 	protected function loadObject()
 	{
 		$this->assignValuesToUi($this->getObjectUiValueNames());
 	}
 
-	// }}}
-	// {{{ protected function assignValuesToUi()
+
+
 
 	protected function assignValuesToUi(array $names)
 	{
 		$this->assignObjectValuesToUi($this->getObject(), $names);
 	}
 
-	// }}}
-	// {{{ protected function assignObjectValuesToUi()
+
+
 
 	protected function assignObjectValuesToUi(
 		SwatDBDataObject $object,
@@ -574,8 +574,8 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		}
 	}
 
-	// }}}
-	// {{{ protected function assignObjectValueToUi()
+
+
 
 	protected function assignObjectValueToUi(SwatDBDataObject $object, $name)
 	{
@@ -604,7 +604,7 @@ abstract class AdminObjectEdit extends AdminDBEdit
 		$widget->value = $value;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminObjectEdit.php
+++ b/Admin/pages/AdminObjectEdit.php
@@ -1,610 +1,479 @@
 <?php
 
 /**
- * Admin edit page for SwatDBDataObjects
+ * Admin edit page for SwatDBDataObjects.
  *
- * @package   Admin
  * @copyright 2014-2021 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminObjectEdit extends AdminDBEdit
 {
-
-
-	/**
-	 * The dataobject instance we are editing on this page.
-	 *
-	 * @var SwatDBDataObject
-	 *
-	 * @see AdminObjectEdit::getObject()
-	 */
-	protected $data_object;
-
-	/**
-	 * When edits should replace the existing object with a new object
-	 * this is the existing object being edited.
-	 *
-	 * @var SwatDBDataObject
-	 *
-	 * @see AdminObjectEdit::shouldReplaceObject()
-	 */
-	protected $old_object;
-
-	/**
-	 * An array of SwatDBDataObject objects to flush
-	 *
-	 * @var array
-	 */
-	protected $data_objects_to_flush = array();
-
-	/**
-	 * The current time as a SwatDate in UTC.
-	 *
-	 * Current time is defined on the first call of getCurrentTime() and used
-	 * to return a consistent date/time when setting date fields on an edit.
-	 *
-	 * @var SwatDate
-	 *
-	 * @see AdminObjectEdit::getCurrentTime()
-	 */
-	protected $current_time;
-
-
-
-
-	abstract protected function getObjectClass();
-
-
-
-
-	abstract protected function getUiXml();
-
-
-
-
-	protected function getResolvedObjectClass()
-	{
-		return SwatDBClassMap::get($this->getObjectClass());
-	}
-
-
-
-
-	protected function getObject()
-	{
-		return $this->data_object;
-	}
-
-
-
-
-	protected function setObject(SwatDBDataObject $object)
-	{
-		$this->data_object = $object;
-	}
-
-
-
-
-	protected function getOldObject()
-	{
-		if (!$this->old_object instanceof SwatDBDataObject) {
-			$this->old_object = clone $this->getObject();
-		}
-
-		return $this->old_object;
-	}
-
-
-
-
-	/**
-	 * Whether or not to replace the object being edited with a new object.
-	 *
-	 * This is useful for cases where generating a new object and corresponding
-	 * id is necessary, for example when dealing with objects such as images
-	 * that could be cached by a browser or CDN storage based on its id.
-	 *
-	 * @returns boolean
-	 */
-	protected function shouldReplaceObject()
-	{
-		return false;
-	}
-
-
-
-
-	protected function getObjectUiValueNames()
-	{
-		return array();
-	}
-
-
-
-
-	protected function getCurrentTime()
-	{
-		if (!$this->current_time instanceof SwatDate) {
-			$this->current_time = new SwatDate();
-			$this->current_time->toUTC();
-		}
-
-		return $this->current_time;
-	}
-
-
-
-
-	protected function getObjectTimeZone()
-	{
-		$object = $this->getObject();
-		$name = $this->getObjectTimeZonePropertyName();
-
-		return property_exists($object, $name) && $object->$name != ''
-			? new DateTimeZone($object->$name)
-			: $this->app->default_time_zone;
-	}
-
-
-
-
-	protected function getObjectTimeZonePropertyName()
-	{
-		return 'time_zone';
-	}
-
-
-
-	// init phase
-
-
-	public function init()
-	{
-		// Skip other admin page init methods so that we can load the UI from
-		// getUiXml() as part of init.
-		SitePage::init();
-
-		$this->ui = new AdminUI();
-		$this->ui->loadFromXML($this->getUiXml());
-
-		$this->initInternal();
-
-		$this->ui->init();
-	}
-
-
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->initObject();
-		$this->initTimeZoneWidget();
-	}
-
-
-
-
-	protected function initObject()
-	{
-		$this->data_object = $this->getNewObjectInstance();
-
-		if (!$this->isNew()) {
-			if (!$this->data_object->load($this->id)) {
-				throw new AdminNotFoundException(
-					sprintf(
-						'A %s with the id of ‘%s’ does not exist',
-						get_class($this->data_object),
-						$this->id
-					)
-				);
-			}
-		}
-	}
-
-
-
-
-	protected function initTimeZoneWidget()
-	{
-		$name = $this->getObjectTimeZonePropertyName();
-		if ($this->ui->hasWidget($name)) {
-			$widget = $this->ui->getWidget($name);
-			$widget->value = $this->getObjectTimeZone()->getName();
-		}
-	}
-
-
-
-
-	protected function getNewObjectInstance()
-	{
-		$class_name = $this->getResolvedObjectClass();
-		$data_object = new $class_name();
-		$data_object->setDatabase($this->app->db);
-
-		if ($this->app->hasModule('SiteMemcacheModule')) {
-			$data_object->setFlushableCache(
-				$this->app->getModule('SiteMemcacheModule')
-			);
-		}
-
-		return $data_object;
-	}
-
-
-
-	// process phase
-
-
-	protected function validateShortname($shortname)
-	{
-		$valid = parent::validateShortname($shortname);
-
-		$class_name = $this->getResolvedObjectClass();
-		$object = new $class_name();
-		$object->setDatabase($this->app->db);
-
-		if (method_exists($object, 'loadByShortname') &&
-			$object->loadByShortname($shortname) &&
-			$object->id !== $this->getObject()->id) {
-			$valid = false;
-		}
-
-		return $valid;
-	}
-
-
-
-
-	protected function saveDBData(): void
-	{
-		$this->updateObject();
-		$this->updateModifiedDate();
-
-		// If the main data object wasn't modified, don't flush any other
-		// data objects automagically.
-		if (!$this->getObject()->isModified()) {
-			$this->clearObjectsToFlush();
-		}
-
-		$this->saveObject();
-		$this->postSaveObject();
-		$this->deleteOldObject();
-		$this->flushObjectsOnSave();
-		$this->addSavedMessage();
-	}
-
-
-
-
-	protected function updateObject()
-	{
-		$object = $this->getObject();
-
-		// Clone the old object for flushing before any changes are made to it.
-		if (!$this->isNew()) {
-			$old_object = $this->getOldObject();
-			$this->addObjectToFlushOnSave($old_object);
-		}
-
-		$this->assignUiValues($this->getObjectUiValueNames());
-
-		if ($this->isNew()) {
-			if ($object->hasPublicProperty('createdate') &&
-				$object->hasDateProperty('createdate')) {
-				$object->createdate = $this->getCurrentTime();
-			}
-
-			if ($object->hasPublicProperty('shortname') &&
-				$this->ui->hasWidget('shortname') &&
-				$this->ui->hasWidget('title')) {
-				$shortname = $this->ui->getWidget('shortname')->value;
-
-				if ($shortname == '') {
-					$object->shortname = $this->generateShortname(
-						$this->ui->getWidget('title')->value
-					);
-				}
-			}
-		} else {
-			// SwatDBDataObject::duplicate makes a copy of the object with no
-			// id, so a fresh row is saved. This happens at the end of
-			// updateObject() so that all the values set automagically by
-			// AdminObjectEdit::updateObject() get copied, but so that
-			// subclasses then modify the duplicated object. It is not necessary
-			// if it is a new object.
-			if ($this->shouldReplaceObject()) {
-				$object = $object->duplicate();
-				$this->setObject($object);
-			}
-		}
-	}
-
-
-
-
-	protected function updateModifiedDate()
-	{
-		$object = $this->getObject();
-		if ($object->hasPublicProperty('modified_date') &&
-			$object->hasDateProperty('modified_date')) {
-
-			if ($object->isModified() ||
-				$this->shouldReplaceObject() ||
-				!$object->modified_date instanceof SwatDate) {
-				$object->modified_date = $this->getCurrentTime();
-			}
-		}
-	}
-
-
-
-
-	protected function saveObject()
-	{
-		$this->getObject()->save();
-	}
-
-
-
-
-	protected function deleteOldObject()
-	{
-		if (!$this->isNew() &&
-			$this->shouldReplaceObject() &&
-			$this->getOldObject() instanceof SwatDBDataObject) {
-			$this->getOldObject()->delete();
-		}
-	}
-
-
-
-
-	protected function postSaveObject()
-	{
-	}
-
-
-
-
-	protected function addObjectToFlushOnSave(SwatDBDataObject $object)
-	{
-		// Make sure the flushable cache is set.
-		if ($this->app->hasModule('SiteMemcacheModule')) {
-			$object->setFlushableCache(
-				$this->app->getModule('SiteMemcacheModule')
-			);
-		}
-
-		$this->data_objects_to_flush[] = $object;
-	}
-
-
-
-
-	protected function clearObjectsToFlush()
-	{
-		$this->data_objects_to_flush = array();
-	}
-
-
-
-
-	protected function flushObjectsOnSave()
-	{
-		foreach ($this->data_objects_to_flush as $object) {
-			if ($object instanceof SwatDBDataObject) {
-				$object->flushCacheNamespaces();
-			}
-		}
-	}
-
-
-
-
-	protected function addSavedMessage()
-	{
-		if ($this->app->hasModule('SiteMessagesModule')) {
-			$message = $this->getSavedMessage();
-			if ($message instanceof SwatMessage) {
-				$this->app->getModule('SiteMessagesModule')->add($message);
-			}
-		}
-	}
-
-
-
-
-	protected function getSavedMessage()
-	{
-		$message = null;
-		$message_type      = $this->getSavedMessageType();
-		$primary_content   = $this->getSavedMessagePrimaryContent();
-		$secondary_content = $this->getSavedMessageSecondaryContent();
-		$content_type      = $this->getSavedMessageContentType();
-
-		if ($primary_content != '') {
-			$message = new SwatMessage($primary_content, $message_type);
-
-			if ($secondary_content != '') {
-				$message->secondary_content = $secondary_content;
-			}
-
-			if ($content_type != '') {
-				$message->content_type = $content_type;
-			}
-		}
-
-		return $message;
-	}
-
-
-
-
-	protected function getSavedMessagePrimaryContent()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getSavedMessageSecondaryContent()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getSavedMessageType()
-	{
-		return null;
-	}
-
-
-
-
-	protected function getSavedMessageContentType()
-	{
-		return null;
-	}
-
-
-
-
-	protected function assignUiValues(array $names)
-	{
-		$this->assignUiValuesToObject($this->getObject(), $names);
-	}
-
-
-
-
-	protected function assignUiValuesToObject(
-		SwatDBDataObject $object,
-		array $names
-	) {
-		$tz_name = $this->getObjectTimeZonePropertyName();
-
-		if (in_array($tz_name, $names)) {
-			$this->assignUiValueToObject($object, $tz_name);
-		}
-
-		foreach ($names as $name) {
-			// Already processed the $tz_name property
-			if ($name !== $tz_name) {
-				$this->assignUiValueToObject($object, $name);
-			}
-		}
-	}
-
-
-
-
-	protected function assignUiValueToObject(
-		SwatDBDataObject $object,
-		$name
-	) {
-		$widget = $this->ui->getWidget($name);
-
-		// only clone the value when its actually an object
-		if ($widget instanceof SwatDateEntry &&
-			$widget->value instanceof SwatDate) {
-			$value = clone $widget->value;
-			$value->setTZ($this->getObjectTimeZone());
-			$value->toUTC();
-		} else {
-			$value = $widget->value;
-		}
-
-		if (property_exists($object, $name) ||
-			$object->hasInternalValue($name)) {
-
-			$object->$name = $value;
-		} else {
-			throw new SwatInvalidPropertyException(
-				sprintf(
-					'Specified “%s” object does not have a property “%s”.',
-					get_class($object),
-					$name
-				)
-			);
-		}
-	}
-
-
-
-	// build phase
-
-
-	protected function loadDBData()
-	{
-		$this->loadObject();
-	}
-
-
-
-
-	protected function loadObject()
-	{
-		$this->assignValuesToUi($this->getObjectUiValueNames());
-	}
-
-
-
-
-	protected function assignValuesToUi(array $names)
-	{
-		$this->assignObjectValuesToUi($this->getObject(), $names);
-	}
-
-
-
-
-	protected function assignObjectValuesToUi(
-		SwatDBDataObject $object,
-		array $names
-	) {
-		foreach ($names as $name) {
-			$this->assignObjectValueToUi($object, $name);
-		}
-	}
-
-
-
-
-	protected function assignObjectValueToUi(SwatDBDataObject $object, $name)
-	{
-		if (property_exists($object, $name)) {
-			$value = $object->$name;
-		} elseif ($object->hasInternalValue($name)) {
-			$value = $object->getInternalValue($name);
-		} else {
-			throw new SwatInvalidPropertyException(
-				sprintf(
-					'Specified “%s” record does not have a property “%s”.',
-					get_class($object),
-					$name
-				)
-			);
-		}
-
-		$widget = $this->ui->getWidget($name);
-
-		if ($widget instanceof SwatDateEntry &&
-			$value instanceof SwatDate) {
-			$value = new SwatDate($value);
-			$value->convertTZ($this->getObjectTimeZone());
-		}
-
-		$widget->value = $value;
-	}
-
-
+    /**
+     * The dataobject instance we are editing on this page.
+     *
+     * @var SwatDBDataObject
+     *
+     * @see AdminObjectEdit::getObject()
+     */
+    protected $data_object;
+
+    /**
+     * When edits should replace the existing object with a new object
+     * this is the existing object being edited.
+     *
+     * @var SwatDBDataObject
+     *
+     * @see AdminObjectEdit::shouldReplaceObject()
+     */
+    protected $old_object;
+
+    /**
+     * An array of SwatDBDataObject objects to flush.
+     *
+     * @var array
+     */
+    protected $data_objects_to_flush = [];
+
+    /**
+     * The current time as a SwatDate in UTC.
+     *
+     * Current time is defined on the first call of getCurrentTime() and used
+     * to return a consistent date/time when setting date fields on an edit.
+     *
+     * @var SwatDate
+     *
+     * @see AdminObjectEdit::getCurrentTime()
+     */
+    protected $current_time;
+
+    abstract protected function getObjectClass();
+
+    abstract protected function getUiXml();
+
+    protected function getResolvedObjectClass()
+    {
+        return SwatDBClassMap::get($this->getObjectClass());
+    }
+
+    protected function getObject()
+    {
+        return $this->data_object;
+    }
+
+    protected function setObject(SwatDBDataObject $object)
+    {
+        $this->data_object = $object;
+    }
+
+    protected function getOldObject()
+    {
+        if (!$this->old_object instanceof SwatDBDataObject) {
+            $this->old_object = clone $this->getObject();
+        }
+
+        return $this->old_object;
+    }
+
+    /**
+     * Whether or not to replace the object being edited with a new object.
+     *
+     * This is useful for cases where generating a new object and corresponding
+     * id is necessary, for example when dealing with objects such as images
+     * that could be cached by a browser or CDN storage based on its id.
+     *
+     * @returns boolean
+     */
+    protected function shouldReplaceObject()
+    {
+        return false;
+    }
+
+    protected function getObjectUiValueNames()
+    {
+        return [];
+    }
+
+    protected function getCurrentTime()
+    {
+        if (!$this->current_time instanceof SwatDate) {
+            $this->current_time = new SwatDate();
+            $this->current_time->toUTC();
+        }
+
+        return $this->current_time;
+    }
+
+    protected function getObjectTimeZone()
+    {
+        $object = $this->getObject();
+        $name = $this->getObjectTimeZonePropertyName();
+
+        return property_exists($object, $name) && $object->{$name} != ''
+            ? new DateTimeZone($object->{$name})
+            : $this->app->default_time_zone;
+    }
+
+    protected function getObjectTimeZonePropertyName()
+    {
+        return 'time_zone';
+    }
+
+    // init phase
+
+    public function init()
+    {
+        // Skip other admin page init methods so that we can load the UI from
+        // getUiXml() as part of init.
+        SitePage::init();
+
+        $this->ui = new AdminUI();
+        $this->ui->loadFromXML($this->getUiXml());
+
+        $this->initInternal();
+
+        $this->ui->init();
+    }
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->initObject();
+        $this->initTimeZoneWidget();
+    }
+
+    protected function initObject()
+    {
+        $this->data_object = $this->getNewObjectInstance();
+
+        if (!$this->isNew()) {
+            if (!$this->data_object->load($this->id)) {
+                throw new AdminNotFoundException(
+                    sprintf(
+                        'A %s with the id of ‘%s’ does not exist',
+                        get_class($this->data_object),
+                        $this->id
+                    )
+                );
+            }
+        }
+    }
+
+    protected function initTimeZoneWidget()
+    {
+        $name = $this->getObjectTimeZonePropertyName();
+        if ($this->ui->hasWidget($name)) {
+            $widget = $this->ui->getWidget($name);
+            $widget->value = $this->getObjectTimeZone()->getName();
+        }
+    }
+
+    protected function getNewObjectInstance()
+    {
+        $class_name = $this->getResolvedObjectClass();
+        $data_object = new $class_name();
+        $data_object->setDatabase($this->app->db);
+
+        if ($this->app->hasModule('SiteMemcacheModule')) {
+            $data_object->setFlushableCache(
+                $this->app->getModule('SiteMemcacheModule')
+            );
+        }
+
+        return $data_object;
+    }
+
+    // process phase
+
+    protected function validateShortname($shortname)
+    {
+        $valid = parent::validateShortname($shortname);
+
+        $class_name = $this->getResolvedObjectClass();
+        $object = new $class_name();
+        $object->setDatabase($this->app->db);
+
+        if (method_exists($object, 'loadByShortname')
+            && $object->loadByShortname($shortname)
+            && $object->id !== $this->getObject()->id) {
+            $valid = false;
+        }
+
+        return $valid;
+    }
+
+    protected function saveDBData(): void
+    {
+        $this->updateObject();
+        $this->updateModifiedDate();
+
+        // If the main data object wasn't modified, don't flush any other
+        // data objects automagically.
+        if (!$this->getObject()->isModified()) {
+            $this->clearObjectsToFlush();
+        }
+
+        $this->saveObject();
+        $this->postSaveObject();
+        $this->deleteOldObject();
+        $this->flushObjectsOnSave();
+        $this->addSavedMessage();
+    }
+
+    protected function updateObject()
+    {
+        $object = $this->getObject();
+
+        // Clone the old object for flushing before any changes are made to it.
+        if (!$this->isNew()) {
+            $old_object = $this->getOldObject();
+            $this->addObjectToFlushOnSave($old_object);
+        }
+
+        $this->assignUiValues($this->getObjectUiValueNames());
+
+        if ($this->isNew()) {
+            if ($object->hasPublicProperty('createdate')
+                && $object->hasDateProperty('createdate')) {
+                $object->createdate = $this->getCurrentTime();
+            }
+
+            if ($object->hasPublicProperty('shortname')
+                && $this->ui->hasWidget('shortname')
+                && $this->ui->hasWidget('title')) {
+                $shortname = $this->ui->getWidget('shortname')->value;
+
+                if ($shortname == '') {
+                    $object->shortname = $this->generateShortname(
+                        $this->ui->getWidget('title')->value
+                    );
+                }
+            }
+        } else {
+            // SwatDBDataObject::duplicate makes a copy of the object with no
+            // id, so a fresh row is saved. This happens at the end of
+            // updateObject() so that all the values set automagically by
+            // AdminObjectEdit::updateObject() get copied, but so that
+            // subclasses then modify the duplicated object. It is not necessary
+            // if it is a new object.
+            if ($this->shouldReplaceObject()) {
+                $object = $object->duplicate();
+                $this->setObject($object);
+            }
+        }
+    }
+
+    protected function updateModifiedDate()
+    {
+        $object = $this->getObject();
+        if ($object->hasPublicProperty('modified_date')
+            && $object->hasDateProperty('modified_date')) {
+            if ($object->isModified()
+                || $this->shouldReplaceObject()
+                || !$object->modified_date instanceof SwatDate) {
+                $object->modified_date = $this->getCurrentTime();
+            }
+        }
+    }
+
+    protected function saveObject()
+    {
+        $this->getObject()->save();
+    }
+
+    protected function deleteOldObject()
+    {
+        if (!$this->isNew()
+            && $this->shouldReplaceObject()
+            && $this->getOldObject() instanceof SwatDBDataObject) {
+            $this->getOldObject()->delete();
+        }
+    }
+
+    protected function postSaveObject() {}
+
+    protected function addObjectToFlushOnSave(SwatDBDataObject $object)
+    {
+        // Make sure the flushable cache is set.
+        if ($this->app->hasModule('SiteMemcacheModule')) {
+            $object->setFlushableCache(
+                $this->app->getModule('SiteMemcacheModule')
+            );
+        }
+
+        $this->data_objects_to_flush[] = $object;
+    }
+
+    protected function clearObjectsToFlush()
+    {
+        $this->data_objects_to_flush = [];
+    }
+
+    protected function flushObjectsOnSave()
+    {
+        foreach ($this->data_objects_to_flush as $object) {
+            if ($object instanceof SwatDBDataObject) {
+                $object->flushCacheNamespaces();
+            }
+        }
+    }
+
+    protected function addSavedMessage()
+    {
+        if ($this->app->hasModule('SiteMessagesModule')) {
+            $message = $this->getSavedMessage();
+            if ($message instanceof SwatMessage) {
+                $this->app->getModule('SiteMessagesModule')->add($message);
+            }
+        }
+    }
+
+    protected function getSavedMessage()
+    {
+        $message = null;
+        $message_type = $this->getSavedMessageType();
+        $primary_content = $this->getSavedMessagePrimaryContent();
+        $secondary_content = $this->getSavedMessageSecondaryContent();
+        $content_type = $this->getSavedMessageContentType();
+
+        if ($primary_content != '') {
+            $message = new SwatMessage($primary_content, $message_type);
+
+            if ($secondary_content != '') {
+                $message->secondary_content = $secondary_content;
+            }
+
+            if ($content_type != '') {
+                $message->content_type = $content_type;
+            }
+        }
+
+        return $message;
+    }
+
+    protected function getSavedMessagePrimaryContent()
+    {
+        return null;
+    }
+
+    protected function getSavedMessageSecondaryContent()
+    {
+        return null;
+    }
+
+    protected function getSavedMessageType()
+    {
+        return null;
+    }
+
+    protected function getSavedMessageContentType()
+    {
+        return null;
+    }
+
+    protected function assignUiValues(array $names)
+    {
+        $this->assignUiValuesToObject($this->getObject(), $names);
+    }
+
+    protected function assignUiValuesToObject(
+        SwatDBDataObject $object,
+        array $names
+    ) {
+        $tz_name = $this->getObjectTimeZonePropertyName();
+
+        if (in_array($tz_name, $names)) {
+            $this->assignUiValueToObject($object, $tz_name);
+        }
+
+        foreach ($names as $name) {
+            // Already processed the $tz_name property
+            if ($name !== $tz_name) {
+                $this->assignUiValueToObject($object, $name);
+            }
+        }
+    }
+
+    protected function assignUiValueToObject(
+        SwatDBDataObject $object,
+        $name
+    ) {
+        $widget = $this->ui->getWidget($name);
+
+        // only clone the value when its actually an object
+        if ($widget instanceof SwatDateEntry
+            && $widget->value instanceof SwatDate) {
+            $value = clone $widget->value;
+            $value->setTZ($this->getObjectTimeZone());
+            $value->toUTC();
+        } else {
+            $value = $widget->value;
+        }
+
+        if (property_exists($object, $name)
+            || $object->hasInternalValue($name)) {
+            $object->{$name} = $value;
+        } else {
+            throw new SwatInvalidPropertyException(
+                sprintf(
+                    'Specified “%s” object does not have a property “%s”.',
+                    get_class($object),
+                    $name
+                )
+            );
+        }
+    }
+
+    // build phase
+
+    protected function loadDBData()
+    {
+        $this->loadObject();
+    }
+
+    protected function loadObject()
+    {
+        $this->assignValuesToUi($this->getObjectUiValueNames());
+    }
+
+    protected function assignValuesToUi(array $names)
+    {
+        $this->assignObjectValuesToUi($this->getObject(), $names);
+    }
+
+    protected function assignObjectValuesToUi(
+        SwatDBDataObject $object,
+        array $names
+    ) {
+        foreach ($names as $name) {
+            $this->assignObjectValueToUi($object, $name);
+        }
+    }
+
+    protected function assignObjectValueToUi(SwatDBDataObject $object, $name)
+    {
+        if (property_exists($object, $name)) {
+            $value = $object->{$name};
+        } elseif ($object->hasInternalValue($name)) {
+            $value = $object->getInternalValue($name);
+        } else {
+            throw new SwatInvalidPropertyException(
+                sprintf(
+                    'Specified “%s” record does not have a property “%s”.',
+                    get_class($object),
+                    $name
+                )
+            );
+        }
+
+        $widget = $this->ui->getWidget($name);
+
+        if ($widget instanceof SwatDateEntry
+            && $value instanceof SwatDate) {
+            $value = new SwatDate($value);
+            $value->convertTZ($this->getObjectTimeZone());
+        }
+
+        $widget->value = $value;
+    }
 }
-
-?>

--- a/Admin/pages/AdminOrder.php
+++ b/Admin/pages/AdminOrder.php
@@ -1,224 +1,175 @@
 <?php
 
 /**
- * Generic admin ordering page
+ * Generic admin ordering page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * ordering page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminOrder extends AdminPage
 {
-	// init phase
-
-
-	protected function initInternal()
-	{
-		parent::initInternal();
-
-		$this->ui->getRoot()->addJavaScript(
-			'packages/admin/javascript/admin-order.js'
-		);
-
-		$this->ui->loadFromXML($this->getUiXml());
-	}
-
-
-
-
-	protected function getUiXml()
-	{
-		return __DIR__.'/order.xml';
-	}
-
-
-
-	// process phase
-
-
-	protected function processInternal()
-	{
-		parent::processInternal();
-
-		$form = $this->ui->getWidget('order_form');
-
-		if ($form->isProcessed()) {
-			$this->saveData();
-			$this->app->messages->add($this->getUpdatedMessage());
-			$this->relocate();
-		}
-	}
-
-
-
-
-	/**
-	 * Saves ordering information
-	 */
-	protected function saveData()
-	{
-		$this->saveIndexes();
-	}
-
-
-
-
-	/**
-	 * Saves the updated ordering indexes of each option
-	 *
-	 * @see AdminOrder::saveIndex()
-	 */
-	protected function saveIndexes()
-	{
-		$count = 0;
-		$order_widget = $this->ui->getWidget('order');
-		$options_list = $this->ui->getWidget('options');
-
-		foreach ($order_widget->values as $id) {
-			if ($options_list->value == 'custom')
-				$count++;
-
-			$this->saveIndex($id, $count);
-		}
-	}
-
-
-
-
-	/**
-	 * Relocates after processing is complete
-	 */
-	protected function relocate()
-	{
-		$form = $this->ui->getWidget('order_form');
-		$url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
-		$this->app->relocate($url);
-	}
-
-
-
-
-	/**
-	 * Gets the message to show the user when the order is successfully updated
-	 *
-	 * @return SwatMessage a SwatMessage object containing the message to
-	 *                      show the user when the order is successfully
-	 *                      updated.
-	 */
-	protected function getUpdatedMessage()
-	{
-		return new SwatMessage(Admin::_('Order updated.'));
-	}
-
-
-
-
-	/**
-	 * Save index
-	 *
-	 * This method is called by {@link AdminOrder::saveIndexes()} to save a
-	 * single ordering index. Sub-classes should implement this method and
-	 * perform whatever actions are necessary to store the ordering index.
-	 *
-	 * @param mixed $id an integer identifier of the option to which
-	 *                   ordering information is saved.
-	 * @param integer $index the ordering index to store.
-	 */
-	abstract protected function saveIndex($id, $index);
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-		$this->buildOptionList();
-		$this->buildButton();
-		$this->buildForm();
-		$this->loadData();
-	}
-
-
-
-
-	protected function buildOptionList()
-	{
-		$options_list = $this->ui->getWidget('options');
-		$options_list->addOptionsByArray(array(
-			'auto'   => Admin::_('Alphabetically'),
-			'custom' => Admin::_('Custom'))
-		);
-	}
-
-
-
-
-	protected function buildButton()
-	{
-		$button = $this->ui->getWidget('submit_button');
-		$button->title = Admin::_('Update Order');
-	}
-
-
-
-
-	protected function buildForm()
-	{
-		$form = $this->ui->getWidget('order_form');
-		$form->action = $this->source;
-
-		if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
-			$url = $this->getRefererURL();
-			$form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
-		}
-	}
-
-
-
-
-	protected function buildNavBar()
-	{
-		parent::buildNavBar();
-
-		$this->navbar->createEntry(Admin::_('Change Order'));
-	}
-
-
-
-
-	protected function display()
-	{
-		parent::display();
-		Swat::displayInlineJavaScript($this->getInlineJavaScript());
-	}
-
-
-
-
-	/**
-	 * Load the data
-	 *
-	 * This method is called to load data to be edited into the widgets.
-	 * Sub-classes should implement this method and perform whatever actions
-	 * are necessary to obtain the data. Widgets can be accessed through the
-	 * $ui class variable.
-	 */
-	abstract protected function loadData();
-
-
-
-
-	private function getInlineJavaScript()
-	{
-		return "var admin_order = new AdminOrder('options_custom', order_obj);";
-	}
-
-
+    // init phase
+
+    protected function initInternal()
+    {
+        parent::initInternal();
+
+        $this->ui->getRoot()->addJavaScript(
+            'packages/admin/javascript/admin-order.js'
+        );
+
+        $this->ui->loadFromXML($this->getUiXml());
+    }
+
+    protected function getUiXml()
+    {
+        return __DIR__ . '/order.xml';
+    }
+
+    // process phase
+
+    protected function processInternal()
+    {
+        parent::processInternal();
+
+        $form = $this->ui->getWidget('order_form');
+
+        if ($form->isProcessed()) {
+            $this->saveData();
+            $this->app->messages->add($this->getUpdatedMessage());
+            $this->relocate();
+        }
+    }
+
+    /**
+     * Saves ordering information.
+     */
+    protected function saveData()
+    {
+        $this->saveIndexes();
+    }
+
+    /**
+     * Saves the updated ordering indexes of each option.
+     *
+     * @see AdminOrder::saveIndex()
+     */
+    protected function saveIndexes()
+    {
+        $count = 0;
+        $order_widget = $this->ui->getWidget('order');
+        $options_list = $this->ui->getWidget('options');
+
+        foreach ($order_widget->values as $id) {
+            if ($options_list->value == 'custom') {
+                $count++;
+            }
+
+            $this->saveIndex($id, $count);
+        }
+    }
+
+    /**
+     * Relocates after processing is complete.
+     */
+    protected function relocate()
+    {
+        $form = $this->ui->getWidget('order_form');
+        $url = $form->getHiddenField(self::RELOCATE_URL_FIELD);
+        $this->app->relocate($url);
+    }
+
+    /**
+     * Gets the message to show the user when the order is successfully updated.
+     *
+     * @return SwatMessage a SwatMessage object containing the message to
+     *                     show the user when the order is successfully
+     *                     updated
+     */
+    protected function getUpdatedMessage()
+    {
+        return new SwatMessage(Admin::_('Order updated.'));
+    }
+
+    /**
+     * Save index.
+     *
+     * This method is called by {@link AdminOrder::saveIndexes()} to save a
+     * single ordering index. Sub-classes should implement this method and
+     * perform whatever actions are necessary to store the ordering index.
+     *
+     * @param mixed $id    an integer identifier of the option to which
+     *                     ordering information is saved
+     * @param int   $index the ordering index to store
+     */
+    abstract protected function saveIndex($id, $index);
+
+    // build phase
+
+    protected function buildInternal()
+    {
+        parent::buildInternal();
+        $this->buildOptionList();
+        $this->buildButton();
+        $this->buildForm();
+        $this->loadData();
+    }
+
+    protected function buildOptionList()
+    {
+        $options_list = $this->ui->getWidget('options');
+        $options_list->addOptionsByArray(
+            [
+                'auto'   => Admin::_('Alphabetically'),
+                'custom' => Admin::_('Custom')]
+        );
+    }
+
+    protected function buildButton()
+    {
+        $button = $this->ui->getWidget('submit_button');
+        $button->title = Admin::_('Update Order');
+    }
+
+    protected function buildForm()
+    {
+        $form = $this->ui->getWidget('order_form');
+        $form->action = $this->source;
+
+        if ($form->getHiddenField(self::RELOCATE_URL_FIELD) === null) {
+            $url = $this->getRefererURL();
+            $form->addHiddenField(self::RELOCATE_URL_FIELD, $url);
+        }
+    }
+
+    protected function buildNavBar()
+    {
+        parent::buildNavBar();
+
+        $this->navbar->createEntry(Admin::_('Change Order'));
+    }
+
+    protected function display()
+    {
+        parent::display();
+        Swat::displayInlineJavaScript($this->getInlineJavaScript());
+    }
+
+    /**
+     * Load the data.
+     *
+     * This method is called to load data to be edited into the widgets.
+     * Sub-classes should implement this method and perform whatever actions
+     * are necessary to obtain the data. Widgets can be accessed through the
+     * $ui class variable.
+     */
+    abstract protected function loadData();
+
+    private function getInlineJavaScript()
+    {
+        return "var admin_order = new AdminOrder('options_custom', order_obj);";
+    }
 }
-
-?>

--- a/Admin/pages/AdminOrder.php
+++ b/Admin/pages/AdminOrder.php
@@ -13,7 +13,7 @@
 abstract class AdminOrder extends AdminPage
 {
 	// init phase
-	// {{{ protected function initInternal()
+
 
 	protected function initInternal()
 	{
@@ -26,18 +26,18 @@ abstract class AdminOrder extends AdminPage
 		$this->ui->loadFromXML($this->getUiXml());
 	}
 
-	// }}}
-	// {{{ protected function getUiXml()
+
+
 
 	protected function getUiXml()
 	{
 		return __DIR__.'/order.xml';
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -52,8 +52,8 @@ abstract class AdminOrder extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function saveData()
+
+
 
 	/**
 	 * Saves ordering information
@@ -63,8 +63,8 @@ abstract class AdminOrder extends AdminPage
 		$this->saveIndexes();
 	}
 
-	// }}}
-	// {{{ protected function saveIndexes()
+
+
 
 	/**
 	 * Saves the updated ordering indexes of each option
@@ -85,8 +85,8 @@ abstract class AdminOrder extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function relocate()
+
+
 
 	/**
 	 * Relocates after processing is complete
@@ -98,8 +98,8 @@ abstract class AdminOrder extends AdminPage
 		$this->app->relocate($url);
 	}
 
-	// }}}
-	// {{{ protected function getUpdatedMessage()
+
+
 
 	/**
 	 * Gets the message to show the user when the order is successfully updated
@@ -113,8 +113,8 @@ abstract class AdminOrder extends AdminPage
 		return new SwatMessage(Admin::_('Order updated.'));
 	}
 
-	// }}}
-	// {{{ abstract protected function saveIndex()
+
+
 
 	/**
 	 * Save index
@@ -129,10 +129,10 @@ abstract class AdminOrder extends AdminPage
 	 */
 	abstract protected function saveIndex($id, $index);
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -143,8 +143,8 @@ abstract class AdminOrder extends AdminPage
 		$this->loadData();
 	}
 
-	// }}}
-	// {{{ protected function buildOptionList()
+
+
 
 	protected function buildOptionList()
 	{
@@ -155,8 +155,8 @@ abstract class AdminOrder extends AdminPage
 		);
 	}
 
-	// }}}
-	// {{{ protected function buildButton()
+
+
 
 	protected function buildButton()
 	{
@@ -164,8 +164,8 @@ abstract class AdminOrder extends AdminPage
 		$button->title = Admin::_('Update Order');
 	}
 
-	// }}}
-	// {{{ protected function buildForm()
+
+
 
 	protected function buildForm()
 	{
@@ -178,8 +178,8 @@ abstract class AdminOrder extends AdminPage
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildNavBar()
+
+
 
 	protected function buildNavBar()
 	{
@@ -188,8 +188,8 @@ abstract class AdminOrder extends AdminPage
 		$this->navbar->createEntry(Admin::_('Change Order'));
 	}
 
-	// }}}
-	// {{{ protected function display()
+
+
 
 	protected function display()
 	{
@@ -197,8 +197,8 @@ abstract class AdminOrder extends AdminPage
 		Swat::displayInlineJavaScript($this->getInlineJavaScript());
 	}
 
-	// }}}
-	// {{{ abstract protected function loadData()
+
+
 
 	/**
 	 * Load the data
@@ -210,15 +210,15 @@ abstract class AdminOrder extends AdminPage
 	 */
 	abstract protected function loadData();
 
-	// }}}
-	// {{{ private function getInlineJavaScript()
+
+
 
 	private function getInlineJavaScript()
 	{
 		return "var admin_order = new AdminOrder('options_custom', order_obj);";
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminPage.php
+++ b/Admin/pages/AdminPage.php
@@ -9,12 +9,12 @@
  */
 abstract class AdminPage extends SitePage
 {
-	// {{{ class constants
+
 
 	const RELOCATE_URL_FIELD = '_admin_relocate_url';
 
-	// }}}
-	// {{{ public properties
+
+
 
 	/**
 	 * Source of this page
@@ -55,8 +55,8 @@ abstract class AdminPage extends SitePage
 	 */
 	public $navbar = null;
 
-	// }}}
-	// {{{ protected properties
+
+
 
 	/**
 	 * The user-interface of this page
@@ -65,8 +65,8 @@ abstract class AdminPage extends SitePage
 	 */
 	protected $ui = null;
 
-	// }}}
-	// {{{ public function __construct()
+
+
 
 	public function __construct(
 		SiteApplication $app,
@@ -82,8 +82,8 @@ abstract class AdminPage extends SitePage
 		$this->ui = new AdminUI();
 	}
 
-	// }}}
-	// {{{ public function getRelativeURL()
+
+
 
 	public function getRelativeURL()
 	{
@@ -98,8 +98,8 @@ abstract class AdminPage extends SitePage
 		return $url;
 	}
 
-	// }}}
-	// {{{ public function getRefererURL()
+
+
 
 	public function getRefererURL()
 	{
@@ -111,34 +111,34 @@ abstract class AdminPage extends SitePage
 		}
 	}
 
-	// }}}
-	// {{{ public function getComponentName()
+
+
 
 	public function getComponentName()
 	{
 		return $this->component;
 	}
 
-	// }}}
-	// {{{ public function getComponentTitle()
+
+
 
 	public function getComponentTitle()
 	{
 		return $this->title;
 	}
 
-	// }}}
-	// {{{ protected function createLayout()
+
+
 
 	protected function createLayout()
 	{
 		return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
 	}
 
-	// }}}
+
 
 	// init phase
-	// {{{ public function init()
+
 
 	/**
 	 * Initialize the page
@@ -155,8 +155,8 @@ abstract class AdminPage extends SitePage
 		$this->ui->init();
 	}
 
-	// }}}
-	// {{{ protected function initInternal()
+
+
 
 	/**
 	 * Initialize the page
@@ -169,10 +169,10 @@ abstract class AdminPage extends SitePage
 	{
 	}
 
-	// }}}
+
 
 	// process phase
-	// {{{ public function process()
+
 
 	/**
 	 * Process the page
@@ -191,8 +191,8 @@ abstract class AdminPage extends SitePage
 		}
 	}
 
-	// }}}
-	// {{{ protected function formsAreAuthenticated()
+
+
 
 	/**
 	 * Authenticate any forms on the page
@@ -220,8 +220,8 @@ abstract class AdminPage extends SitePage
 		return true;
 	}
 
-	// }}}
-	// {{{ protected function processInternal()
+
+
 
 	/**
 	 * Processes the page
@@ -233,10 +233,10 @@ abstract class AdminPage extends SitePage
 	{
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ public function build()
+
 
 	public function build()
 	{
@@ -253,8 +253,8 @@ abstract class AdminPage extends SitePage
 		$this->layout->endCapture();
 	}
 
-	// }}}
-	// {{{ protected function buildInternal()
+
+
 
 	/**
 	 * Build the page for display
@@ -270,8 +270,8 @@ abstract class AdminPage extends SitePage
 	{
 	}
 
-	// }}}
-	// {{{ protected function buildMessages()
+
+
 
 	protected function buildMessages()
 	{
@@ -284,8 +284,8 @@ abstract class AdminPage extends SitePage
 		}
 	}
 
-	// }}}
-	// {{{ protected function display()
+
+
 
 	/**
 	 * Display the page
@@ -300,10 +300,10 @@ abstract class AdminPage extends SitePage
 		}
 	}
 
-	// }}}
+
 
 	// finalize phase
-	// {{{ public function finalize()
+
 
 	public function finalize()
 	{
@@ -312,7 +312,7 @@ abstract class AdminPage extends SitePage
 			$this->ui->getRoot()->getHtmlHeadEntrySet());
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminPage.php
+++ b/Admin/pages/AdminPage.php
@@ -1,318 +1,254 @@
 <?php
 
 /**
- * Page of an administration application
+ * Page of an administration application.
  *
- * @package   Admin
  * @copyright 2004-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminPage extends SitePage
 {
-
-
-	const RELOCATE_URL_FIELD = '_admin_relocate_url';
-
-
-
-
-	/**
-	 * Source of this page
-	 *
-	 * @var string
-	 */
-	public $source;
-
-	/**
-	 * Component name of this page
-	 *
-	 * @var string
-	 */
-	public $component;
-
-	/**
-	 * Subcomponent name of this page
-	 *
-	 * @var string
-	 */
-	public $subcomponent;
-
-	/**
-	 * Title of this page
-	 *
-	 * @var string
-	 */
-	public $title = null;
-
-	/**
-	 * Reference to the navbar object
-	 *
-	 * Officially the navbar now lives in the layout object, but this
-	 * reference is very useful for backwards compatibility with
-	 * exisitng code.
-	 *
-	 * @var AdminNavBar
-	 */
-	public $navbar = null;
-
-
-
-
-	/**
-	 * The user-interface of this page
-	 *
-	 * @var AdminUI
-	 */
-	protected $ui = null;
-
-
-
-
-	public function __construct(
-		SiteApplication $app,
-		SiteLayout $layout = null,
-		array $arguments = array()
-	) {
-		parent::__construct($app, $layout, $arguments);
-
-		// see comment above on navbar class var
-		if (isset($this->layout->navbar))
-			$this->navbar = $this->layout->navbar;
-
-		$this->ui = new AdminUI();
-	}
-
-
-
-
-	public function getRelativeURL()
-	{
-		$url = $this->source.'?';
-
-		foreach ($_GET as $name => $value)
-			if ($name != 'source')
-				$url.= $name.'='.$value.'&';
-
-		$url = mb_substr($url, 0, -1);
-
-		return $url;
-	}
-
-
-
-
-	public function getRefererURL()
-	{
-		if (isset($_SERVER['HTTP_REFERER'])) {
-			return $_SERVER['HTTP_REFERER'];
-		} else {
-			$source_exp = explode('/', $this->source);
-			return $source_exp[0];
-		}
-	}
-
-
-
-
-	public function getComponentName()
-	{
-		return $this->component;
-	}
-
-
-
-
-	public function getComponentTitle()
-	{
-		return $this->title;
-	}
-
-
-
-
-	protected function createLayout()
-	{
-		return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
-	}
-
-
-
-	// init phase
-
-
-	/**
-	 * Initialize the page
-	 *
-	 * Initializes {@link AdminPage::initInternal()} and {@link
-	 * AdminPage::$ui}. Sub-classes should implement
-	 * {@link SitePage::initInternal()} to perform their own
-	 * initialization.
-	 */
-	public function init()
-	{
-		parent::init();
-		$this->initInternal();
-		$this->ui->init();
-	}
-
-
-
-
-	/**
-	 * Initialize the page
-	 *
-	 * Sub-classes should implement this method to initialize the page. At
-	 * this point the {@link AdminPage::$ui} has been constructed but has not
-	 * been initialized.
-	 */
-	protected function initInternal()
-	{
-	}
-
-
-
-	// process phase
-
-
-	/**
-	 * Process the page
-	 *
-	 * Sub-classes should implement this method to process the page.
-	 * Sub-classes should call parent::process first which calls
-	 * {@link AdminPage::$ui->process()}.
-	 * Called after {@link AdminPage::init()}.
-	 */
-	public function process()
-	{
-		parent::process();
-		if ($this->formsAreAuthenticated()) {
-			$this->ui->process();
-			$this->processInternal();
-		}
-	}
-
-
-
-
-	/**
-	 * Authenticate any forms on the page
-	 *
-	 * This happens before {@link AdminPage::$ui} has been processed.
-	 */
-	protected function formsAreAuthenticated()
-	{
-		$forms = $this->ui->getRoot()->getDescendants('SwatForm');
-		foreach ($forms as $form) {
-			if (!$form->isAuthenticated()) {
-				$message = new SwatMessage(Admin::_('There is a problem with '.
-					'the information submitted.'), 'warning');
-
-				$message->secondary_content =
-					Admin::_('In order to ensure your security, we were '.
-					'unable to process your request. Please try again.');
-
-				$this->app->messages->add($message);
-
-				// if one form is not authenticated, we don't need to check more
-				return false;
-			}
-		}
-		return true;
-	}
-
-
-
-
-	/**
-	 * Processes the page
-	 *
-	 * Sub-classes should implement this method to process the page. At
-	 * this point the {@link AdminPage::$ui} has already been processed.
-	 */
-	protected function processInternal()
-	{
-	}
-
-
-
-	// build phase
-
-
-	public function build()
-	{
-		parent::build();
-
-		$this->buildInternal();
-
-		$this->layout->data->title =
-			SwatString::minimizeEntities($this->title).' - '.
-			SwatString::minimizeEntities($this->app->title);
-
-		$this->layout->startCapture('content');
-		$this->display();
-		$this->layout->endCapture();
-	}
-
-
-
-
-	/**
-	 * Build the page for display
-	 *
-	 * Sub-classes should implement this method to initialize elements of
-	 * the page. This method is called at the beginning of {@link
-	 * AdminPage::build()}. This is useful to do database queries that are
-	 * only needed for {@link AdminPage::display()} and not {@link
-	 * AdminPage::process()}, while initialization needed for both display
-	 * and process should be included in {@link AdminPage::init()}.
-	 */
-	protected function buildInternal()
-	{
-	}
-
-
-
-
-	protected function buildMessages()
-	{
-		try {
-			$message_display = $this->ui->getWidget('message_display');
-			foreach ($this->app->messages->getAll() as $message)
-				$message_display->add($message);
-		} catch (SwatWidgetNotFoundException $e) {
-			// ignore
-		}
-	}
-
-
-
-
-	/**
-	 * Display the page
-	 *
-	 * Sub-classes should implement this method to display the contents of
-	 * the page. Called after {@link AdminPage::init()}
-	 */
-	protected function display()
-	{
-		if ($this->ui !== null) {
-			$this->ui->display();
-		}
-	}
-
-
-
-	// finalize phase
-
-
-	public function finalize()
-	{
-		parent::finalize();
-		$this->layout->addHtmlHeadEntrySet(
-			$this->ui->getRoot()->getHtmlHeadEntrySet());
-	}
-
-
+    public const RELOCATE_URL_FIELD = '_admin_relocate_url';
+
+    /**
+     * Source of this page.
+     *
+     * @var string
+     */
+    public $source;
+
+    /**
+     * Component name of this page.
+     *
+     * @var string
+     */
+    public $component;
+
+    /**
+     * Subcomponent name of this page.
+     *
+     * @var string
+     */
+    public $subcomponent;
+
+    /**
+     * Title of this page.
+     *
+     * @var string
+     */
+    public $title;
+
+    /**
+     * Reference to the navbar object.
+     *
+     * Officially the navbar now lives in the layout object, but this
+     * reference is very useful for backwards compatibility with
+     * exisitng code.
+     *
+     * @var AdminNavBar
+     */
+    public $navbar;
+
+    /**
+     * The user-interface of this page.
+     *
+     * @var AdminUI
+     */
+    protected $ui;
+
+    public function __construct(
+        SiteApplication $app,
+        ?SiteLayout $layout = null,
+        array $arguments = []
+    ) {
+        parent::__construct($app, $layout, $arguments);
+
+        // see comment above on navbar class var
+        if (isset($this->layout->navbar)) {
+            $this->navbar = $this->layout->navbar;
+        }
+
+        $this->ui = new AdminUI();
+    }
+
+    public function getRelativeURL()
+    {
+        $url = $this->source . '?';
+
+        foreach ($_GET as $name => $value) {
+            if ($name != 'source') {
+                $url .= $name . '=' . $value . '&';
+            }
+        }
+
+        $url = mb_substr($url, 0, -1);
+
+        return $url;
+    }
+
+    public function getRefererURL()
+    {
+        if (isset($_SERVER['HTTP_REFERER'])) {
+            return $_SERVER['HTTP_REFERER'];
+        }
+        $source_exp = explode('/', $this->source);
+
+        return $source_exp[0];
+    }
+
+    public function getComponentName()
+    {
+        return $this->component;
+    }
+
+    public function getComponentTitle()
+    {
+        return $this->title;
+    }
+
+    protected function createLayout()
+    {
+        return new AdminDefaultLayout($this->app, AdminDefaultTemplate::class);
+    }
+
+    // init phase
+
+    /**
+     * Initialize the page.
+     *
+     * Initializes {@link AdminPage::initInternal()} and {@link * AdminPage::$ui}. Sub-classes should implement
+     * {@link SitePage::initInternal()} to perform their own
+     * initialization.
+     */
+    public function init()
+    {
+        parent::init();
+        $this->initInternal();
+        $this->ui->init();
+    }
+
+    /**
+     * Initialize the page.
+     *
+     * Sub-classes should implement this method to initialize the page. At
+     * this point the {@link AdminPage::$ui} has been constructed but has not
+     * been initialized.
+     */
+    protected function initInternal() {}
+
+    // process phase
+
+    /**
+     * Process the page.
+     *
+     * Sub-classes should implement this method to process the page.
+     * Sub-classes should call parent::process first which calls
+     * {@link AdminPage::$ui->process()}.
+     * Called after {@link AdminPage::init()}.
+     */
+    public function process()
+    {
+        parent::process();
+        if ($this->formsAreAuthenticated()) {
+            $this->ui->process();
+            $this->processInternal();
+        }
+    }
+
+    /**
+     * Authenticate any forms on the page.
+     *
+     * This happens before {@link AdminPage::$ui} has been processed.
+     */
+    protected function formsAreAuthenticated()
+    {
+        $forms = $this->ui->getRoot()->getDescendants('SwatForm');
+        foreach ($forms as $form) {
+            if (!$form->isAuthenticated()) {
+                $message = new SwatMessage(Admin::_('There is a problem with ' .
+                    'the information submitted.'), 'warning');
+
+                $message->secondary_content =
+                    Admin::_('In order to ensure your security, we were ' .
+                    'unable to process your request. Please try again.');
+
+                $this->app->messages->add($message);
+
+                // if one form is not authenticated, we don't need to check more
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Processes the page.
+     *
+     * Sub-classes should implement this method to process the page. At
+     * this point the {@link AdminPage::$ui} has already been processed.
+     */
+    protected function processInternal() {}
+
+    // build phase
+
+    public function build()
+    {
+        parent::build();
+
+        $this->buildInternal();
+
+        $this->layout->data->title =
+            SwatString::minimizeEntities($this->title) . ' - ' .
+            SwatString::minimizeEntities($this->app->title);
+
+        $this->layout->startCapture('content');
+        $this->display();
+        $this->layout->endCapture();
+    }
+
+    /**
+     * Build the page for display.
+     *
+     * Sub-classes should implement this method to initialize elements of
+     * the page. This method is called at the beginning of {@link * AdminPage::build()}. This is useful to do database queries that are
+     * only needed for {@link AdminPage::display()} and not {@link * AdminPage::process()}, while initialization needed for both display
+     * and process should be included in {@link AdminPage::init()}.
+     */
+    protected function buildInternal() {}
+
+    protected function buildMessages()
+    {
+        try {
+            $message_display = $this->ui->getWidget('message_display');
+            foreach ($this->app->messages->getAll() as $message) {
+                $message_display->add($message);
+            }
+        } catch (SwatWidgetNotFoundException $e) {
+            // ignore
+        }
+    }
+
+    /**
+     * Display the page.
+     *
+     * Sub-classes should implement this method to display the contents of
+     * the page. Called after {@link AdminPage::init()}
+     */
+    protected function display()
+    {
+        if ($this->ui !== null) {
+            $this->ui->display();
+        }
+    }
+
+    // finalize phase
+
+    public function finalize()
+    {
+        parent::finalize();
+        $this->layout->addHtmlHeadEntrySet(
+            $this->ui->getRoot()->getHtmlHeadEntrySet()
+        );
+    }
 }
-
-?>

--- a/Admin/pages/AdminSearch.php
+++ b/Admin/pages/AdminSearch.php
@@ -1,181 +1,162 @@
 <?php
 
 /**
- * Generic admin search page
+ * Generic admin search page.
  *
  * This class is intended to be a convenience base class. For a fully custom
  * search page, inherit directly from AdminPage instead.
  *
- * @package   Admin
  * @copyright 2005-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 abstract class AdminSearch extends AdminIndex
 {
-	// process phase
+    // process phase
 
+    protected function processInternal()
+    {
+        parent::processInternal();
 
-	protected function processInternal()
-	{
-		parent::processInternal();
+        $form_found = true;
 
-		$form_found = true;
-		try {
-			$form = $this->ui->getWidget('search_form');
-		} catch (SwatWidgetNotFoundException $e) {
-			$form_found = false;
-		}
+        try {
+            $form = $this->ui->getWidget('search_form');
+        } catch (SwatWidgetNotFoundException $e) {
+            $form_found = false;
+        }
 
-		if ($form_found) {
-			$form->process();
+        if ($form_found) {
+            $form->process();
 
-			if ($form->isProcessed())
-				$this->saveState();
+            if ($form->isProcessed()) {
+                $this->saveState();
+            }
 
-			if ($this->hasState()) {
-				$this->loadState();
-				$frame = $this->ui->getWidget('results_frame');
-				$frame->visible = true;
-			}
-		}
-	}
+            if ($this->hasState()) {
+                $this->loadState();
+                $frame = $this->ui->getWidget('results_frame');
+                $frame->visible = true;
+            }
+        }
+    }
 
+    /**
+     * Clears a saved search state.
+     */
+    protected function clearState()
+    {
+        if ($this->hasState()) {
+            unset($this->app->session->{$this->getKey()});
+        }
+    }
 
+    protected function saveState()
+    {
+        $form_found = true;
 
+        try {
+            $search_form = $this->ui->getWidget('search_form');
+        } catch (SwatWidgetNotFoundException $e) {
+            $form_found = false;
+        }
 
-	/**
-	 * Clears a saved search state
-	 */
-	protected function clearState()
-	{
-		if ($this->hasState())
-			unset($this->app->session->{$this->getKey()});
-	}
+        if ($form_found) {
+            $search_state = $search_form->getDescendantStates();
+            $this->app->session->{$this->getKey()} = $search_state;
+        }
+    }
 
+    /**
+     * Loads a saved search state for this page.
+     *
+     * @return bool true if a saved state exists for this page and false if
+     *              it does not
+     *
+     * @see AdminSearchPage::hasState()
+     */
+    protected function loadState()
+    {
+        $return = false;
 
+        $form_found = true;
 
+        try {
+            $search_form = $this->ui->getWidget('search_form');
+        } catch (SwatWidgetNotFoundException $e) {
+            $form_found = false;
+        }
 
-	protected function saveState()
-	{
-		$form_found = true;
-		try {
-			$search_form = $this->ui->getWidget('search_form');
-		} catch (SwatWidgetNotFoundException $e) {
-			$form_found = false;
-		}
+        if ($form_found) {
+            if ($this->hasState()) {
+                $search_form->setDescendantStates(
+                    $this->app->session->{$this->getKey()}
+                );
 
-		if ($form_found) {
-			$search_state = $search_form->getDescendantStates();
-			$this->app->session->{$this->getKey()} = $search_state;
-		}
-	}
+                $return = true;
+            }
+        }
 
+        return $return;
+    }
 
+    /**
+     * Checks if this search page has stored search information.
+     *
+     * @return bool true if this page has stored search information and
+     *              false if it does not
+     */
+    protected function hasState()
+    {
+        return isset($this->app->session->{$this->getKey()});
+    }
 
+    protected function getKey()
+    {
+        return $this->source . '_search_state';
+    }
 
-	/**
-	 * Loads a saved search state for this page
-	 *
-	 * @return boolean true if a saved state exists for this page and false if
-	 *                  it does not.
-	 *
-	 * @see AdminSearchPage::hasState()
-	 */
-	protected function loadState()
-	{
-		$return = false;
+    // build phase
 
-		$form_found = true;
-		try {
-			$search_form = $this->ui->getWidget('search_form');
-		} catch (SwatWidgetNotFoundException $e) {
-			$form_found = false;
-		}
+    protected function buildInternal()
+    {
+        parent::buildInternal();
 
-		if ($form_found) {
-			if ($this->hasState()) {
-				$search_form->setDescendantStates(
-					$this->app->session->{$this->getKey()});
+        try {
+            $form = $this->ui->getWidget('search_form', true);
+            $form->action = $this->source;
+            $form->autofocus = true;
+        } catch (SwatWidgetNotFoundException $e) {
+            // ignore
+        }
+    }
 
-				$return = true;
-			}
-		}
+    /**
+     * Builds views for this search page.
+     *
+     * View models are initialized to an empty table store unless a saved
+     * search state is available.
+     */
+    protected function buildViews()
+    {
+        $form_found = true;
 
-		return $return;
-	}
+        try {
+            $results_frame = $this->ui->getWidget('results_frame');
+        } catch (SwatWidgetNotFoundException $e) {
+            $form_found = false;
+        }
 
+        if ($form_found) {
+            // set non-visible results frame views to have empty models
+            if (!$results_frame->visible) {
+                $views = $results_frame->getDescendants('SwatTableView');
+                foreach ($views as $view) {
+                    $view->model = new SwatTableStore();
+                }
+            }
+        }
 
-
-
-	/**
-	 * Checks if this search page has stored search information
-	 *
-	 * @return boolean true if this page has stored search information and
-	 *                  false if it does not.
-	 */
-	protected function hasState()
-	{
-		return isset($this->app->session->{$this->getKey()});
-	}
-
-
-
-
-	protected function getKey()
-	{
-		return $this->source.'_search_state';
-	}
-
-
-
-	// build phase
-
-
-	protected function buildInternal()
-	{
-		parent::buildInternal();
-
-		try {
-			$form = $this->ui->getWidget('search_form', true);
-			$form->action = $this->source;
-			$form->autofocus = true;
-		} catch (SwatWidgetNotFoundException $e) {
-			// ignore
-		}
-	}
-
-
-
-
-	/**
-	 * Builds views for this search page
-	 *
-	 * View models are initialized to an empty table store unless a saved
-	 * search state is available.
-	 */
-	protected function buildViews()
-	{
-		$form_found = true;
-		try {
-			$results_frame = $this->ui->getWidget('results_frame');
-		} catch (SwatWidgetNotFoundException $e) {
-			$form_found = false;
-		}
-
-		if ($form_found) {
-			// set non-visible results frame views to have empty models
-			if (!$results_frame->visible) {
-				$views = $results_frame->getDescendants('SwatTableView');
-				foreach ($views as $view)
-					$view->model = new SwatTableStore();
-			}
-		}
-
-		// build other views normally
-		parent::buildViews();
-	}
-
-
+        // build other views normally
+        parent::buildViews();
+    }
 }
-
-?>

--- a/Admin/pages/AdminSearch.php
+++ b/Admin/pages/AdminSearch.php
@@ -13,7 +13,7 @@
 abstract class AdminSearch extends AdminIndex
 {
 	// process phase
-	// {{{ protected function processInternal()
+
 
 	protected function processInternal()
 	{
@@ -40,8 +40,8 @@ abstract class AdminSearch extends AdminIndex
 		}
 	}
 
-	// }}}
-	// {{{ protected function clearState()
+
+
 
 	/**
 	 * Clears a saved search state
@@ -52,8 +52,8 @@ abstract class AdminSearch extends AdminIndex
 			unset($this->app->session->{$this->getKey()});
 	}
 
-	// }}}
-	// {{{ protected function saveState()
+
+
 
 	protected function saveState()
 	{
@@ -70,8 +70,8 @@ abstract class AdminSearch extends AdminIndex
 		}
 	}
 
-	// }}}
-	// {{{ protected function loadState()
+
+
 
 	/**
 	 * Loads a saved search state for this page
@@ -104,8 +104,8 @@ abstract class AdminSearch extends AdminIndex
 		return $return;
 	}
 
-	// }}}
-	// {{{ protected function hasState()
+
+
 
 	/**
 	 * Checks if this search page has stored search information
@@ -118,18 +118,18 @@ abstract class AdminSearch extends AdminIndex
 		return isset($this->app->session->{$this->getKey()});
 	}
 
-	// }}}
-	// {{{ protected function getKey()
+
+
 
 	protected function getKey()
 	{
 		return $this->source.'_search_state';
 	}
 
-	// }}}
+
 
 	// build phase
-	// {{{ protected function buildInternal()
+
 
 	protected function buildInternal()
 	{
@@ -144,8 +144,8 @@ abstract class AdminSearch extends AdminIndex
 		}
 	}
 
-	// }}}
-	// {{{ protected function buildViews()
+
+
 
 	/**
 	 * Builds views for this search page
@@ -175,7 +175,7 @@ abstract class AdminSearch extends AdminIndex
 		parent::buildViews();
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/pages/AdminXMLRPCServer.php
+++ b/Admin/pages/AdminXMLRPCServer.php
@@ -1,14 +1,9 @@
 <?php
 
 /**
- * An XML-RPC server for admin applications
+ * An XML-RPC server for admin applications.
  *
- * @package   Admin
  * @copyright 2006-2016 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
-class AdminXMLRPCServer extends SiteXMLRPCServer
-{
-}
-
-?>
+class AdminXMLRPCServer extends SiteXMLRPCServer {}

--- a/Admin/templates/AdminCustomTemplate.php
+++ b/Admin/templates/AdminCustomTemplate.php
@@ -7,14 +7,14 @@
  */
 class AdminCustomTemplate extends SiteAbstractTemplate
 {
-	// {{{ public function display()
+
 
 	public function display(SiteLayoutData $data)
 	{
 		echo $data->content;
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/templates/AdminCustomTemplate.php
+++ b/Admin/templates/AdminCustomTemplate.php
@@ -1,20 +1,13 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2017 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminCustomTemplate extends SiteAbstractTemplate
 {
-
-
-	public function display(SiteLayoutData $data)
-	{
-		echo $data->content;
-	}
-
-
+    public function display(SiteLayoutData $data)
+    {
+        echo $data->content;
+    }
 }
-
-?>

--- a/Admin/templates/AdminDefaultTemplate.php
+++ b/Admin/templates/AdminDefaultTemplate.php
@@ -7,7 +7,7 @@
  */
 class AdminDefaultTemplate extends SiteAbstractTemplate
 {
-	// {{{ public function display()
+
 
 	public function display(SiteLayoutData $data)
 	{
@@ -60,7 +60,7 @@ HTML;
 		// @codingStandardsIgnoreEnd
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/templates/AdminDefaultTemplate.php
+++ b/Admin/templates/AdminDefaultTemplate.php
@@ -1,66 +1,59 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2017 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminDefaultTemplate extends SiteAbstractTemplate
 {
+    public function display(SiteLayoutData $data)
+    {
+        // @codingStandardsIgnoreStart
+        echo <<<HTML
+            <!DOCTYPE html>
+            <!--[if lt IE 7 ]> <html class="ie6"> <![endif]-->
+            <!--[if IE 7 ]>    <html class="ie7"> <![endif]-->
+            <!--[if IE 8 ]>    <html class="ie8"> <![endif]-->
+            <!--[if (gte IE 9)|!(IE)]><!--> <html> <!--<![endif]-->
+            <head>
+            	<meta charset="utf-8">
+            	<title>{$data->title}</title>
+            	<!--if IE]><base href="{$data->basehref}"></base><![endif]-->
+            	<!--if !(IE)]><!--><base href="{$data->basehref}" /><!--<![endif]-->
+            	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+            	<link rel="icon" href="../favicon.ico" type="image/x-icon" />
+            	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,800' rel='stylesheet' type='text/css' />
+            	{$data->html_head_entries}
+            </head>
+            <body {$data->body_classes}>
 
+            <div id="doc3" class="yui-t1">
 
-	public function display(SiteLayoutData $data)
-	{
-		// @codingStandardsIgnoreStart
-		echo <<<HTML
-<!DOCTYPE html>
-<!--[if lt IE 7 ]> <html class="ie6"> <![endif]-->
-<!--[if IE 7 ]>    <html class="ie7"> <![endif]-->
-<!--[if IE 8 ]>    <html class="ie8"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--> <html> <!--<![endif]-->
-<head>
-	<meta charset="utf-8">
-	<title>{$data->title}</title>
-	<!--if IE]><base href="{$data->basehref}"></base><![endif]-->
-	<!--if !(IE)]><!--><base href="{$data->basehref}" /><!--<![endif]-->
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<link rel="icon" href="../favicon.ico" type="image/x-icon" />
-	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,800' rel='stylesheet' type='text/css' />
-	{$data->html_head_entries}
-</head>
-<body {$data->body_classes}>
+            <div id="bd">
 
-<div id="doc3" class="yui-t1">
+            	<div id="yui-main">
+            		<div class="yui-b">
+            			<div id="hd">
+            				{$data->header}
+            				<div id="admin-navbar">
+            					{$data->navbar}
+            				</div><!-- end admin-navbar -->
+            			</div><!-- end #hd -->
+            			{$data->content}
+            		</div><!-- end admin-content -->
+            	</div><!-- end #yui-main -->
 
-<div id="bd">
+            	<div class="yui-b">
+            	{$data->menu}
+            	</div>
 
-	<div id="yui-main">
-		<div class="yui-b">
-			<div id="hd">
-				{$data->header}
-				<div id="admin-navbar">
-					{$data->navbar}
-				</div><!-- end admin-navbar -->
-			</div><!-- end #hd -->
-			{$data->content}
-		</div><!-- end admin-content -->
-	</div><!-- end #yui-main -->
+            </div><!-- end #bd -->
 
-	<div class="yui-b">
-	{$data->menu}
-	</div>
+            </div><!-- end #doc -->
+            </body>
+            </html>
 
-</div><!-- end #bd -->
-
-</div><!-- end #doc -->
-</body>
-</html>
-
-HTML;
-		// @codingStandardsIgnoreEnd
-	}
-
-
+            HTML;
+        // @codingStandardsIgnoreEnd
+    }
 }
-
-?>

--- a/Admin/templates/AdminLoginTemplate.php
+++ b/Admin/templates/AdminLoginTemplate.php
@@ -7,7 +7,7 @@
  */
 class AdminLoginTemplate extends SiteAbstractTemplate
 {
-	// {{{ public function display()
+
 
 	public function display(SiteLayoutData $data)
 	{
@@ -39,7 +39,7 @@ HTML;
 		// @codingStandardsIgnoreEnd
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Admin/templates/AdminLoginTemplate.php
+++ b/Admin/templates/AdminLoginTemplate.php
@@ -1,45 +1,38 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2017 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminLoginTemplate extends SiteAbstractTemplate
 {
+    public function display(SiteLayoutData $data)
+    {
+        // @codingStandardsIgnoreStart
+        echo <<<HTML
+            <!DOCTYPE html>
+            <!--[if lt IE 7 ]> <html class="ie6"> <![endif]-->
+            <!--[if IE 7 ]>    <html class="ie7"> <![endif]-->
+            <!--[if IE 8 ]>    <html class="ie8"> <![endif]-->
+            <!--[if (gte IE 9)|!(IE)]><!--> <html> <!--<![endif]-->
+            <head>
+            	<meta charset="utf-8">
+            	<title>{$data->title}</title>
+            	<!--if IE]><base href="{$data->basehref}"></base><![endif]-->
+            	<!--if !(IE)]><!--><base href="{$data->basehref}" /><!--<![endif]-->
+            	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+            	<link rel="icon" href="../favicon.ico" type="image/x-icon" />
+            	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,800' rel='stylesheet' type='text/css' />
+            	{$data->html_head_entries}
+            </head>
+            <body {$data->body_classes}>
 
+            {$data->content}
 
-	public function display(SiteLayoutData $data)
-	{
-		// @codingStandardsIgnoreStart
-		echo <<<HTML
-<!DOCTYPE html>
-<!--[if lt IE 7 ]> <html class="ie6"> <![endif]-->
-<!--[if IE 7 ]>    <html class="ie7"> <![endif]-->
-<!--[if IE 8 ]>    <html class="ie8"> <![endif]-->
-<!--[if (gte IE 9)|!(IE)]><!--> <html> <!--<![endif]-->
-<head>
-	<meta charset="utf-8">
-	<title>{$data->title}</title>
-	<!--if IE]><base href="{$data->basehref}"></base><![endif]-->
-	<!--if !(IE)]><!--><base href="{$data->basehref}" /><!--<![endif]-->
-	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-	<link rel="icon" href="../favicon.ico" type="image/x-icon" />
-	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400italic,700italic,400,700,800' rel='stylesheet' type='text/css' />
-	{$data->html_head_entries}
-</head>
-<body {$data->body_classes}>
+            </body>
+            </html>
 
-{$data->content}
-
-</body>
-</html>
-
-HTML;
-		// @codingStandardsIgnoreEnd
-	}
-
-
+            HTML;
+        // @codingStandardsIgnoreEnd
+    }
 }
-
-?>

--- a/Admin/templates/AdminMSWordTemplate.php
+++ b/Admin/templates/AdminMSWordTemplate.php
@@ -1,39 +1,32 @@
 <?php
 
 /**
- * @package   Admin
  * @copyright 2017 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class AdminMSWordTemplate extends SiteAbstractTemplate
 {
+    public function display(SiteLayoutData $data)
+    {
+        // @codingStandardsIgnoreStart
+        echo <<<'HTML'
+            <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+            <html xmlns="http://www.w3.org/1999/xhtml">
+            <body>
 
+            HTML;
 
-	public function display(SiteLayoutData $data)
-	{
-		// @codingStandardsIgnoreStart
-		echo <<<'HTML'
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-<body>
+        header('Content-Type: application/msword');
+        header(
+            'Content-Disposition: attachment; filename=' . $data->filename . '.doc'
+        );
+        echo $data->content;
+        echo <<<'HTML'
 
-HTML;
+            </body>
+            </html>
 
-		header('Content-Type: application/msword');
-		header(
-			'Content-Disposition: attachment; filename='.$data->filename.'.doc'
-		);
-		echo $data->content;
-		echo <<<'HTML'
-
-</body>
-</html>
-
-HTML;
-		// @codingStandardsIgnoreEnd
-	}
-
-
+            HTML;
+        // @codingStandardsIgnoreEnd
+    }
 }
-
-?>

--- a/Admin/templates/AdminMSWordTemplate.php
+++ b/Admin/templates/AdminMSWordTemplate.php
@@ -7,7 +7,7 @@
  */
 class AdminMSWordTemplate extends SiteAbstractTemplate
 {
-	// {{{ public function display()
+
 
 	public function display(SiteLayoutData $data)
 	{
@@ -33,7 +33,7 @@ HTML;
 		// @codingStandardsIgnoreEnd
 	}
 
-	// }}}
+
 }
 
 ?>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
             }
         }
 
-        stage('Lint Modified Files') {
+        stage('Check Code Style for Modified Files') {
             when {
                 not {
                     branch 'master'
@@ -16,25 +16,20 @@ pipeline {
             }
             steps {
                 sh '''
-                    master_sha=$(git rev-parse origin/master)
-                    newest_sha=$(git rev-parse HEAD)
-                    ./vendor/bin/phpcs \
-                    --standard=SilverorangeTransitional \
-                    --tab-width=4 \
-                    --encoding=utf-8 \
-                    --warning-severity=0 \
-                    --extensions=php \
-                    $(git diff --diff-filter=ACRM --name-only $master_sha...$newest_sha)
+                    files=$(git diff-tree --diff-filter=ACRM --no-commit-id --name-only -r HEAD)
+                    if [ -n "$files" ]; then
+                        composer run phpcs:ci $files
+                    fi
                 '''
             }
         }
 
-        stage('Lint Entire Project') {
+        stage('Check Code Style for Entire Project') {
             when {
                 branch 'master'
             }
             steps {
-                sh './vendor/bin/phpcs'
+                sh 'composer run phpcs:ci'
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,71 +1,79 @@
 {
-	"name": "silverorange/admin",
-	"description": "Framework for backend admin website.",
-	"type": "library",
-	"keywords": [ "framework", "admin", "management" ],
-	"homepage": "https://github.com/silverorange/admin",
-	"license": "LGPL-2.1",
-	"authors": [
-		{
-			"name": "Charles Waddell",
-			"email": "charles@silverorange.com"
-		},
-		{
-			"name": "Isaac Grant",
-			"email": "isaac@silverorange.com"
-		},
-		{
-			"name": "Michael Gauthier",
-			"email": "mike@silverorange.com"
-		},
-		{
-			"name": "Nathan Frederikson",
-			"email": "nathan@silverorange.com"
-		},
-		{
-			"name": "Nick Burka",
-			"email": "nick@silverorange.com"
-		},
-		{
-			"name": "Steven Garrity",
-			"email": "steven@silverorange.com"
-		}
-	],
-	"repositories": [
-		{
-			"type": "composer",
-			"url": "https://composer.silverorange.com",
-			"only": ["silverorange/*"]
-		}
-	],
-	"require": {
-		"php": ">=8.2.0",
-		"ext-mbstring": "*",
-		"silverorange/site": "^15.0.0",
-		"silverorange/swat": "^7.1.0"
-	},
-	"require-dev": {
-		"bacon/bacon-qr-code": "^3.0",
-		"friendsofphp/php-cs-fixer": "3.64.0",
-		"phpstan/phpstan": "^1.12",
-		"robthree/twofactorauth": "^3.0"
-	},
-	"suggest": {
-		"robthree/twofactorauth": "required for the use of two factor authentication",
-		"bacon/bacon-qr-code": "required to show QR codes for two factor auth"
-	},
-	"autoload": {
-		"classmap": [ "Admin/" ]
-	},
-	"scripts": {
-		"phpcs": "./vendor/bin/php-cs-fixer check -v",
-		"phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
-		"phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
-		"phpstan": "./vendor/bin/phpstan analyze",
-		"phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
-		"phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline"
-	},
-	"config": {
-		"sort-packages": true
-	}
+  "name": "silverorange/admin",
+  "description": "Framework for backend admin website.",
+  "type": "library",
+  "keywords": [
+    "framework",
+    "admin",
+    "management"
+  ],
+  "homepage": "https://github.com/silverorange/admin",
+  "license": "LGPL-2.1",
+  "authors": [
+    {
+      "name": "Charles Waddell",
+      "email": "charles@silverorange.com"
+    },
+    {
+      "name": "Isaac Grant",
+      "email": "isaac@silverorange.com"
+    },
+    {
+      "name": "Michael Gauthier",
+      "email": "mike@silverorange.com"
+    },
+    {
+      "name": "Nathan Frederikson",
+      "email": "nathan@silverorange.com"
+    },
+    {
+      "name": "Nick Burka",
+      "email": "nick@silverorange.com"
+    },
+    {
+      "name": "Steven Garrity",
+      "email": "steven@silverorange.com"
+    }
+  ],
+  "repositories": [
+    {
+      "type": "composer",
+      "url": "https://composer.silverorange.com",
+      "only": [
+        "silverorange/*"
+      ]
+    }
+  ],
+  "require": {
+    "php": ">=8.2.0",
+    "ext-mbstring": "*",
+    "silverorange/site": "^15.0.0",
+    "silverorange/swat": "^7.1.0"
+  },
+  "require-dev": {
+    "bacon/bacon-qr-code": "^3.0",
+    "friendsofphp/php-cs-fixer": "3.64.0",
+    "phpstan/phpstan": "^1.12",
+    "robthree/twofactorauth": "^3.0"
+  },
+  "suggest": {
+    "robthree/twofactorauth": "required for the use of two factor authentication",
+    "bacon/bacon-qr-code": "required to show QR codes for two factor auth"
+  },
+  "autoload": {
+    "classmap": [
+      "Admin/"
+    ]
+  },
+  "scripts": {
+    "phpcs": "./vendor/bin/php-cs-fixer check -v",
+    "phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
+    "phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
+    "phpstan": "./vendor/bin/phpstan analyze",
+    "phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
+    "phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline"
+  },
+  "config": {
+    "sort-packages": true
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -46,9 +46,9 @@
 	},
 	"require-dev": {
 		"bacon/bacon-qr-code": "^3.0",
+		"friendsofphp/php-cs-fixer": "3.64.0",
 		"phpstan/phpstan": "^1.12",
-		"robthree/twofactorauth": "^3.0",
-		"silverorange/coding-standard": "^1.0.0"
+		"robthree/twofactorauth": "^3.0"
 	},
 	"suggest": {
 		"robthree/twofactorauth": "required for the use of two factor authentication",
@@ -58,10 +58,12 @@
 		"classmap": [ "Admin/" ]
 	},
 	"scripts": {
-		"lint": "./vendor/bin/phpcs",
+		"phpcs": "./vendor/bin/php-cs-fixer check -v",
+		"phpcs:ci": "./vendor/bin/php-cs-fixer check --config=.php-cs-fixer.php --no-interaction --show-progress=none --diff --using-cache=no -vvv",
+		"phpcs:write": "./vendor/bin/php-cs-fixer fix -v",
 		"phpstan": "./vendor/bin/phpstan analyze",
-		"post-install-cmd": "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src",
-		"post-update-cmd": "./vendor/bin/phpcs --config-set installed_paths vendor/silverorange/coding-standard/src"
+		"phpstan:ci": "./vendor/bin/phpstan analyze -vvv --no-progress --memory-limit 2G",
+		"phpstan:baseline": "./vendor/bin/phpstan analyze --generate-baseline"
 	},
 	"config": {
 		"sort-packages": true

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,21 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Access to an undefined property AdminApplication\\:\\:\\$config\\.$#"
-			count: 1
-			path: Admin/AdminApplication.php
-
-		-
-			message: "#^Access to an undefined property AdminApplication\\:\\:\\$database\\.$#"
-			count: 1
-			path: Admin/AdminApplication.php
-
-		-
-			message: "#^Access to an undefined property AdminApplication\\:\\:\\$session\\.$#"
-			count: 1
-			path: Admin/AdminApplication.php
-
-		-
 			message: "#^Access to an undefined property AdminSessionModule\\:\\:\\$history\\.$#"
 			count: 1
 			path: Admin/AdminSessionModule.php
@@ -24,11 +9,6 @@ parameters:
 			message: "#^Access to an undefined property AdminSessionModule\\:\\:\\$user\\.$#"
 			count: 10
 			path: Admin/AdminSessionModule.php
-
-		-
-			message: "#^Access to an undefined property AdminUser\\:\\:\\$most_recent_history\\.$#"
-			count: 1
-			path: Admin/dataobjects/AdminUser.php
 
 		-
 			message: "#^Variable \\$transaction might not be defined\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,46 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to an undefined property AdminApplication\\:\\:\\$config\\.$#"
+			count: 1
+			path: Admin/AdminApplication.php
+
+		-
+			message: "#^Access to an undefined property AdminApplication\\:\\:\\$database\\.$#"
+			count: 1
+			path: Admin/AdminApplication.php
+
+		-
+			message: "#^Access to an undefined property AdminApplication\\:\\:\\$session\\.$#"
+			count: 1
+			path: Admin/AdminApplication.php
+
+		-
+			message: "#^Access to an undefined property AdminSessionModule\\:\\:\\$history\\.$#"
+			count: 1
+			path: Admin/AdminSessionModule.php
+
+		-
+			message: "#^Access to an undefined property AdminSessionModule\\:\\:\\$user\\.$#"
+			count: 10
+			path: Admin/AdminSessionModule.php
+
+		-
+			message: "#^Access to an undefined property AdminUser\\:\\:\\$most_recent_history\\.$#"
+			count: 1
+			path: Admin/dataobjects/AdminUser.php
+
+		-
+			message: "#^Variable \\$transaction might not be defined\\.$#"
+			count: 1
+			path: Admin/pages/AdminDBConfirmation.php
+
+		-
+			message: "#^Variable \\$transaction might not be defined\\.$#"
+			count: 1
+			path: Admin/pages/AdminDBEdit.php
+
+		-
+			message: "#^Variable \\$transaction might not be defined\\.$#"
+			count: 1
+			path: Admin/pages/AdminDBOrder.php

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,8 +1,11 @@
+includes:
+  - phpstan-baseline.neon
+
 parameters:
   phpVersion: 80200
-  level: 0
+  level: 1
   paths:
     - Admin
-    - po/preprocess.php
+    - po
   editorUrl: '%%file%%:%%line%%'
   editorUrlTitle: '%%file%%:%%line%%'

--- a/po/preprocess.php
+++ b/po/preprocess.php
@@ -2,11 +2,10 @@
 
 /**
  * Removes PHP string concatenations inside gettext markers given a PHP source
- * file
+ * file.
  *
  * @copyright 2006-2016 silverorange
  */
-
 $source = file_get_contents($_SERVER['argv'][1]);
 
 $output = '';
@@ -16,104 +15,111 @@ $gettext_blank_lines = 0;
 
 $tokens = token_get_all($source);
 for ($i = 0; $i < count($tokens); $i++) {
-	$token = $tokens[$i];
-	if (is_string($token)) {
-		switch ($token) {
-		// ignore string concatenation inside gettext calls 
-		case '.':
-			if (!$in_gettext)
-				$output.= $token;
+    $token = $tokens[$i];
+    if (is_string($token)) {
+        switch ($token) {
+            // ignore string concatenation inside gettext calls
+            case '.':
+                if (!$in_gettext) {
+                    $output .= $token;
+                }
 
-			break;
-		// for ngettext multiple translations
-		case ',':
-			if ($in_gettext_string) {
-				$output.= "', ";
-				$in_gettext_string = false;
-			} else {
-				$output.= $token;
-			}
-			break;
-		// TODO: this can catch ngettext('string1', 'string2', count($foo))
-		//                              ^                                ^
-		case ')':
-			if ($in_gettext) {
-				if ($in_gettext_string) {
-					$output.= "'";
-					$in_gettext_string = false;
-				}
-				$output.= $token;
-				// blank lines so line numbers match with original file
-				$output.= str_repeat("\n", $gettext_blank_lines);
-				$in_gettext = false;
-			} else {
-				$output.= $token;
-			}
+                break;
 
-			break;
-		default:
-			$output.= $token;
-			break;
-		}
-	} else {
-		list($id, $text) = $token;
-		switch ($id) {
-		// most whitespace in gettext is from concatenation, ignore it
-		case T_WHITESPACE:
-			if ($in_gettext) {
-				if (strpos($text, "\n") !== false) {
-					$gettext_blank_lines++;
-				}
-			} else {
-				$output.= $text;
-			}
-			break;
-		case T_STRING:
-			$output.= $text;
-			if ($text === '_' || $text === 'ngettext' || $text === 'gettext') {
-				if ($in_gettext) {
-					echo "error: gettext marker detected inside gettext ".
-						"marker\n";
+                // for ngettext multiple translations
+            case ',':
+                if ($in_gettext_string) {
+                    $output .= "', ";
+                    $in_gettext_string = false;
+                } else {
+                    $output .= $token;
+                }
+                break;
 
-					exit(1);
-				}
+                // TODO: this can catch ngettext('string1', 'string2', count($foo))
+                //                              ^                                ^
+            case ')':
+                if ($in_gettext) {
+                    if ($in_gettext_string) {
+                        $output .= "'";
+                        $in_gettext_string = false;
+                    }
+                    $output .= $token;
+                    // blank lines so line numbers match with original file
+                    $output .= str_repeat("\n", $gettext_blank_lines);
+                    $in_gettext = false;
+                } else {
+                    $output .= $token;
+                }
 
-				// ignore gettext function definition
-				if ($tokens[$i - 2][0] != T_FUNCTION) {
-					$in_gettext = true;
-					$gettext_blank_lines = 0;
-				}
-			}
-			break;
-		case T_CONSTANT_ENCAPSED_STRING:
-			if ($in_gettext) {
-				if (!$in_gettext_string) {
-					$output.= "'";
-					$in_gettext_string = true;
-				}
+                break;
 
-				// normalize to single quotes
-				$string = $text;
-				if ($string[0] === '"')
-					$string = str_replace('\"', '"', $string);
+            default:
+                $output .= $token;
+                break;
+        }
+    } else {
+        [$id, $text] = $token;
+        switch ($id) {
+            // most whitespace in gettext is from concatenation, ignore it
+            case T_WHITESPACE:
+                if ($in_gettext) {
+                    if (strpos($text, "\n") !== false) {
+                        $gettext_blank_lines++;
+                    }
+                } else {
+                    $output .= $text;
+                }
+                break;
 
-				if ($string[0] === "'")
-					$string = str_replace("\\'", "'", $string);
+            case T_STRING:
+                $output .= $text;
+                if ($text === '_' || $text === 'ngettext' || $text === 'gettext') {
+                    if ($in_gettext) {
+                        echo 'error: gettext marker detected inside gettext ' .
+                            "marker\n";
 
-				$string = substr($string, 1, -1);
-				$string = str_replace("'", "\\'", $string);
-				$output.= $string;
-			} else {
-				$output.= $text;
-			}
-			break;
-		default:
-			$output.= $text;
-			break;
-		}
-	}
+                        exit(1);
+                    }
+
+                    // ignore gettext function definition
+                    if ($tokens[$i - 2][0] != T_FUNCTION) {
+                        $in_gettext = true;
+                        $gettext_blank_lines = 0;
+                    }
+                }
+                break;
+
+            case T_CONSTANT_ENCAPSED_STRING:
+                if ($in_gettext) {
+                    if (!$in_gettext_string) {
+                        $output .= "'";
+                        $in_gettext_string = true;
+                    }
+
+                    // normalize to single quotes
+                    $string = $text;
+                    if ($string[0] === '"') {
+                        $string = str_replace('\"', '"', $string);
+                    }
+
+                    if ($string[0] === "'") {
+                        $string = str_replace("\\'", "'", $string);
+                    }
+
+                    $string = substr($string, 1, -1);
+                    $string = str_replace("'", "\\'", $string);
+                    $output .= $string;
+                } else {
+                    $output .= $text;
+                }
+                break;
+
+            default:
+                $output .= $text;
+                break;
+        }
+    }
 }
 
 echo $output;
-
-?>


### PR DESCRIPTION
> [!WARNING]
> This branch is dependent on #109 being merged first, as it branched off of that PR's changes.

Similar to https://github.com/silverorange/site/pull/344, this adds `@property` annotations to the classes that extend `SwatDBDataObject`. This should help IDEs with autocompletion and type-hinting, without actually changing the PHP code by adding "real" types that may break existing behaviour.

I also added annotations for the `AdminApplication` class, based on the `getDefaultModuleList()` method.  This will help with typing and code-completion for things like:

```php
$this->app->session; // knows that it's an instance of AdminSessionModule 
```

It also corrects a long-standing typo in `AdminUserHistory::$instance`, which should be a `SiteInstance` object, not a (non-existent) `Instance` object.

Finally, I've converted all string scalars that refer to class names from `'SomeClass'` to `SomeClass::class` (to help code traversal, and hopefully prevent issues like the above from happening in the future).
